### PR TITLE
Add support for dynamic client registration.

### DIFF
--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -67,6 +67,11 @@
 		3417422D1C5D850C000EF209 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417422C1C5D850C000EF209 /* Security.framework */; };
 		34FEA6AE1DB6E083005C9212 /* OIDLoopbackHTTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 34FEA6AC1DB6E083005C9212 /* OIDLoopbackHTTPServer.h */; };
 		34FEA6AF1DB6E083005C9212 /* OIDLoopbackHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */; };
+		60140F7A1DE4276800DA0DC3 /* OIDClientMetadataParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 60140F791DE4276800DA0DC3 /* OIDClientMetadataParameters.m */; };
+		60140F7C1DE42E1000DA0DC3 /* OIDRegistrationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 60140F7B1DE42E1000DA0DC3 /* OIDRegistrationRequest.m */; };
+		60140F801DE4344200DA0DC3 /* OIDRegistrationResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 60140F7F1DE4344200DA0DC3 /* OIDRegistrationResponse.m */; };
+		60140F831DE43BAF00DA0DC3 /* OIDRegistrationRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60140F821DE43BAF00DA0DC3 /* OIDRegistrationRequestTests.m */; };
+		60140F861DE43CC700DA0DC3 /* OIDRegistrationResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60140F851DE43CC700DA0DC3 /* OIDRegistrationResponseTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +171,16 @@
 		3417422C1C5D850C000EF209 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		34FEA6AC1DB6E083005C9212 /* OIDLoopbackHTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDLoopbackHTTPServer.h; sourceTree = "<group>"; };
 		34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDLoopbackHTTPServer.m; sourceTree = "<group>"; };
+		60140F781DE4262000DA0DC3 /* OIDClientMetadataParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDClientMetadataParameters.h; sourceTree = "<group>"; };
+		60140F791DE4276800DA0DC3 /* OIDClientMetadataParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDClientMetadataParameters.m; sourceTree = "<group>"; };
+		60140F7B1DE42E1000DA0DC3 /* OIDRegistrationRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDRegistrationRequest.m; sourceTree = "<group>"; };
+		60140F7D1DE42E3000DA0DC3 /* OIDRegistrationRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OIDRegistrationRequest.h; sourceTree = "<group>"; };
+		60140F7E1DE4335200DA0DC3 /* OIDRegistrationResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OIDRegistrationResponse.h; sourceTree = "<group>"; };
+		60140F7F1DE4344200DA0DC3 /* OIDRegistrationResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDRegistrationResponse.m; sourceTree = "<group>"; };
+		60140F811DE43B4D00DA0DC3 /* OIDRegistrationRequestTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OIDRegistrationRequestTests.h; sourceTree = "<group>"; };
+		60140F821DE43BAF00DA0DC3 /* OIDRegistrationRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDRegistrationRequestTests.m; sourceTree = "<group>"; };
+		60140F841DE43C8C00DA0DC3 /* OIDRegistrationResponseTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OIDRegistrationResponseTests.h; sourceTree = "<group>"; };
+		60140F851DE43CC700DA0DC3 /* OIDRegistrationResponseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDRegistrationResponseTests.m; sourceTree = "<group>"; };
 		F68103B61D2568D10053658E /* OIDAuthorizationUICoordinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDAuthorizationUICoordinator.h; sourceTree = "<group>"; };
 		F6F60FB01D2BFEFE00325CB3 /* OIDAuthState+IOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthState+IOS.m"; path = "iOS/OIDAuthState+IOS.m"; sourceTree = "<group>"; };
 		F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthorizationService+IOS.m"; path = "iOS/OIDAuthorizationService+IOS.m"; sourceTree = "<group>"; };
@@ -256,6 +271,8 @@
 				341741BB1C5D8243000EF209 /* OIDAuthState.m */,
 				341741BC1C5D8243000EF209 /* OIDAuthStateChangeDelegate.h */,
 				341741BD1C5D8243000EF209 /* OIDAuthStateErrorDelegate.h */,
+				60140F781DE4262000DA0DC3 /* OIDClientMetadataParameters.h */,
+				60140F791DE4276800DA0DC3 /* OIDClientMetadataParameters.m */,
 				341741BE1C5D8243000EF209 /* OIDDefines.h */,
 				341741BF1C5D8243000EF209 /* OIDError.h */,
 				341741C01C5D8243000EF209 /* OIDError.m */,
@@ -263,6 +280,10 @@
 				341741C21C5D8243000EF209 /* OIDErrorUtilities.m */,
 				341741C31C5D8243000EF209 /* OIDFieldMapping.h */,
 				341741C41C5D8243000EF209 /* OIDFieldMapping.m */,
+				60140F7E1DE4335200DA0DC3 /* OIDRegistrationResponse.h */,
+				60140F7F1DE4344200DA0DC3 /* OIDRegistrationResponse.m */,
+				60140F7D1DE42E3000DA0DC3 /* OIDRegistrationRequest.h */,
+				60140F7B1DE42E1000DA0DC3 /* OIDRegistrationRequest.m */,
 				341741C51C5D8243000EF209 /* OIDGrantTypes.h */,
 				341741C61C5D8243000EF209 /* OIDGrantTypes.m */,
 				341741C71C5D8243000EF209 /* OIDResponseTypes.h */,
@@ -297,6 +318,7 @@
 				341742031C5D82D3000EF209 /* OIDAuthorizationResponseTests.m */,
 				341742041C5D82D3000EF209 /* OIDAuthStateTests.h */,
 				341742051C5D82D3000EF209 /* OIDAuthStateTests.m */,
+				60140F811DE43B4D00DA0DC3 /* OIDRegistrationRequestTests.h */,
 				341742061C5D82D3000EF209 /* OIDGrantTypesTests.m */,
 				341742071C5D82D3000EF209 /* OIDResponseTypesTests.m */,
 				341742081C5D82D3000EF209 /* OIDScopesTests.m */,
@@ -311,6 +333,9 @@
 				341742111C5D82D3000EF209 /* OIDURLQueryComponentTests.h */,
 				341742121C5D82D3000EF209 /* OIDURLQueryComponentTests.m */,
 				341742131C5D82D3000EF209 /* OIDURLQueryComponentTestsIOS7.m */,
+				60140F821DE43BAF00DA0DC3 /* OIDRegistrationRequestTests.m */,
+				60140F841DE43C8C00DA0DC3 /* OIDRegistrationResponseTests.h */,
+				60140F851DE43CC700DA0DC3 /* OIDRegistrationResponseTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -500,12 +525,14 @@
 				341741E01C5D8243000EF209 /* OIDErrorUtilities.m in Sources */,
 				341741EA1C5D8243000EF209 /* OIDTokenUtilities.m in Sources */,
 				341741E21C5D8243000EF209 /* OIDGrantTypes.m in Sources */,
+				60140F7C1DE42E1000DA0DC3 /* OIDRegistrationRequest.m in Sources */,
 				341741E81C5D8243000EF209 /* OIDTokenRequest.m in Sources */,
 				340DAECC1D582DE100EC285B /* OIDAuthState+IOS.m in Sources */,
 				341741E91C5D8243000EF209 /* OIDTokenResponse.m in Sources */,
 				341741E51C5D8243000EF209 /* OIDScopeUtilities.m in Sources */,
 				341741DC1C5D8243000EF209 /* OIDAuthorizationResponse.m in Sources */,
 				341741E61C5D8243000EF209 /* OIDServiceConfiguration.m in Sources */,
+				60140F7A1DE4276800DA0DC3 /* OIDClientMetadataParameters.m in Sources */,
 				341741DE1C5D8243000EF209 /* OIDAuthState.m in Sources */,
 				341741DD1C5D8243000EF209 /* OIDAuthorizationService.m in Sources */,
 				340DAECD1D582DE100EC285B /* OIDAuthorizationUICoordinatorIOS.m in Sources */,
@@ -513,6 +540,7 @@
 				341741E11C5D8243000EF209 /* OIDFieldMapping.m in Sources */,
 				341741DF1C5D8243000EF209 /* OIDError.m in Sources */,
 				341741DB1C5D8243000EF209 /* OIDAuthorizationRequest.m in Sources */,
+				60140F801DE4344200DA0DC3 /* OIDRegistrationResponse.m in Sources */,
 				340DAECB1D582DE100EC285B /* OIDAuthorizationService+IOS.m in Sources */,
 				341741E31C5D8243000EF209 /* OIDResponseTypes.m in Sources */,
 				341741E41C5D8243000EF209 /* OIDScopes.m in Sources */,
@@ -533,6 +561,8 @@
 				341742171C5D82D3000EF209 /* OIDAuthorizationRequestTests.m in Sources */,
 				3417421A1C5D82D3000EF209 /* OIDGrantTypesTests.m in Sources */,
 				3417421B1C5D82D3000EF209 /* OIDResponseTypesTests.m in Sources */,
+				60140F831DE43BAF00DA0DC3 /* OIDRegistrationRequestTests.m in Sources */,
+				60140F861DE43CC700DA0DC3 /* OIDRegistrationResponseTests.m in Sources */,
 				341742191C5D82D3000EF209 /* OIDAuthStateTests.m in Sources */,
 				3417421D1C5D82D3000EF209 /* OIDServiceConfigurationTests.m in Sources */,
 				3417421C1C5D82D3000EF209 /* OIDScopesTests.m in Sources */,

--- a/Source/AppAuth.h
+++ b/Source/AppAuth.h
@@ -26,6 +26,8 @@
 #import "OIDError.h"
 #import "OIDErrorUtilities.h"
 #import "OIDGrantTypes.h"
+#import "OIDRegistrationRequest.h"
+#import "OIDRegistrationResponse.h"
 #import "OIDResponseTypes.h"
 #import "OIDScopes.h"
 #import "OIDScopeUtilities.h"

