### PR TITLE
Fix nil pointer dereference when 'nil' passed in to receive error

### DIFF
--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -134,10 +134,12 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
   for (NSString *field in requiredFields) {
     if (!dictionary[field]) {
-      NSString *errorText = [NSString stringWithFormat:kMissingFieldErrorText, field];
-      *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeInvalidDiscoveryDocument
-                                underlyingError:nil
-                                    description:errorText];
+      if (error) {
+        NSString *errorText = [NSString stringWithFormat:kMissingFieldErrorText, field];
+        *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeInvalidDiscoveryDocument
+                                  underlyingError:nil
+                                      description:errorText];
+      }
       return NO;
     }
   }
@@ -151,10 +153,12 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
   for (NSString *field in requiredURLFields) {
     if (![NSURL URLWithString:dictionary[field]]) {
-      NSString *errorText = [NSString stringWithFormat:kInvalidURLFieldErrorText, field];
-      *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeInvalidDiscoveryDocument
-                                underlyingError:nil
-                                    description:errorText];
+      if (error) {
+        NSString *errorText = [NSString stringWithFormat:kInvalidURLFieldErrorText, field];
+        *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeInvalidDiscoveryDocument
+                                  underlyingError:nil
+                                      description:errorText];
+      }
       return NO;
     }
   }


### PR DESCRIPTION
Per Objective-C guidelines, error pointers may be set to nil/null if the caller doesn't care about specifics of the error. In this case, *error is a nil pointer dereference and will crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/26)
<!-- Reviewable:end -->
