### PR TITLE
Add modal presentation options for SFSafariVC

### DIFF
--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -136,6 +136,26 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
     presentingViewController:(UIViewController *)presentingViewController
                     callback:(OIDAuthStateAuthorizationCallback)callback;
 
+/*! @fn authStateByPresentingAuthorizationRequest:presentingViewController:modalPresentationStyle:modalTransitionStyle:callback:
+    @brief Convenience method to create a @c OIDAuthState by presenting an authorization request
+        and performing the authorization code exchange in the case of code flow requests.
+    @param authorizationRequest The authorization request to present.
+    @param presentingViewController The view controller from which to present the
+        \SFSafariViewController.
+    @param modalPresentationStyle Modal presentation style for the \SFSafariViewController.
+    @param modalTransitionStyle Modal transition style for the \SFSafariViewController.
+    @param callback The method called when the request has completed or failed.
+    @return A @c OIDAuthorizationFlowSession instance which will terminate when it
+        receives a @c OIDAuthorizationFlowSession.cancel message, or after processing a
+        @c OIDAuthorizationFlowSession.resumeAuthorizationFlowWithURL: message.
+ */
++ (id<OIDAuthorizationFlowSession>)authStateByPresentingAuthorizationRequest:
+    (OIDAuthorizationRequest *)authorizationRequest
+    presentingViewController:(UIViewController *)presentingViewController
+      modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+        modalTransitionStyle:(UIModalTransitionStyle)modalTransitionStyle
+                    callback:(OIDAuthStateAuthorizationCallback)callback;
+
 /*! @fn init
     @internal
     @brief Unavailable. Please use @c initWithAuthorizationResponse:.

--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -120,10 +120,25 @@ static const NSUInteger kExpiryTimeTolerance = 60;
     (OIDAuthorizationRequest *)authorizationRequest
     presentingViewController:(UIViewController *)presentingViewController
                     callback:(OIDAuthStateAuthorizationCallback)callback {
+    return [self authStateByPresentingAuthorizationRequest:authorizationRequest
+                           presentingViewController:presentingViewController
+                             modalPresentationStyle:UIModalPresentationFullScreen
+                               modalTransitionStyle:UIModalTransitionStyleCoverVertical
+                                           callback:callback];
+}
+
++ (id<OIDAuthorizationFlowSession>)authStateByPresentingAuthorizationRequest:
+    (OIDAuthorizationRequest *)authorizationRequest
+    presentingViewController:(UIViewController *)presentingViewController
+      modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+        modalTransitionStyle:(UIModalTransitionStyle)modalTransitionStyle
+                    callback:(OIDAuthStateAuthorizationCallback)callback {
   // presents the authorization request
   id<OIDAuthorizationFlowSession> authFlowSession =
       [OIDAuthorizationService presentAuthorizationRequest:authorizationRequest
                                   presentingViewController:presentingViewController
+                                    modalPresentationStyle:modalPresentationStyle
+                                      modalTransitionStyle:modalTransitionStyle
           callback:^(OIDAuthorizationResponse *_Nullable authorizationResponse,
                      NSError *_Nullable error) {
     // inspects response and processes further if needed (e.g. authorization code exchange)

--- a/Source/OIDAuthorizationService.h
+++ b/Source/OIDAuthorizationService.h
@@ -120,6 +120,25 @@ typedef NSDictionary<NSString *, NSString *> *_Nullable OIDTokenEndpointParamete
        presentingViewController:(UIViewController *)presentingViewController
                        callback:(OIDAuthorizationCallback)callback;
 
+/*! @fn presentAuthorizationRequest:presentingViewController:modalPresentationStyle:modalTransitionStyle:callback:
+    @brief Perform an authorization flow using \SFSafariViewController.
+    @param request The authorization request.
+    @param presentingViewController The view controller from which to present the
+        \SFSafariViewController.
+    @param modalPresentationStyle Modal presentation style for the \SFSafariViewController.
+    @param modalTransitionStyle Modal transition style for the \SFSafariViewController.
+    @param callback The method called when the request has completed or failed.
+    @return A @c OIDAuthorizationFlowSession instance which will terminate when it
+        receives a @c OIDAuthorizationFlowSession.cancel message, or after processing a
+        @c OIDAuthorizationFlowSession.resumeAuthorizationFlowWithURL: message.
+ */
++ (id<OIDAuthorizationFlowSession>)
+    presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+       presentingViewController:(UIViewController *)presentingViewController
+         modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+           modalTransitionStyle:(UIModalTransitionStyle)modalTransitionStyle
+                       callback:(OIDAuthorizationCallback)callback;
+
 /*! @fn performTokenRequest:callback:
     @brief Performs a token request.
     @param request The token request.

--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -49,6 +49,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presentSafariViewControllerWithViewController:(UIViewController *)parentViewController
     callback:(OIDAuthorizationCallback)authorizationFlowCallback;
 
+- (void)presentSafariViewControllerWithViewController:(UIViewController *)parentViewController
+    modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+    modalTransitionStyle:(UIModalTransitionStyle)modalTransitionStyle
+    callback:(OIDAuthorizationCallback)authorizationFlowCallback;
+
 @end
 
 @implementation OIDAuthorizationFlowSessionImplementation {
@@ -67,6 +72,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)presentSafariViewControllerWithViewController:(UIViewController *)parentViewController
     callback:(OIDAuthorizationCallback)authorizationFlowCallback {
+    [self presentSafariViewControllerWithViewController:parentViewController
+                                 modalPresentationStyle:UIModalPresentationFullScreen
+                                   modalTransitionStyle:UIModalTransitionStyleCoverVertical
+                                               callback:authorizationFlowCallback];
+}
+
+- (void)presentSafariViewControllerWithViewController:(UIViewController *)parentViewController
+                               modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+                                 modalTransitionStyle:(UIModalTransitionStyle)modalTransitionStyle
+                                             callback:(OIDAuthorizationCallback)authorizationFlowCallback {
   _pendingauthorizationFlowCallback = authorizationFlowCallback;
   NSURL *URL = [_request authorizationRequestURL];
   if ([SFSafariViewController class]) {
@@ -74,6 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                            entersReaderIfAvailable:NO];
     safariVC.delegate = self;
     _safariVC = safariVC;
+    _safariVC.modalPresentationStyle = modalPresentationStyle;
+    _safariVC.modalTransitionStyle = modalTransitionStyle;
     [parentViewController presentViewController:safariVC animated:YES completion:nil];
   } else {
     BOOL openedSafari = [[UIApplication sharedApplication] openURL:URL];
@@ -269,6 +286,21 @@ NS_ASSUME_NONNULL_BEGIN
   OIDAuthorizationFlowSessionImplementation *flow =
       [[OIDAuthorizationFlowSessionImplementation alloc] initWithRequest:request];
   [flow presentSafariViewControllerWithViewController:presentingViewController
+                                             callback:callback];
+  return flow;
+}
+
++ (id<OIDAuthorizationFlowSession>)
+    presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+       presentingViewController:(UIViewController *)presentingViewController
+         modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+           modalTransitionStyle:(UIModalTransitionStyle)modalTransitionStyle
+                       callback:(OIDAuthorizationCallback)callback {
+  OIDAuthorizationFlowSessionImplementation *flow =
+      [[OIDAuthorizationFlowSessionImplementation alloc] initWithRequest:request];
+  [flow presentSafariViewControllerWithViewController:presentingViewController
+                               modalPresentationStyle:modalPresentationStyle
+                                 modalTransitionStyle:modalTransitionStyle
                                              callback:callback];
   return flow;
 }


### PR DESCRIPTION
Adds support for specifing the modal presentation and transition styles of the presented SFSafariViewController.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/28)

<!-- Reviewable:end -->