--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -20,6 +20,7 @@
 @class OIDAuthorizationRequest;
 @class OIDAuthorizationResponse;
 @class OIDAuthState;
+@class OIDRegistrationResponse;
 @class OIDTokenResponse;
 @class OIDTokenRequest;
 @protocol OIDAuthorizationFlowSession;
@@ -76,6 +77,11 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
         contain the latest access token.
  */
 @property(nonatomic, readonly, nullable) OIDTokenResponse *lastTokenResponse;
+
+/*! @brief The most recent registration response used to update this authorization state. This will
+        contain the latest client credentials.
+ */
+@property(nonatomic, readonly, nullable) OIDRegistrationResponse *lastRegistrationResponse;
 
 /*! @brief The authorization error that invalidated this @c OIDAuthState.
     @discussion The authorization error encountered by @c OIDAuthState or set by the user via
@@ -143,6 +149,23 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
     (OIDAuthorizationResponse *)authorizationResponse
                                          tokenResponse:(nullable OIDTokenResponse *)tokenResponse;
 
+/*! @brief Creates an auth state from an registration response.
+    @param registrationResponse The registration response.
+ */
+- (nullable instancetype)initWithRegistrationResponse:
+    (OIDRegistrationResponse *)registrationResponse;
+
+/*! @brief Creates an auth state from an authorization, token and registration response.
+    @param authorizationResponse The authorization response.
+    @param tokenResponse The token response.
+    @param registrationResponse The registration response.
+ */
+- (nullable instancetype)initWithAuthorizationResponse:
+    (nullable OIDAuthorizationResponse *)authorizationResponse
+           tokenResponse:(nullable OIDTokenResponse *)tokenResponse
+    registrationResponse:(nullable OIDRegistrationResponse *)registrationResponse
+    NS_DESIGNATED_INITIALIZER;
+
 /*! @brief Updates the authorization state based on a new authorization response.
     @param authorizationResponse The new authorization response to update the state with.
     @param error Any error encountered when performing the authorization request. Errors in the
@@ -164,6 +187,13 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
  */
 - (void)updateWithTokenResponse:(nullable OIDTokenResponse *)tokenResponse
                           error:(nullable NSError *)error;
+
+/*! @brief Updates the authorization state based on a new registration response.
+    @param registrationResponse The new registration response to update the state with.
+    @discussion Typically called with the response from a successful client registration
+        request. Will reset the auth state.
+ */
+- (void)updateWithRegistrationResponse:(nullable OIDRegistrationResponse *)registrationResponse;
 
 /*! @brief Updates the authorization state based on an authorization error.
     @param authorizationError The authorization error.

--- a/Source/OIDAuthorizationService.h
+++ b/Source/OIDAuthorizationService.h
@@ -21,6 +21,8 @@
 @class OIDAuthorization;
 @class OIDAuthorizationRequest;
 @class OIDAuthorizationResponse;
+@class OIDRegistrationRequest;
+@class OIDRegistrationResponse;
 @class OIDServiceConfiguration;
 @class OIDTokenRequest;
 @class OIDTokenResponse;
@@ -57,6 +59,14 @@ typedef void (^OIDTokenCallback)(OIDTokenResponse *_Nullable tokenResponse,
         when making authorization or token endpoint requests.
  */
 typedef NSDictionary<NSString *, NSString *> *_Nullable OIDTokenEndpointParameters;
+
+/*! @brief Represents the type of block used as a callback for various methods of
+        @c OIDAuthorizationService.
+    @param registrationResponse The registration response, if available.
+    @param error The error if an error occurred.
+*/
+typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable registrationResponse,
+                                          NSError *_Nullable error);
 
 /*! @brief Performs various OAuth and OpenID Connect related calls via the user agent or
         \NSURLSession.
@@ -116,6 +126,13 @@ typedef NSDictionary<NSString *, NSString *> *_Nullable OIDTokenEndpointParamete
     @param callback The method called when the request has completed or failed.
  */
 + (void)performTokenRequest:(OIDTokenRequest *)request callback:(OIDTokenCallback)callback;
+
+/*! @brief Performs a registration request.
+    @param request The registration request.
+    @param completion The method called when the request has completed or failed.
+ */
++ (void)performRegistrationRequest:(OIDRegistrationRequest *)request
+                        completion:(OIDRegistrationCompletion)completion;
 
 @end
 

--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -23,6 +23,8 @@
 #import "OIDAuthorizationUICoordinator.h"
 #import "OIDDefines.h"
 #import "OIDErrorUtilities.h"
+#import "OIDRegistrationRequest.h"
+#import "OIDRegistrationResponse.h"
 #import "OIDServiceConfiguration.h"
 #import "OIDServiceDiscovery.h"
 #import "OIDTokenRequest.h"
@@ -344,6 +346,114 @@ NS_ASSUME_NONNULL_BEGIN
     // Success
     dispatch_async(dispatch_get_main_queue(), ^{
       callback(tokenResponse, nil);
+    });
+  }] resume];
+}
+
+
+#pragma mark - Registration Endpoint
+
++ (void)performRegistrationRequest:(OIDRegistrationRequest *)request
+                          completion:(OIDRegistrationCompletion)completion {
+  NSURLRequest *URLRequest = [request URLRequest];
+  if (!URLRequest) {
+    // A problem occurred deserializing the response/JSON.
+    NSError *returnedError = [OIDErrorUtilities errorWithCode:OIDErrorCodeJSONSerializationError
+                                              underlyingError:nil
+                                                  description:@"The registration request could not "
+                                                               "be serialized as JSON."];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      completion(nil, returnedError);
+    });
+    return;
+  }
+
+  NSURLSession *session = [NSURLSession sharedSession];
+  [[session dataTaskWithRequest:URLRequest
+              completionHandler:^(NSData *_Nullable data,
+                                  NSURLResponse *_Nullable response,
+                                  NSError *_Nullable error) {
+    if (error) {
+      // A network error or server error occurred.
+      NSError *returnedError = [OIDErrorUtilities errorWithCode:OIDErrorCodeNetworkError
+                                                underlyingError:error
+                                                    description:nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        completion(nil, returnedError);
+      });
+      return;
+    }
+
+    NSHTTPURLResponse *HTTPURLResponse = (NSHTTPURLResponse *) response;
+
+    if (HTTPURLResponse.statusCode != 201 && HTTPURLResponse.statusCode != 200) {
+      // A server error occurred.
+      NSError *serverError = [OIDErrorUtilities HTTPErrorWithHTTPResponse:HTTPURLResponse
+                                                                     data:data];
+
+      // HTTP 400 may indicate an OpenID Connect Dynamic Client Registration 1.0 Section 3.3 error
+      // response, checks for that
+      if (HTTPURLResponse.statusCode == 400) {
+        NSError *jsonDeserializationError;
+        NSDictionary<NSString *, NSObject <NSCopying> *> *json =
+            [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonDeserializationError];
+
+        // if the HTTP 400 response parses as JSON and has an 'error' key, it's an OAuth error
+        // these errors are special as they indicate a problem with the authorization grant
+        if (json[OIDOAuthErrorFieldError]) {
+          NSError *oauthError =
+              [OIDErrorUtilities OAuthErrorWithDomain:OIDOAuthRegistrationErrorDomain
+                                        OAuthResponse:json
+                                      underlyingError:serverError];
+          dispatch_async(dispatch_get_main_queue(), ^{
+            completion(nil, oauthError);
+          });
+          return;
+        }
+      }
+
+      // not an OAuth error, just a generic server error
+      NSError *returnedError = [OIDErrorUtilities errorWithCode:OIDErrorCodeServerError
+                                                underlyingError:serverError
+                                                    description:nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        completion(nil, returnedError);
+      });
+      return;
+    }
+
+    NSError *jsonDeserializationError;
+    NSDictionary<NSString *, NSObject <NSCopying> *> *json =
+        [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonDeserializationError];
+    if (jsonDeserializationError) {
+      // A problem occurred deserializing the response/JSON.
+      NSError *returnedError = [OIDErrorUtilities errorWithCode:OIDErrorCodeJSONDeserializationError
+                                                underlyingError:jsonDeserializationError
+                                                    description:nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        completion(nil, returnedError);
+      });
+      return;
+    }
+
+    OIDRegistrationResponse *registrationResponse =
+        [[OIDRegistrationResponse alloc] initWithRequest:request
+                                              parameters:json];
+    if (!registrationResponse) {
+      // A problem occurred constructing the registration response from the JSON.
+      NSError *returnedError =
+          [OIDErrorUtilities errorWithCode:OIDErrorCodeRegistrationResponseConstructionError
+                           underlyingError:jsonDeserializationError
+                               description:nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        completion(nil, returnedError);
+      });
+      return;
+    }
+
+    // Success
+    dispatch_async(dispatch_get_main_queue(), ^{
+      completion(registrationResponse, nil);
     });
   }] resume];
 }

--- a/Source/OIDClientMetadataParameters.h
+++ b/Source/OIDClientMetadataParameters.h
@@ -1,0 +1,51 @@
+/*! @file OIDClientMetadataParameters.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief Parameter name for the token endpoint authentication method.
+ */
+extern NSString *const OIDTokenEndpointAuthenticationMethodParam;
+
+/*! @brief Parameter name for the application type.
+ */
+extern NSString *const OIDApplicationTypeParam;
+
+/*! @brief Parameter name for the redirect URI values.
+ */
+extern NSString *const OIDRedirectURIsParam;
+
+/*! @brief Parameter name for the response type values.
+ */
+extern NSString *const OIDResponseTypesParam;
+
+/*! @brief Parameter name for the grant type values.
+ */
+extern NSString *const OIDGrantTypesParam;
+
+/*! @brief Parameter name for the subject type.
+ */
+extern NSString *const OIDSubjectTypeParam;
+
+/*! @brief Application type that indicates this client is a native (not a web) application.
+ */
+extern NSString *const OIDApplicationTypeNative;
+
+NS_ASSUME_NONNULL_END

