### PR TITLE
Access token and id token can be nil when OIDAuthStateAction is called.

### DIFF
--- a/Example-Mac/Source/AppAuthExampleViewController.m
+++ b/Example-Mac/Source/AppAuthExampleViewController.m
@@ -301,8 +301,8 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 
   [self logMessage:@"Performing userinfo request"];
 
-  [_authState withFreshTokensPerformAction:^(NSString *_Nonnull accessToken,
-                                             NSString *_Nonnull idToken,
+  [_authState withFreshTokensPerformAction:^(NSString *_Nullable accessToken,
+                                             NSString *_Nullable idToken,
                                              NSError *_Nullable error) {
     if (error) {
       [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];


### PR DESCRIPTION
Access token and id token can be nil when OIDAuthStateAction is called (when having an error). The definition of OIDAuthStateAction is correct, but the callback is wrongly defined in AppAuthExampleViewController.m.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/39)
<!-- Reviewable:end -->
