### PR TITLE
Adds SFSafariViewController customization.

### DIFF
--- a/Source/iOS/OIDAuthorizationUICoordinatorIOS.h
+++ b/Source/iOS/OIDAuthorizationUICoordinatorIOS.h
@@ -20,12 +20,34 @@
 
 #import "OIDAuthorizationUICoordinator.h"
 
+@class SFSafariViewController;
+
 NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief Allows library consumers to bootstrap an @c SFSafariViewController as they see fit.
+    @remarks Useful for customizing tint colors and presentation styles.
+ */
+@protocol OIDSafariViewControllerFactory
+
+/*! @brief Creates and returns a new @c SFSafariViewController.
+    @param URL The URL which the @c SFSafariViewController should load initially.
+ */
+- (SFSafariViewController *)safariViewControllerWithURL:(NSURL *)URL;
+
+@end
 
 /*! @brief An iOS specific authorization UI Coordinator that uses a \SFSafariViewController to
         present an authorization request.
  */
 @interface OIDAuthorizationUICoordinatorIOS : NSObject<OIDAuthorizationUICoordinator>
+
+/*! @brief Allows library consumers to change the @c OIDSafariViewControllerFactory used to create
+        new instances of @c SFSafariViewController.
+    @remarks Useful for customizing tint colors and presentation styles.
+    @param factory The @c OIDSafariViewControllerFactory to use for creating new instances of
+        @c SFSafariViewController.
+ */
++ (void)setSafariViewControllerFactory:(id<OIDSafariViewControllerFactory>)factory;
 
 /*! @internal
     @brief Unavailable. Please use @c initWithPresentingViewController:


### PR DESCRIPTION
Adds SFSafariViewController customization to the library by introducing a new protocol; OIDSafariViewControllerFactory - which allows the library consumer to take control of the SFSafariViewController creation, if they want.

Instructions:
- Create a class which implements the @c OIDSafariViewControllerFactory protocol.
- Implement the @c OIDSafariViewControllerFactory.safariViewControllerWithURL: method.
- Create a new instance of your @c OIDSafariViewControllerFactory at application startup (or at any time before an interactive authorization is attempted.)
- Call: [OIDAuthorizationUICoordinatorIOS setSafariViewControllerFactory:myFactory];

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/34)

<!-- Reviewable:end -->