--- a/Source/OIDClientMetadataParameters.m
+++ b/Source/OIDClientMetadataParameters.m
@@ -1,0 +1,33 @@
+/*! @file OIDClientMetadataParameters.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDClientMetadataParameters.h"
+
+NSString *const OIDTokenEndpointAuthenticationMethodParam = @"token_endpoint_auth_method";
+
+NSString *const OIDApplicationTypeParam = @"application_type";
+
+NSString *const OIDRedirectURIsParam = @"redirect_uris";
+
+NSString *const OIDResponseTypesParam = @"response_types";
+
+NSString *const OIDGrantTypesParam = @"grant_types";
+
+NSString *const OIDSubjectTypeParam = @"subject_type";
+
+NSString *const OIDApplicationTypeNative = @"native";

--- a/Source/OIDError.h
+++ b/Source/OIDError.h
@@ -48,6 +48,19 @@ extern NSString *const OIDOAuthAuthorizationErrorDomain;
  */
 extern NSString *const OIDOAuthTokenErrorDomain;
 
+/*! @brief The error domain for dynamic client registration errors.
+    @discussion This error domain is used when the server responds with HTTP 400 and an OAuth error,
+         as defined in OpenID Connect Dynamic Client Registration 1.0 Section 3.3. If an HTTP 400
+         response does not parse as an OAuth error (i.e. no 'error' field is present or the JSON is
+         invalid), another error domain will be  used. The entire OAuth error response dictionary is
+         available in the \NSError_userInfo dictionary using the @c ::OIDOAuthErrorResponseErrorKey
+         key. Unlike transient network errors, errors in this domain invalidate the authentication
+         state, and indicates a client error.
+         The \NSError_code will be one of the @c ::OIDErrorCodeOAuthToken enum values.
+     @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+ */
+extern NSString *const OIDOAuthRegistrationErrorDomain;
+
 /*! @brief The error domain for authorization errors encountered out of band on the resource server.
  */
 extern NSString *const OIDResourceServerAuthorizationErrorDomain;
@@ -123,6 +136,13 @@ typedef NS_ENUM(NSInteger, OIDErrorCode) {
    */
   OIDErrorCodeTokenRefreshError = -11,
 
+  /*! @brief Indicates a problem occurred constructing the registration response from the JSON.
+   */
+  OIDErrorCodeRegistrationResponseConstructionError = -12,
+
+  /*! @brief Indicates a problem occurred deserializing the response/JSON.
+   */
+  OIDErrorCodeJSONSerializationError = -13,
 
 };
 
@@ -188,6 +208,16 @@ typedef NS_ENUM(NSInteger, OIDErrorCodeOAuth) {
       @see https://tools.ietf.org/html/rfc6749#section-5.2
    */
   OIDErrorCodeOAuthUnsupportedGrantType = -11,
+
+  /*! @remarks invalid_redirect_uri
+      @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+   */
+  OIDErrorCodeOAuthInvalidRedirectURI = -12,
+
+  /*! @remarks invalid_client_metadata
+      @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+   */
+  OIDErrorCodeOAuthInvalidClientMetadata = -13,
 
   /*! @brief An authorization error occurring on the client rather than the server. For example,
         due to a state mismatch or misconfiguration. Should be treated as an unrecoverable
@@ -309,6 +339,39 @@ typedef NS_ENUM(NSInteger, OIDErrorCodeOAuthToken) {
    */
   OIDErrorCodeOAuthTokenOther = OIDErrorCodeOAuthOther,
 };
+
+/*! @brief The error codes for the @c ::OIDOAuthRegistrationErrorDomain error domain
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+ */
+typedef NS_ENUM(NSInteger, OIDErrorCodeOAuthRegistration) {
+  /*! @remarks invalid_request
+      @see http://tools.ietf.org/html/rfc6750#section-3.1
+   */
+  OIDErrorCodeOAuthRegistrationInvalidRequest = OIDErrorCodeOAuthInvalidRequest,
+
+  /*! @remarks invalid_redirect_uri
+      @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+   */
+  OIDErrorCodeOAuthRegistrationInvalidRedirectURI = OIDErrorCodeOAuthInvalidRedirectURI,
+
+  /*! @remarks invalid_client_metadata
+      @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+   */
+  OIDErrorCodeOAuthRegistrationInvalidClientMetadata = OIDErrorCodeOAuthInvalidClientMetadata,
+
+  /*! @brief An unrecoverable token error occurring on the client rather than the server.
+   */
+  OIDErrorCodeOAuthRegistrationClientError = OIDErrorCodeOAuthClientError,
+
+  /*! @brief A registration endpoint OAuth error not known to this library
+      @discussion this indicates an OAuth error, but the error code was not in our
+          list. It could be a custom error code, or one from an OAuth extension. See the "error" key
+          of the \NSError_userInfo property. We assume such errors are not transient.
+      @see https://tools.ietf.org/html/rfc6749#section-5.2
+   */
+  OIDErrorCodeOAuthRegistrationOther = OIDErrorCodeOAuthOther,
+};
+
 
 /*! @brief The exception text for the exception which occurs when a
         @c OIDAuthorizationFlowSession receives a message after it has already completed.

--- a/Source/OIDError.m
+++ b/Source/OIDError.m
@@ -24,6 +24,8 @@ NSString *const OIDOAuthTokenErrorDomain = @"org.openid.appauth.oauth_token";
 
 NSString *const OIDOAuthAuthorizationErrorDomain = @"org.openid.appauth.oauth_authorization";
 
+NSString *const OIDOAuthRegistrationErrorDomain = @"org.openid.appauth.oauth_registration";
+
 NSString *const OIDResourceServerAuthorizationErrorDomain = @"org.openid.appauth.resourceserver";
 
 NSString *const OIDHTTPErrorDomain = @"org.openid.appauth.remote-http";

--- a/Source/OIDErrorUtilities.m
+++ b/Source/OIDErrorUtilities.m
@@ -38,7 +38,8 @@
 }
 
 + (BOOL)isOAuthErrorDomain:(NSString *)errorDomain {
-  return errorDomain == OIDOAuthAuthorizationErrorDomain
+  return errorDomain == OIDOAuthRegistrationErrorDomain
+      || errorDomain == OIDOAuthAuthorizationErrorDomain
       || errorDomain == OIDOAuthTokenErrorDomain;
 }
 

--- a/Source/OIDFieldMapping.h
+++ b/Source/OIDFieldMapping.h
@@ -111,6 +111,16 @@ typedef _Nullable id(^OIDFieldMappingConversionFunction)(NSObject *_Nullable val
  */
 + (OIDFieldMappingConversionFunction)URLConversion;
 
+/*! @brief Returns a function for converting an @c NSNumber number of seconds from now to an
+        @c NSDate.
+ */
++ (OIDFieldMappingConversionFunction)dateSinceNowConversion;
+
+/*! @brief Returns a function for converting an @c NSNumber representing a unix time stamp to an
+        @c NSDate.
+ */
++ (OIDFieldMappingConversionFunction)dateEpochConversion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/OIDFieldMapping.m
+++ b/Source/OIDFieldMapping.m
@@ -109,4 +109,24 @@
   };
 }
 
++ (OIDFieldMappingConversionFunction)dateSinceNowConversion {
+  return ^id _Nullable(NSObject *_Nullable value) {
+    if (![value isKindOfClass:[NSNumber class]]) {
+      return value;
+    }
+    NSNumber *valueAsNumber = (NSNumber *)value;
+    return [NSDate dateWithTimeIntervalSinceNow:[valueAsNumber longLongValue]];
+  };
+}
+
++ (OIDFieldMappingConversionFunction)dateEpochConversion {
+  return ^id _Nullable(NSObject *_Nullable value) {
+    if (![value isKindOfClass:[NSNumber class]]) {
+      return value;
+    }
+    NSNumber *valueAsNumber = (NSNumber *) value;
+    return [NSDate dateWithTimeIntervalSince1970:[valueAsNumber longLongValue]];
+  };
+}
+
 @end

