### PR TITLE
Nonnull initializers

### DIFF
--- a/Source/OIDAuthorizationRequest.h
+++ b/Source/OIDAuthorizationRequest.h
@@ -127,7 +127,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
     @brief Unavailable. Please use
         @c initWithConfiguration:clientId:scopes:redirectURL:additionalParameters:.
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /*! @fn initWithConfiguration:clientId:scopes:redirectURL:responseType:additionalParameters:
     @brief Creates an authorization request with opinionated defaults (a secure @c state, and
@@ -141,7 +141,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
     @remarks This convenience initializer generates a state parameter and PKCE challenges
         automatically.
  */
-- (nullable instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                 clientId:(NSString *)clientID
                   scopes:(nullable NSArray<NSString *> *)scopes
              redirectURL:(NSURL *)redirectURL
@@ -166,7 +166,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
         challenge.
     @param additionalParameters The client's additional authorization parameters.
  */
-- (nullable instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                 clientId:(NSString *)clientID
                    scope:(nullable NSString *)scope
              redirectURL:(NSURL *)redirectURL

--- a/Source/OIDAuthorizationRequest.m
+++ b/Source/OIDAuthorizationRequest.m
@@ -102,7 +102,7 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
                    additionalParameters:)
     );
 
-- (nullable instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                 clientId:(NSString *)clientID
                    scope:(nullable NSString *)scope
              redirectURL:(NSURL *)redirectURL
@@ -131,7 +131,7 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
   return self;
 }
 
-- (nullable instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                 clientId:(NSString *)clientID
                   scopes:(nullable NSArray<NSString *> *)scopes
              redirectURL:(NSURL *)redirectURL

--- a/Source/OIDServiceConfiguration.h
+++ b/Source/OIDServiceConfiguration.h
@@ -56,20 +56,20 @@ typedef void (^OIDServiceConfigurationCreated)
     @brief Unavailable. Please use @c initWithAuthorizationEndpoint:tokenEndpoint: or
         @c initWithDiscoveryDocument:.
  */
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /*! @fn initWithAuthorizationEndpoint:tokenEndpoint:
     @param authorizationEndpoint The authorization endpoint URI.
     @param tokenEndpoint The token exchange and refresh endpoint URI.
  */
-- (nullable instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
+- (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
                                          tokenEndpoint:(NSURL *)tokenEndpoint;
 
 /*! @fn initWithDiscoveryDocument:
     @param discoveryDocument The discovery document from which to extract the required OAuth
         configuration.
  */
-- (nullable instancetype)initWithDiscoveryDocument:(OIDServiceDiscovery *)discoveryDocument;
+- (instancetype)initWithDiscoveryDocument:(OIDServiceDiscovery *)discoveryDocument;
 
 @end
 

--- a/Source/OIDServiceConfiguration.m
+++ b/Source/OIDServiceConfiguration.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OIDServiceConfiguration ()
 
-- (nullable instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
+- (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
         tokenEndpoint:(NSURL *)tokenEndpoint
     discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument
     NS_DESIGNATED_INITIALIZER;
@@ -50,10 +50,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OIDServiceConfiguration
 
-- (nullable instancetype)init
+- (instancetype)init
     OID_UNAVAILABLE_USE_INITIALIZER(@selector(initWithAuthorizationEndpoint:tokenEndpoint:));
 
-- (nullable instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
+- (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
         tokenEndpoint:(NSURL *)tokenEndpoint
     discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument {
 
@@ -66,14 +66,14 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (nullable instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
+- (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
                                          tokenEndpoint:(NSURL *)tokenEndpoint {
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint
                            discoveryDocument:nil];
 }
 
-- (nullable instancetype)initWithDiscoveryDocument:(OIDServiceDiscovery *) discoveryDocument {
+- (instancetype)initWithDiscoveryDocument:(OIDServiceDiscovery *) discoveryDocument {
   return [self initWithAuthorizationEndpoint:discoveryDocument.authorizationEndpoint
                                tokenEndpoint:discoveryDocument.tokenEndpoint
                            discoveryDocument:discoveryDocument];


### PR DESCRIPTION
This change removes `nullable` annotations from user-facing initializers which makes them much nicer to use at the Swift call-site:

_Before:_
```swift
let config = OIDServiceConfiguration(authorizationEndpoint: authEndpoint,
		                                     tokenEndpoint: tokenEndpoint)!
```

_After (no force-unwrapping required):_
```swift
let config = OIDServiceConfiguration(authorizationEndpoint: authEndpoint,
		                                     tokenEndpoint: tokenEndpoint)
```

I've checked the initializers if there is any chance they could ever return `nil` and it turned out there is none. They do call `NSObject`'s `init` which guarantees to never return `nil`.


There are many more initializers in this project marked as `nullable`, but these two classes are the most "visible" ones to library users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/33)
<!-- Reviewable:end -->