--- a/Source/OIDRegistrationRequest.h
+++ b/Source/OIDRegistrationRequest.h
@@ -1,0 +1,108 @@
+/*! @file OIDRegistrationRequest.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class OIDAuthorizationResponse;
+@class OIDServiceConfiguration;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief Represents a registration request.
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationRequest
+ */
+@interface OIDRegistrationRequest : NSObject <NSCopying, NSSecureCoding>
+
+/*! @brief The service's configuration.
+    @remarks This configuration specifies how to connect to a particular OAuth provider.
+        Configurations may be created manually, or via an OpenID Connect Discovery Document.
+ */
+@property(nonatomic, readonly) OIDServiceConfiguration *configuration;
+
+/*! @brief The application type to register, will always be 'native'.
+    @remarks application_type
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+ */
+@property(nonatomic, readonly) NSString *applicationType;
+
+/*! @brief The client's redirect URI's.
+    @remarks redirect_uris
+    @see https://tools.ietf.org/html/rfc6749#section-3.1.2
+ */
+@property(nonatomic, readonly) NSArray<NSURL *> *redirectURIs;
+
+/*! @brief The response types to register for usage by this client.
+    @remarks response_types
+    @see http://openid.net/specs/openid-connect-core-1_0.html#Authentication
+ */
+@property(nonatomic, readonly, nullable) NSArray<NSString *> *responseTypes;
+
+/*! @brief The grant types to register for usage by this client.
+    @remarks grant_types
+ @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+ */
+@property(nonatomic, readonly, nullable) NSArray<NSString *> *grantTypes;
+
+/*! @brief The subject type to to request.
+    @remarks subject_type
+    @see http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes
+ */
+@property(nonatomic, readonly, nullable) NSString *subjectType;
+
+/*! @brief The client authentication method to use at the token endpoint.
+    @remarks token_endpoint_auth_method
+    @see http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ */
+@property(nonatomic, readonly, nullable) NSString *tokenEndpointAuthenticationMethod;
+
+/*! @brief The client's additional token request parameters.
+ */
+@property(nonatomic, readonly, nullable) NSDictionary<NSString *, NSString *> *additionalParameters;
+
+/*! @internal
+    @brief Unavailable. Please use initWithConfiguration
+ */
+- (nullable instancetype)init NS_UNAVAILABLE;
+
+/*! @brief Designated initializer.
+    @param configuration The service's configuration.
+    @param redirectURIs The redirect URIs to register for the client.
+    @param responseTypes The response types to register for the client.
+    @param grantTypes The grant types to register for the client.
+    @param subjectType The subject type to register for the client.
+    @param tokenEndpointAuthMethod The token endpoint authentication method to register for the
+        client.
+    @param additionalParameters The client's additional registration request parameters.
+ */
+- (nullable instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+            redirectURIs:(NSArray<NSURL *> *)redirectURIs
+           responseTypes:(nullable NSArray<NSString *> *)responseTypes
+              grantTypes:(nullable NSArray<NSString *> *)grantTypes
+             subjectType:(nullable NSString *)subjectType
+ tokenEndpointAuthMethod:(nullable NSString *)tokenEndpointAuthMethod
+    additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters
+    NS_DESIGNATED_INITIALIZER;
+
+/*! @brief Constructs an @c NSURLRequest representing the registration request.
+    @return An @c NSURLRequest representing the registration request.
+ */
+- (NSURLRequest *)URLRequest;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/OIDRegistrationRequest.m
+++ b/Source/OIDRegistrationRequest.m
@@ -1,0 +1,215 @@
+/*! @file OIDRegistrationRequest.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDRegistrationRequest.h"
+
+#import "OIDClientMetadataParameters.h"
+#import "OIDDefines.h"
+#import "OIDServiceConfiguration.h"
+
+/*! @brief The key for the @c configuration property for @c NSSecureCoding
+ */
+static NSString *const kConfigurationKey = @"configuration";
+
+/*! @brief Key used to encode the @c redirectURIs property for @c NSSecureCoding
+ */
+static NSString *const kRedirectURIsKey = @"redirect_uris";
+
+/*! @brief The key for the @c responseTypes property for @c NSSecureCoding.
+ */
+static NSString *const kResponseTypesKey = @"response_types";
+
+/*! @brief Key used to encode the @c grantType property for @c NSSecureCoding
+ */
+static NSString *const kGrantTypesKey = @"grant_types";
+
+/*! @brief Key used to encode the @c subjectType property for @c NSSecureCoding
+ */
+static NSString *const kSubjectTypeKey = @"subject_type";
+
+/*! @brief Key used to encode the @c additionalParameters property for
+        @c NSSecureCoding
+ */
+static NSString *const kAdditionalParametersKey = @"additionalParameters";
+
+@implementation OIDRegistrationRequest
+
+#pragma mark - Initializers
+
+- (instancetype)init
+    OID_UNAVAILABLE_USE_INITIALIZER(
+        @selector(initWithConfiguration:
+                           redirectURIs:
+                          responseTypes:
+                             grantTypes:
+                            subjectType:
+                tokenEndpointAuthMethod:
+                   additionalParameters:)
+    );
+
+- (nullable instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+            redirectURIs:(NSArray<NSURL *> *)redirectURIs
+           responseTypes:(nullable NSArray<NSString *> *)responseTypes
+              grantTypes:(nullable NSArray<NSString *> *)grantTypes
+             subjectType:(nullable NSString *)subjectType
+ tokenEndpointAuthMethod:(nullable NSString *)tokenEndpointAuthenticationMethod
+    additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
+  self = [super init];
+  if (self) {
+    _configuration = [configuration copy];
+    _redirectURIs = [redirectURIs copy];
+    _responseTypes = [responseTypes copy];
+    _grantTypes = [grantTypes copy];
+    _subjectType = [subjectType copy];
+    _tokenEndpointAuthenticationMethod = [tokenEndpointAuthenticationMethod copy];
+    _additionalParameters =
+        [[NSDictionary alloc] initWithDictionary:additionalParameters copyItems:YES];
+
+    _applicationType = OIDApplicationTypeNative;
+  }
+  return self;
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(nullable NSZone *)zone {
+  // The documentation for NSCopying specifically advises us to return a reference to the original
+  // instance in the case where instances are immutable (as ours is):
+  // "Implement NSCopying by retaining the original instead of creating a new copy when the class
+  // and its contents are immutable."
+  return self;
+}
+
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  OIDServiceConfiguration *configuration =
+  [aDecoder decodeObjectOfClass:[OIDServiceConfiguration class]
+                         forKey:kConfigurationKey];
+  NSArray<NSURL *> *redirectURIs = [aDecoder decodeObjectOfClass:[NSArray<NSURL *> class]
+                                                          forKey:kRedirectURIsKey];
+  NSArray<NSString *> *responseTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
+                                                              forKey:kResponseTypesKey];
+  NSArray<NSString *> *grantTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
+                                                           forKey:kGrantTypesKey];
+  NSString *subjectType = [aDecoder decodeObjectOfClass:[NSString class]
+                                                 forKey:kSubjectTypeKey];
+  NSString *tokenEndpointAuthenticationMethod =
+      [aDecoder decodeObjectOfClass:[NSString class]
+                             forKey:OIDTokenEndpointAuthenticationMethodParam];
+  NSSet *additionalParameterCodingClasses = [NSSet setWithArray:@[ [NSDictionary class],
+                                                                   [NSString class] ]];
+  NSDictionary *additionalParameters =
+      [aDecoder decodeObjectOfClasses:additionalParameterCodingClasses
+                               forKey:kAdditionalParametersKey];
+  self = [self initWithConfiguration:configuration
+                        redirectURIs:redirectURIs
+                       responseTypes:responseTypes
+                          grantTypes:grantTypes
+                         subjectType:subjectType
+             tokenEndpointAuthMethod:tokenEndpointAuthenticationMethod
+                additionalParameters:additionalParameters];
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [aCoder encodeObject:_configuration forKey:kConfigurationKey];
+  [aCoder encodeObject:_redirectURIs forKey:kRedirectURIsKey];
+  [aCoder encodeObject:_responseTypes forKey:kResponseTypesKey];
+  [aCoder encodeObject:_grantTypes forKey:kGrantTypesKey];
+  [aCoder encodeObject:_subjectType forKey:kSubjectTypeKey];
+  [aCoder encodeObject:_tokenEndpointAuthenticationMethod
+                forKey:OIDTokenEndpointAuthenticationMethodParam];
+  [aCoder encodeObject:_additionalParameters forKey:kAdditionalParametersKey];
+}
+
+#pragma mark - NSObject overrides
+
+- (NSString *)description {
+  NSURLRequest *request = [self URLRequest];
+  NSString *requestBody = [[NSString alloc] initWithData:request.HTTPBody
+                                                encoding:NSUTF8StringEncoding];
+  return [NSString stringWithFormat:@"<%@: %p, request: <URL: %@, HTTPBody: %@>>",
+                                    NSStringFromClass([self class]),
+                                    self,
+                                    request.URL,
+                                    requestBody];
+}
+
+- (NSURLRequest *)URLRequest {
+  static NSString *const kHTTPPost = @"POST";
+  static NSString *const kHTTPContentTypeHeaderKey = @"Content-Type";
+  static NSString *const kHTTPContentTypeHeaderValue = @"application/json";
+
+  NSData *postBody = [self JSONString];
+  if (!postBody) {
+    return nil;
+  }
+
+  NSURL *registrationRequestURL = _configuration.registrationEndpoint;
+  NSMutableURLRequest *URLRequest =
+      [[NSURLRequest requestWithURL:registrationRequestURL] mutableCopy];
+  URLRequest.HTTPMethod = kHTTPPost;
+  [URLRequest setValue:kHTTPContentTypeHeaderValue forHTTPHeaderField:kHTTPContentTypeHeaderKey];
+  URLRequest.HTTPBody = postBody;
+  return URLRequest;
+}
+
+- (NSData *)JSONString {
+  // Dictionary with several kay/value pairs and the above array of arrays
+  NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+  NSMutableArray<NSString *> *redirectURIStrings =
+  [NSMutableArray arrayWithCapacity:[_redirectURIs count]];
+  for (id obj in _redirectURIs) {
+    [redirectURIStrings addObject:[obj absoluteString]];
+  }
+  dict[OIDRedirectURIsParam] = redirectURIStrings;
+  dict[OIDApplicationTypeParam] = _applicationType;
+
+  if (_additionalParameters) {
+    // Add any additional parameters first to allow them
+    // to be overwritten by instance values
+    [dict addEntriesFromDictionary:_additionalParameters];
+  }
+  if (_responseTypes) {
+    dict[OIDResponseTypesParam] = _responseTypes;
+  }
+  if (_grantTypes) {
+    dict[OIDGrantTypesParam] = _grantTypes;
+  }
+  if (_subjectType) {
+    dict[OIDSubjectTypeParam] = _subjectType;
+  }
+  if (_tokenEndpointAuthenticationMethod) {
+    dict[OIDTokenEndpointAuthenticationMethodParam] = _tokenEndpointAuthenticationMethod;
+  }
+
+  NSError *error;
+  NSData *json = [NSJSONSerialization dataWithJSONObject:dict options:kNilOptions error:&error];
+  if (json == nil || error != nil) {
+    return nil;
+  }
+
+  return json;
+}
+
+@end

--- a/Source/OIDRegistrationResponse.h
+++ b/Source/OIDRegistrationResponse.h
@@ -1,0 +1,126 @@
+/*! @file OIDRegistrationResponse.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+@class OIDRegistrationRequest;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief Parameter name for the client id.
+ */
+extern NSString *const OIDClientIDParam;
+
+/*! @brief Parameter name for the client id issuance timestamp.
+ */
+extern NSString *const OIDClientIDIssuedAtParam;
+
+/*! @brief Parameter name for the client secret.
+ */
+extern NSString *const OIDClientSecretParam;
+
+/*! @brief Parameter name for the client secret expiration time.
+ */
+extern NSString *const OIDClientSecretExpirestAtParam;
+
+/*! @brief Parameter name for the registration access token.
+ */
+extern NSString *const OIDRegistrationAccessTokenParam;
+
+/*! @brief Parameter name for the client configuration URI.
+ */
+extern NSString *const OIDRegistrationClientURIParam;
+
+/*! @brief Represents a registration response.
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+@interface OIDRegistrationResponse : NSObject <NSCopying, NSSecureCoding>
+
+/*! @brief The request which was serviced.
+ */
+@property(nonatomic, readonly) OIDRegistrationRequest *request;
+
+/*! @brief The registered client identifier.
+    @remarks client_id
+    @see https://tools.ietf.org/html/rfc6749#section-4
+    @see https://tools.ietf.org/html/rfc6749#section-4.1.1
+ */
+@property(nonatomic, readonly) NSString *clientID;
+
+/*! @brief Timestamp of when the client identifier was issued, if provided.
+    @remarks client_id_issued_at
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+@property(nonatomic, readonly, nullable) NSDate *clientIDIssuedAt;
+
+/*! @brief TThe client secret, which is part of the client credentials, if provided.
+    @remarks client_secret
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+@property(nonatomic, readonly, nullable) NSString *clientSecret;
+
+/*! @brief Timestamp of when the client credentials expires, if provided.
+    @remarks client_secret_expires_at
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+@property(nonatomic, readonly, nullable) NSDate *clientSecretExpiresAt;
+
+/*! @brief Client registration access token that can be used for subsequent operations upon the
+        client registration.
+    @remarks registration_access_token
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+@property(nonatomic, readonly, nullable) NSString *registrationAccessToken;
+
+/*! @brief Location of the client configuration endpoint, if provided.
+    @remarks registration_client_uri
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+@property(nonatomic, readonly, nullable) NSURL *registrationClientURI;
+
+/*! @brief Client authentication method to use at the token endpoint, if provided.
+    @remarks token_endpoint_auth_method
+    @see http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ */
+@property(nonatomic, readonly, nullable) NSString *tokenEndpointAuthenticationMethod;
+
+/*! @brief Additional parameters returned from the token server.
+ */
+@property(nonatomic, readonly, nullable) NSDictionary<NSString *, NSObject <NSCopying> *>
+    *additionalParameters;
+
+/*! @internal
+    @brief Unavailable. Please use initWithRequest
+ */
+- (nullable instancetype)init NS_UNAVAILABLE;
+
+/*! @brief Designated initializer.
+    @param request The serviced request.
+    @param parameters The decoded parameters returned from the Authorization Server.
+    @remarks Known parameters are extracted from the @c parameters parameter and the normative
+        properties are populated. Non-normative parameters are placed in the
+        @c #additionalParameters dictionary.
+ */
+- (nullable instancetype)initWithRequest:(OIDRegistrationRequest *)request
+                         parameters:(NSDictionary<NSString *, NSObject <NSCopying> *> *)parameters
+                         NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/OIDRegistrationResponse.m
+++ b/Source/OIDRegistrationResponse.m
@@ -1,0 +1,163 @@
+/*! @file OIDRegistrationResponse.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDRegistrationResponse.h"
+
+#import "OIDClientMetadataParameters.h"
+#import "OIDDefines.h"
+#import "OIDFieldMapping.h"
+#import "OIDRegistrationRequest.h"
+
+NSString *const OIDClientIDParam = @"client_id";
+NSString *const OIDClientIDIssuedAtParam = @"client_id_issued_at";
+NSString *const OIDClientSecretParam = @"client_secret";
+NSString *const OIDClientSecretExpirestAtParam = @"client_secret_expires_at";
+NSString *const OIDRegistrationAccessTokenParam = @"registration_access_token";
+NSString *const OIDRegistrationClientURIParam = @"registration_client_uri";
+
+/*! @brief Key used to encode the @c request property for @c NSSecureCoding
+ */
+static NSString *const kRequestKey = @"request";
+
+/*! @brief Key used to encode the @c additionalParameters property for @c NSSecureCoding
+ */
+static NSString *const kAdditionalParametersKey = @"additionalParameters";
+
+@implementation OIDRegistrationResponse
+
+/*! @brief Returns a mapping of incoming parameters to instance variables.
+    @return A mapping of incoming parameters to instance variables.
+ */
++ (NSDictionary<NSString *, OIDFieldMapping *> *)fieldMap {
+  static NSMutableDictionary<NSString *, OIDFieldMapping *> *fieldMap;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    fieldMap = [NSMutableDictionary dictionary];
+    fieldMap[OIDClientIDParam] = [[OIDFieldMapping alloc] initWithName:@"_clientID"
+                                                                  type:[NSString class]];
+    fieldMap[OIDClientIDIssuedAtParam] =
+    [[OIDFieldMapping alloc] initWithName:@"_clientIDIssuedAt"
+                                     type:[NSDate class]
+                               conversion:[OIDFieldMapping dateEpochConversion]];
+    fieldMap[OIDClientSecretParam] =
+    [[OIDFieldMapping alloc] initWithName:@"_clientSecret"
+                                     type:[NSString class]];
+    fieldMap[OIDClientSecretExpirestAtParam] =
+    [[OIDFieldMapping alloc] initWithName:@"_clientSecretExpiresAt"
+                                     type:[NSDate class]
+                               conversion:[OIDFieldMapping dateEpochConversion]];
+    fieldMap[OIDRegistrationAccessTokenParam] =
+    [[OIDFieldMapping alloc] initWithName:@"_registrationAccessToken"
+                                     type:[NSString class]];
+    fieldMap[OIDRegistrationClientURIParam] =
+    [[OIDFieldMapping alloc] initWithName:@"_registrationClientURI"
+                                     type:[NSURL class]
+                               conversion:[OIDFieldMapping URLConversion]];
+    fieldMap[OIDTokenEndpointAuthenticationMethodParam] =
+    [[OIDFieldMapping alloc] initWithName:@"_tokenEndpointAuthenticationMethod"
+                                     type:[NSString class]];
+  });
+  return fieldMap;
+}
+
+
+#pragma mark - Initializers
+
+- (nullable instancetype)init
+  OID_UNAVAILABLE_USE_INITIALIZER(@selector(initWithRequest:parameters:));
+
+- (nullable instancetype)initWithRequest:(OIDRegistrationRequest *)request
+                              parameters:(NSDictionary<NSString *, NSObject <NSCopying> *> *)parameters {
+  self = [super init];
+  if (self) {
+    _request = [request copy];
+    NSDictionary<NSString *, NSObject <NSCopying> *> *additionalParameters =
+    [OIDFieldMapping remainingParametersWithMap:[[self class] fieldMap]
+                                     parameters:parameters
+                                       instance:self];
+    _additionalParameters = additionalParameters;
+
+    if ((_clientSecret && !_clientSecretExpiresAt)
+        || (!!_registrationClientURI != !!_registrationAccessToken)) {
+      // If client_secret is issued, client_secret_expires_at is REQUIRED,
+      // and the response MUST contain "[...] both a Client Configuration Endpoint
+      // and a Registration Access Token or neither of them"
+      return nil;
+    }
+  }
+  return self;
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(nullable NSZone *)zone {
+  // The documentation for NSCopying specifically advises us to return a reference to the original
+  // instance in the case where instances are immutable (as ours is):
+  // "Implement NSCopying by retaining the original instead of creating a new copy when the class
+  // and its contents are immutable."
+  return self;
+}
+
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+  OIDRegistrationRequest *request = [aDecoder decodeObjectOfClass:[OIDRegistrationRequest class]
+                                                           forKey:kRequestKey];
+  self = [self initWithRequest:request
+                    parameters:@{}];
+  if (self) {
+    [OIDFieldMapping decodeWithCoder:aDecoder
+                                 map:[[self class] fieldMap]
+                            instance:self];
+    _additionalParameters = [aDecoder decodeObjectOfClasses:[OIDFieldMapping JSONTypes]
+                                                     forKey:kAdditionalParametersKey];
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [OIDFieldMapping encodeWithCoder:aCoder map:[[self class] fieldMap] instance:self];
+  [aCoder encodeObject:_request forKey:kRequestKey];
+  [aCoder encodeObject:_additionalParameters forKey:kAdditionalParametersKey];
+}
+
+#pragma mark - NSObject overrides
+
+- (NSString *)description {
+  return [NSString stringWithFormat:@"<%@: %p, clientID: \"%@\", clientIDIssuedAt: %@, "
+          "clientSecret: %@, clientSecretExpiresAt: \"%@\", "
+          "registrationAccessToken: \"%@\", "
+          "registrationClientURI: \"%@\", "
+          "additionalParameters: %@, request: %@>",
+          NSStringFromClass([self class]),
+          self,
+          _clientID,
+          _clientIDIssuedAt,
+          _clientSecret,
+          _clientSecretExpiresAt,
+          _registrationAccessToken,
+          _registrationClientURI,
+          _additionalParameters,
+          _request];
+}
+
+@end

--- a/Source/OIDServiceConfiguration.h
+++ b/Source/OIDServiceConfiguration.h
@@ -42,6 +42,10 @@ typedef void (^OIDServiceConfigurationCreated)
  */
 @property(nonatomic, readonly) NSURL *tokenEndpoint;
 
+/*! @brief The dynamic client registration endpoint URI.
+ */
+@property(nonatomic, readonly, nullable) NSURL *registrationEndpoint;
+
 /*! @brief The discovery document.
  */
 @property(nonatomic, readonly, nullable) OIDServiceDiscovery *discoveryDocument;
@@ -56,7 +60,15 @@ typedef void (^OIDServiceConfigurationCreated)
     @param tokenEndpoint The token exchange and refresh endpoint URI.
  */
 - (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
-                                         tokenEndpoint:(NSURL *)tokenEndpoint;
+                                tokenEndpoint:(NSURL *)tokenEndpoint;
+
+/*! @param authorizationEndpoint The authorization endpoint URI.
+    @param tokenEndpoint The token exchange and refresh endpoint URI.
+    @param registrationEndpoint The dynamic client registration endpoint URI.
+ */
+- (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
+                                tokenEndpoint:(NSURL *)tokenEndpoint
+                         registrationEndpoint:(nullable NSURL *)registrationEndpoint;
 
 /*! @param discoveryDocument The discovery document from which to extract the required OAuth
         configuration.

--- a/Source/OIDServiceConfiguration.m
+++ b/Source/OIDServiceConfiguration.m
@@ -30,6 +30,10 @@ static NSString *const kAuthorizationEndpointKey = @"authorizationEndpoint";
  */
 static NSString *const kTokenEndpointKey = @"tokenEndpoint";
 
+/*! @brief The key for the @c registrationEndpoint property.
+ */
+static NSString *const kRegistrationEndpointKey = @"registrationEndpoint";
+
 /*! @brief The key for the @c discoveryDocument property.
  */
 static NSString *const kDiscoveryDocumentKey = @"discoveryDocument";
@@ -39,40 +43,58 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OIDServiceConfiguration ()
 
 - (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
-        tokenEndpoint:(NSURL *)tokenEndpoint
-    discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument
-    NS_DESIGNATED_INITIALIZER;
+                                tokenEndpoint:(NSURL *)tokenEndpoint
+                         registrationEndpoint:(nullable NSURL *)registrationEndpoint
+                            discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument
+                            NS_DESIGNATED_INITIALIZER;
 
 @end
 
 @implementation OIDServiceConfiguration
 
 - (instancetype)init
-    OID_UNAVAILABLE_USE_INITIALIZER(@selector(initWithAuthorizationEndpoint:tokenEndpoint:));
+    OID_UNAVAILABLE_USE_INITIALIZER(@selector(
+        initWithAuthorizationEndpoint:
+                       tokenEndpoint:
+                registrationEndpoint:)
+    );
 
 - (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
         tokenEndpoint:(NSURL *)tokenEndpoint
+ registrationEndpoint:(nullable NSURL *)registrationEndpoint
     discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument {
 
   self = [super init];
   if (self) {
     _authorizationEndpoint = [authorizationEndpoint copy];
     _tokenEndpoint = [tokenEndpoint copy];
+    _registrationEndpoint = [registrationEndpoint copy];
     _discoveryDocument = [discoveryDocument copy];
   }
   return self;
 }
 
 - (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
-                                         tokenEndpoint:(NSURL *)tokenEndpoint {
+                                tokenEndpoint:(NSURL *)tokenEndpoint {
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint
+                        registrationEndpoint:nil
+                           discoveryDocument:nil];
+}
+
+- (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
+                                tokenEndpoint:(NSURL *)tokenEndpoint
+                         registrationEndpoint:(nullable NSURL *)registrationEndpoint {
+  return [self initWithAuthorizationEndpoint:authorizationEndpoint
+                               tokenEndpoint:tokenEndpoint
+                        registrationEndpoint:registrationEndpoint
                            discoveryDocument:nil];
 }
 
 - (instancetype)initWithDiscoveryDocument:(OIDServiceDiscovery *) discoveryDocument {
   return [self initWithAuthorizationEndpoint:discoveryDocument.authorizationEndpoint
                                tokenEndpoint:discoveryDocument.tokenEndpoint
+                        registrationEndpoint:discoveryDocument.registrationEndpoint
                            discoveryDocument:discoveryDocument];
 }
 
@@ -97,6 +119,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                         forKey:kAuthorizationEndpointKey];
   NSURL *tokenEndpoint = [aDecoder decodeObjectOfClass:[NSURL class]
                                                 forKey:kTokenEndpointKey];
+  NSURL *registrationEndpoint = [aDecoder decodeObjectOfClass:[NSURL class]
+                                                       forKey:kRegistrationEndpointKey];
   // We don't accept nil authorizationEndpoints or tokenEndpoints.
   if (!authorizationEndpoint || !tokenEndpoint) {
     return nil;
@@ -107,12 +131,14 @@ NS_ASSUME_NONNULL_BEGIN
 
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint
+                        registrationEndpoint:registrationEndpoint
                            discoveryDocument:discoveryDocument];
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [aCoder encodeObject:_authorizationEndpoint forKey:kAuthorizationEndpointKey];
   [aCoder encodeObject:_tokenEndpoint forKey:kTokenEndpointKey];
+  [aCoder encodeObject:_registrationEndpoint forKey:kRegistrationEndpointKey];
   [aCoder encodeObject:_discoveryDocument forKey:kDiscoveryDocumentKey];
 }
 
@@ -121,9 +147,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description {
   return [NSString stringWithFormat:
       @"OIDServiceConfiguration authorizationEndpoint: %@, tokenEndpoint: %@, "
-          "discoveryDocument: [%@]",
+          "registrationEndpoint: %@, discoveryDocument: [%@]",
       _authorizationEndpoint,
       _tokenEndpoint,
+      _registrationEndpoint,
       _discoveryDocument];
 }
 

--- a/Source/OIDTokenResponse.m
+++ b/Source/OIDTokenResponse.m
@@ -73,13 +73,7 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
     fieldMap[kExpiresInKey] =
         [[OIDFieldMapping alloc] initWithName:@"_accessTokenExpirationDate"
                                          type:[NSDate class]
-                                   conversion:^id _Nullable(NSObject *_Nullable value) {
-          if (![value isKindOfClass:[NSNumber class]]) {
-            return value;
-          }
-          NSNumber *valueAsNumber = (NSNumber *)value;
-          return [NSDate dateWithTimeIntervalSinceNow:[valueAsNumber longLongValue]];
-        }];
+                                   conversion:[OIDFieldMapping dateSinceNowConversion]];
     fieldMap[kTokenTypeKey] =
         [[OIDFieldMapping alloc] initWithName:@"_tokenType" type:[NSString class]];
     fieldMap[kIDTokenKey] =

--- a/UnitTests/OIDAuthStateTests.m
+++ b/UnitTests/OIDAuthStateTests.m
@@ -19,10 +19,12 @@
 #import "OIDAuthStateTests.h"
 
 #import "OIDAuthorizationResponseTests.h"
+#import "OIDRegistrationResponseTests.h"
 #import "OIDTokenResponseTests.h"
 #import "Source/OIDAuthState.h"
 #import "Source/OIDAuthorizationResponse.h"
 #import "Source/OIDErrorUtilities.h"
+#import "Source/OIDRegistrationResponse.h"
 #import "Source/OIDTokenResponse.h"
 #import "OIDTokenRequestTests.h"
 
@@ -235,6 +237,20 @@
   NSError *oauthError = [[self class] OAuthAuthorizationError];
   [authState updateWithAuthorizationResponse:authorizationResponse error:oauthError];
   XCTAssertNotNil(authState.authorizationError);
+}
+
+/*! @brief Tests @c OIDAuthState.updateWithRegistrationResponse: with a success response.
+ */
+- (void)testupdateWithRegistrationResponse {
+  OIDAuthState *authState = [[self class] testInstance];
+  OIDRegistrationResponse *registrationResponse = [OIDRegistrationResponseTests testInstance];
+  [authState updateWithRegistrationResponse:registrationResponse];
+  XCTAssertEqualObjects(authState.lastRegistrationResponse, registrationResponse);
+  XCTAssertNil(authState.refreshToken);
+  XCTAssertNil(authState.scope);
+  XCTAssertNil(authState.lastAuthorizationResponse);
+  XCTAssertNil(authState.authorizationError);
+  XCTAssertFalse(authState.isAuthorized);
 }
 
 /*! @brief Tests @c OIDAuthState.updateWithTokenResponse:error: with a success response.

--- a/UnitTests/OIDRegistrationRequestTests.h
+++ b/UnitTests/OIDRegistrationRequestTests.h
@@ -1,0 +1,35 @@
+/*! @file OIDRegistrationRequestTests.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@class OIDRegistrationRequest;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief Unit tests for @c OIDRegistrationRequest.
+ */
+@interface OIDRegistrationRequestTests : XCTestCase
+
+/*! @brief Creates a new @c OIDRegistrationRequest for testing.
+ */
++ (OIDRegistrationRequest *)testInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/UnitTests/OIDRegistrationRequestTests.m
+++ b/UnitTests/OIDRegistrationRequestTests.m
@@ -1,0 +1,177 @@
+/*! @file OIDRegistrationRequestTests.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDRegistrationRequestTests.h"
+
+#import "OIDServiceConfigurationTests.h"
+#import "Source/OIDClientMetadataParameters.h"
+#import "Source/OIDRegistrationRequest.h"
+#import "Source/OIDServiceConfiguration.h"
+
+/*! @brief Test key for the @c additionalParameters property.
+ */
+static NSString *const kTestAdditionalParameterKey = @"A";
+
+/*! @brief Test value for the @c additionalParameters property.
+ */
+static NSString *const kTestAdditionalParameterValue = @"1";
+
+/*! @brief Test value for the @c redirectURL property.
+ */
+static NSString *kRedirectURLTestValue = @"https://client.example.com/redirect";
+
+/*! @brief Test value for the @c responseTypes property.
+ */
+static NSString *kResponseTypeTestValue = @"code";
+
+/*! @brief Test value for the @c grantTypes property.
+ */
+static NSString *kGrantTypeTestValue = @"authorization_code";
+
+/*! @brief Test value for the @c subjectType property.
+ */
+static NSString *kSubjectTypeTestValue = @"public";
+
+/*! @brief Test value for the @c tokenEndpointAuthenticationMethod property.
+ */
+static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
+
+@implementation OIDRegistrationRequestTests
+
++ (OIDRegistrationRequest *)testInstance {
+  NSDictionary *additionalParameters = @{
+                                         kTestAdditionalParameterKey : kTestAdditionalParameterValue
+                                         };
+
+  OIDServiceConfiguration *config = [OIDServiceConfigurationTests testInstance];
+  OIDRegistrationRequest *request =
+      [[OIDRegistrationRequest alloc] initWithConfiguration:config
+                               redirectURIs:@[ [NSURL URLWithString:kRedirectURLTestValue] ]
+                              responseTypes:@[ kResponseTypeTestValue ]
+                                 grantTypes:@[ kGrantTypeTestValue ]
+                                subjectType:kSubjectTypeTestValue
+                    tokenEndpointAuthMethod:kTokenEndpointAuthMethodTestValue
+                       additionalParameters:additionalParameters];
+
+  return request;
+}
+
+- (void)testApplicationIsNativeByDefault {
+  OIDRegistrationRequest *request = [[self class] testInstance];
+  XCTAssertEqualObjects(request.applicationType, OIDApplicationTypeNative);
+}
+
+/*! @brief Tests the @c NSCopying implementation by round-tripping an instance through the copying
+        process and checking to make sure the source and destination instances are equivalent.
+ */
+- (void)testCopying {
+  OIDRegistrationRequest *request = [[self class] testInstance];
+
+  XCTAssertNotNil(request.configuration);
+  XCTAssertEqualObjects(request.applicationType, OIDApplicationTypeNative);
+  XCTAssertEqualObjects(request.redirectURIs, @[ [NSURL URLWithString:kRedirectURLTestValue] ]);
+  XCTAssertEqualObjects(request.responseTypes, @[ kResponseTypeTestValue ]);
+  XCTAssertEqualObjects(request.grantTypes, @[ kGrantTypeTestValue ]);
+  XCTAssertEqualObjects(request.subjectType, kSubjectTypeTestValue);
+  XCTAssertEqualObjects(request.tokenEndpointAuthenticationMethod,
+                        kTokenEndpointAuthMethodTestValue);
+  XCTAssertNotNil(request.additionalParameters);
+  XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+
+  OIDRegistrationRequest *requestCopy = [request copy];
+
+  // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
+  // to make sure the configuration IS actually getting carried along in the copy implementation.
+  XCTAssertEqualObjects(requestCopy.configuration, request.configuration);
+
+  XCTAssertEqualObjects(requestCopy.applicationType, request.applicationType);
+  XCTAssertEqualObjects(requestCopy.redirectURIs, request.redirectURIs);
+  XCTAssertEqualObjects(requestCopy.responseTypes, request.responseTypes);
+  XCTAssertEqualObjects(requestCopy.grantTypes, request.grantTypes);
+  XCTAssertEqualObjects(requestCopy.subjectType, request.subjectType);
+  XCTAssertEqualObjects(requestCopy.tokenEndpointAuthenticationMethod,
+                        request.tokenEndpointAuthenticationMethod);
+  XCTAssertNotNil(requestCopy.additionalParameters);
+  XCTAssertEqualObjects(requestCopy.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+}
+
+/*! @brief Tests the @c NSSecureCoding by round-tripping an instance through the coding process and
+        checking to make sure the source and destination instances are equivalent.
+ */
+- (void)testSecureCoding {
+  OIDRegistrationRequest *request = [[self class] testInstance];
+
+  XCTAssertNotNil(request.configuration);
+  XCTAssertEqualObjects(request.applicationType, OIDApplicationTypeNative);
+  XCTAssertEqualObjects(request.redirectURIs, @[ [NSURL URLWithString:kRedirectURLTestValue] ]);
+  XCTAssertEqualObjects(request.responseTypes, @[ kResponseTypeTestValue ]);
+  XCTAssertEqualObjects(request.grantTypes, @[ kGrantTypeTestValue ]);
+  XCTAssertEqualObjects(request.subjectType, kSubjectTypeTestValue);
+  XCTAssertEqualObjects(request.tokenEndpointAuthenticationMethod,
+                        kTokenEndpointAuthMethodTestValue);
+  XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
+  OIDRegistrationRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+
+  // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
+  // to make sure the configuration IS actually getting serialized and deserialized in the
+  // NSSecureCoding implementation. We'll leave it up to the OIDServiceConfiguration tests to make
+  // sure the NSSecureCoding implementation of that class is correct.
+  XCTAssertNotNil(requestCopy.configuration);
+
+  XCTAssertEqualObjects(requestCopy.applicationType, request.applicationType);
+  XCTAssertEqualObjects(requestCopy.redirectURIs, request.redirectURIs);
+  XCTAssertEqualObjects(requestCopy.responseTypes, request.responseTypes);
+  XCTAssertEqualObjects(requestCopy.grantTypes, request.grantTypes);
+  XCTAssertEqualObjects(requestCopy.subjectType, request.subjectType);
+  XCTAssertEqualObjects(requestCopy.tokenEndpointAuthenticationMethod,
+                        request.tokenEndpointAuthenticationMethod);
+  XCTAssertEqualObjects(requestCopy.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+}
+
+/*! @brief Tests the @c URLRequest method
+ */
+- (void)testURLRequest {
+  OIDRegistrationRequest *request = [[self class] testInstance];
+  NSURLRequest *httpRequest = [request URLRequest];
+  NSError *error;
+  NSDictionary *parsedJSON = [NSJSONSerialization JSONObjectWithData:httpRequest.HTTPBody
+                                                             options:kNilOptions
+                                                               error:&error];
+
+  XCTAssertEqualObjects(httpRequest.HTTPMethod, @"POST");
+  XCTAssertEqualObjects([httpRequest valueForHTTPHeaderField:@"Content-Type"],
+                        @"application/json");
+  XCTAssertEqualObjects(httpRequest.URL, request.configuration.registrationEndpoint);
+  XCTAssertEqualObjects(parsedJSON[OIDApplicationTypeParam], request.applicationType);
+  XCTAssertEqualObjects(parsedJSON[OIDRedirectURIsParam][0],
+                        [request.redirectURIs[0] absoluteString]);
+  XCTAssertEqualObjects(parsedJSON[OIDResponseTypesParam], request.responseTypes);
+  XCTAssertEqualObjects(parsedJSON[OIDGrantTypesParam], request.grantTypes);
+  XCTAssertEqualObjects(parsedJSON[OIDSubjectTypeParam], request.subjectType);
+  XCTAssertEqualObjects(parsedJSON[OIDTokenEndpointAuthenticationMethodParam],
+                        request.tokenEndpointAuthenticationMethod);
+  XCTAssertEqualObjects(parsedJSON[kTestAdditionalParameterKey], kTestAdditionalParameterValue);
+}
+
+@end

--- a/UnitTests/OIDRegistrationResponseTests.h
+++ b/UnitTests/OIDRegistrationResponseTests.h
@@ -1,0 +1,33 @@
+/*! @file OIDRegistrationResponseTests.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@class OIDRegistrationResponse;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OIDRegistrationResponseTests : XCTestCase
+
+/*! @brief Creates a new @c OIDRegistrationResponseTests for testing.
+ */
++ (OIDRegistrationResponse *)testInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/UnitTests/OIDRegistrationResponseTests.m
+++ b/UnitTests/OIDRegistrationResponseTests.m
@@ -1,0 +1,181 @@
+/*! @file OIDRegistrationResponseTests.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth for iOS Authors. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDRegistrationResponseTests.h"
+
+#import "OIDClientMetadataParameters.h"
+#import "OIDRegistrationRequestTests.h"
+#import "Source/OIDRegistrationRequest.h"
+#import "Source/OIDRegistrationResponse.h"
+
+/*! @brief The test value for the @c clientID property.
+ */
+static NSString *const kClientIDTestValue = @"client1";
+
+/*! @brief The test value for the @c clientSecretExpiresAt property.
+ */
+static long long const kClientSecretExpiresAtTestValue = 1463414761;
+
+/*! @brief The test value for the @c clientSecret property.
+ */
+static NSString *const kClientSecretTestValue = @"secret1";
+
+/*! @brief The test value for the @c clientIDIssuedAt property.
+ */
+static long long const kClientIDIssuedAtTestValue = 1463411161;
+
+/*! @brief The test value for the @c clientRegistrationAccessToken property.
+ */
+static NSString *const kClientRegistrationAccessTokenTestValue = @"abcdefgh";
+
+/*! @brief The test value for the @c registrationClientURI property.
+ */
+static NSString *const kRegistrationClientURITestValue = @"https://provider.example.com/client1";
+
+/*! @brief The test value for the @c tokenEndpointAuthenticationMethod property.
+ */
+static NSString *const kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
+
+/*! @brief Test key for the @c additionalParameters property.
+ */
+static NSString *const kTestAdditionalParameterKey = @"example_parameter";
+
+/*! @brief Test value for the @c additionalParameters property.
+ */
+static NSString *const kTestAdditionalParameterValue = @"example_value";
+
+@implementation OIDRegistrationResponseTests
++ (OIDRegistrationResponse *)testInstance {
+  OIDRegistrationRequest *request = [OIDRegistrationRequestTests testInstance];
+  OIDRegistrationResponse *response = [[OIDRegistrationResponse alloc] initWithRequest:request
+      parameters:@{
+          OIDClientIDParam : kClientIDTestValue,
+          OIDClientIDIssuedAtParam : @(kClientIDIssuedAtTestValue),
+          OIDClientSecretParam : kClientSecretTestValue,
+          OIDClientSecretExpirestAtParam : @(kClientSecretExpiresAtTestValue),
+          OIDRegistrationAccessTokenParam : kClientRegistrationAccessTokenTestValue,
+          OIDRegistrationClientURIParam : [NSURL URLWithString:kRegistrationClientURITestValue],
+          OIDTokenEndpointAuthenticationMethodParam : kTokenEndpointAuthMethodTestValue,
+          kTestAdditionalParameterKey : kTestAdditionalParameterValue
+      }];
+  return response;
+}
+
+/*! @brief Tests the @c NSCopying implementation by round-tripping an instance through the copying
+        process and checking to make sure the source and destination instances are equivalent.
+ */
+- (void)testCopying {
+  OIDRegistrationResponse *response = [[self class] testInstance];
+  XCTAssertNotNil(response.request);
+  XCTAssertEqualObjects(response.clientID, kClientIDTestValue);
+  XCTAssertEqualObjects(response.clientIDIssuedAt,
+                        [NSDate dateWithTimeIntervalSince1970:kClientIDIssuedAtTestValue]);
+  XCTAssertEqualObjects(response.clientSecret, kClientSecretTestValue);
+  XCTAssertEqualObjects(response.clientSecretExpiresAt,
+                        [NSDate dateWithTimeIntervalSince1970:kClientSecretExpiresAtTestValue]);
+  XCTAssertEqualObjects(response.registrationAccessToken, kClientRegistrationAccessTokenTestValue);
+  XCTAssertEqualObjects(response.registrationClientURI,
+                        [NSURL URLWithString:kRegistrationClientURITestValue]);
+  XCTAssertEqualObjects(response.tokenEndpointAuthenticationMethod,
+                        kTokenEndpointAuthMethodTestValue);
+  XCTAssertEqualObjects(response.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+
+  OIDRegistrationResponse *responseCopy = [response copy];
+
+  XCTAssertNotNil(responseCopy.request);
+  XCTAssertEqualObjects(responseCopy.clientID, response.clientID);
+  XCTAssertEqualObjects(responseCopy.clientIDIssuedAt, response.clientIDIssuedAt);
+  XCTAssertEqualObjects(responseCopy.clientSecret, response.clientSecret);
+  XCTAssertEqualObjects(responseCopy.clientSecretExpiresAt, response.clientSecretExpiresAt);
+  XCTAssertEqualObjects(responseCopy.registrationAccessToken, response.registrationAccessToken);
+  XCTAssertEqualObjects(responseCopy.registrationClientURI, response.registrationClientURI);
+  XCTAssertEqualObjects(responseCopy.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+}
+
+/*! @brief Tests the @c NSSecureCoding by round-tripping an instance through the coding process and
+        checking to make sure the source and destination instances are equivalent.
+ */
+- (void)testSecureCoding {
+  OIDRegistrationResponse *response = [[self class] testInstance];
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
+  OIDRegistrationResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+
+  // Not a full test of the request deserialization, but should be sufficient as a smoke test
+  // to make sure the request IS actually getting serialized and deserialized in the
+  // NSSecureCoding implementation. We'll leave it up to the OIDAuthorizationRequest tests to make
+  // sure the NSSecureCoding implementation of that class is correct.
+  XCTAssertNotNil(responseCopy.request);
+  XCTAssertEqualObjects(responseCopy.request.applicationType, response.request.applicationType);
+
+  XCTAssertEqualObjects(responseCopy.clientID, response.clientID);
+  XCTAssertEqualObjects(responseCopy.clientIDIssuedAt, response.clientIDIssuedAt);
+  XCTAssertEqualObjects(responseCopy.clientSecret, response.clientSecret);
+  XCTAssertEqualObjects(responseCopy.clientSecretExpiresAt, response.clientSecretExpiresAt);
+  XCTAssertEqualObjects(responseCopy.registrationAccessToken, response.registrationAccessToken);
+  XCTAssertEqualObjects(responseCopy.registrationClientURI, response.registrationClientURI);
+  XCTAssertEqualObjects(responseCopy.tokenEndpointAuthenticationMethod,
+                        response.tokenEndpointAuthenticationMethod);
+  XCTAssertEqualObjects(responseCopy.additionalParameters[kTestAdditionalParameterKey],
+                        kTestAdditionalParameterValue);
+}
+
+/*! @brief Make sure the registration response is verified to ensure the 'client_secret_expires_at'
+        parameter exists if a 'client_secret' is issued.
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+- (void)testMissingClientSecretExpiresAtWithClientSecret {
+  OIDRegistrationRequest *request = [OIDRegistrationRequestTests testInstance];
+  OIDRegistrationResponse *response = [[OIDRegistrationResponse alloc] initWithRequest:request
+      parameters:@{
+          OIDClientIDParam : kClientIDTestValue,
+          OIDClientSecretParam : kClientSecretTestValue,
+      }];
+  XCTAssertNil(response);
+}
+
+/*! @brief Make sure the registration response missing 'registration_access_token' is detected when
+        'client_registration_uri' is specified..
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+- (void)testMissingRegistrationAccessTokenWithRegistrationClientURI {
+  OIDRegistrationRequest *request = [OIDRegistrationRequestTests testInstance];
+  OIDRegistrationResponse *response = [[OIDRegistrationResponse alloc] initWithRequest:request
+      parameters:@{
+          OIDClientIDParam : kClientIDTestValue,
+          OIDRegistrationClientURIParam : [NSURL URLWithString:kRegistrationClientURITestValue]
+      }];
+  XCTAssertNil(response);
+}
+
+/*! @brief Make sure the registration response missing 'client_registration_uri' is detected when
+        'registration_access_token' is specified..
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
+ */
+- (void)testMissingRegistrationClientURIWithRegistrationAccessToken {
+  OIDRegistrationRequest *request = [OIDRegistrationRequestTests testInstance];
+  OIDRegistrationResponse *response = [[OIDRegistrationResponse alloc] initWithRequest:request
+      parameters:@{
+          OIDClientIDParam : kClientIDTestValue,
+          OIDRegistrationAccessTokenParam : kClientRegistrationAccessTokenTestValue
+      }];
+  XCTAssertNil(response);
+}
+
+@end

--- a/UnitTests/OIDServiceConfigurationTests.m
+++ b/UnitTests/OIDServiceConfigurationTests.m
@@ -53,6 +53,11 @@ static NSString *const kInitializerTestAuthEndpoint = @"https://www.example.com/
  */
 static NSString *const kInitializerTestTokenEndpoint = @"https://www.example.com/token";
 
+/*! @brief Test value for the @c tokenEndpoint property.
+ */
+static NSString *const kInitializerTestRegistrationEndpoint =
+    @"https://www.example.com/registration";
+
 /*! @brief Test URL for OpenID Connect Discovery document. Not actually retrieved.
  */
 static NSString *const kInitializerTestDiscoveryEndpoint = @"https://www.example.com/discovery";
@@ -80,9 +85,11 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
 + (OIDServiceConfiguration *)testInstance {
   NSURL *authEndpoint = [NSURL URLWithString:kInitializerTestAuthEndpoint];
   NSURL *tokenEndpoint = [NSURL URLWithString:kInitializerTestTokenEndpoint];
+  NSURL *registrationEndpoint = [NSURL URLWithString:kInitializerTestRegistrationEndpoint];
   OIDServiceConfiguration *configuration =
       [[OIDServiceConfiguration alloc] initWithAuthorizationEndpoint:authEndpoint
-                                                       tokenEndpoint:tokenEndpoint];
+                                                       tokenEndpoint:tokenEndpoint
+                                                registrationEndpoint:registrationEndpoint];
   return configuration;
 }
 
@@ -143,6 +150,8 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
                         kInitializerTestAuthEndpoint);
   XCTAssertEqualObjects(configuration.tokenEndpoint.absoluteString,
                         kInitializerTestTokenEndpoint);
+  XCTAssertEqualObjects(configuration.registrationEndpoint.absoluteString,
+                        kInitializerTestRegistrationEndpoint);
 }
 
 - (void)testIssuer {
@@ -349,6 +358,7 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
 
   XCTAssertEqualObjects(configuration.authorizationEndpoint, unarchived.authorizationEndpoint);
   XCTAssertEqualObjects(configuration.tokenEndpoint, unarchived.tokenEndpoint);
+  XCTAssertEqualObjects(configuration.registrationEndpoint, unarchived.registrationEndpoint);
 }
 
 /*! @brief Tests the @c NSCopying implementation by round-tripping an instance through the copying
@@ -361,6 +371,7 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
 
   XCTAssertEqualObjects(configuration.authorizationEndpoint, unarchived.authorizationEndpoint);
   XCTAssertEqualObjects(configuration.tokenEndpoint, unarchived.tokenEndpoint);
+  XCTAssertEqualObjects(configuration.registrationEndpoint, unarchived.registrationEndpoint);
 }
 
 @end


### PR DESCRIPTION
(Sorry for the large changeset.)

Similar implementation to the one for Android:
- stores the registration response in the AuthState
- constructs the registration request body as JSON
- checks conditions on the registration response
- adds implementation to the example app

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/22)

<!-- Reviewable:end -->
