### PR TITLE
Loopback HTTP redirect support for macOS

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "AppAuth"
-  s.version      = "0.4.2"
+  s.version      = "0.5.0"
   s.summary      = "AppAuth for iOS and macOS is a client SDK for communicating with OAuth 2.0 and OpenID Connect providers."
 
   s.description  = <<-DESC
@@ -40,7 +40,12 @@ tasks like performing an action with fresh tokens.
   s.ios.framework         = "SafariServices"
 
   # macOS
-  s.osx.source_files      = "Source/macOS/**/*.{h,m}"
+  s.osx.source_files = "Source/macOS/*.{h,m}"
   s.osx.deployment_target = '10.8'
 
+  s.subspec 'no-arc' do |sp|
+    sp.source_files = ""
+    sp.osx.source_files = "Source/macOS/LoopbackHTTPServer/*.{h,m}"
+    sp.requires_arc = false
+  end
 end

--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -7,6 +7,31 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		340DAE571D5821A100EC285B /* OIDAuthorizationService+Mac.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAE261D581FE700EC285B /* OIDAuthorizationService+Mac.m */; };
+		340DAE581D5821A100EC285B /* OIDAuthorizationUICoordinatorMac.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAE281D581FE700EC285B /* OIDAuthorizationUICoordinatorMac.m */; };
+		340DAE591D5821A100EC285B /* OIDAuthState+Mac.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAE2A1D581FE700EC285B /* OIDAuthState+Mac.m */; };
+		340DAE5A1D5821AB00EC285B /* OIDAuthorizationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B51C5D8243000EF209 /* OIDAuthorizationRequest.m */; };
+		340DAE5B1D5821AB00EC285B /* OIDAuthorizationResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B71C5D8243000EF209 /* OIDAuthorizationResponse.m */; };
+		340DAE5C1D5821AB00EC285B /* OIDAuthorizationService.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B91C5D8243000EF209 /* OIDAuthorizationService.m */; };
+		340DAE5D1D5821AB00EC285B /* OIDAuthState.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741BB1C5D8243000EF209 /* OIDAuthState.m */; };
+		340DAE5E1D5821AB00EC285B /* OIDError.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741C01C5D8243000EF209 /* OIDError.m */; };
+		340DAE5F1D5821AB00EC285B /* OIDErrorUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741C21C5D8243000EF209 /* OIDErrorUtilities.m */; };
+		340DAE601D5821AB00EC285B /* OIDFieldMapping.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741C41C5D8243000EF209 /* OIDFieldMapping.m */; };
+		340DAE611D5821AB00EC285B /* OIDGrantTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741C61C5D8243000EF209 /* OIDGrantTypes.m */; };
+		340DAE621D5821AB00EC285B /* OIDResponseTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741C81C5D8243000EF209 /* OIDResponseTypes.m */; };
+		340DAE631D5821AB00EC285B /* OIDScopes.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741CA1C5D8243000EF209 /* OIDScopes.m */; };
+		340DAE641D5821AB00EC285B /* OIDScopeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741CC1C5D8243000EF209 /* OIDScopeUtilities.m */; };
+		340DAE651D5821AB00EC285B /* OIDServiceConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741CE1C5D8243000EF209 /* OIDServiceConfiguration.m */; };
+		340DAE661D5821AB00EC285B /* OIDServiceDiscovery.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741D01C5D8243000EF209 /* OIDServiceDiscovery.m */; };
+		340DAE671D5821AB00EC285B /* OIDTokenRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741D21C5D8243000EF209 /* OIDTokenRequest.m */; };
+		340DAE681D5821AB00EC285B /* OIDTokenResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741D41C5D8243000EF209 /* OIDTokenResponse.m */; };
+		340DAE691D5821AB00EC285B /* OIDTokenUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741D61C5D8243000EF209 /* OIDTokenUtilities.m */; };
+		340DAE6A1D5821AB00EC285B /* OIDURLQueryComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741D81C5D8243000EF209 /* OIDURLQueryComponent.m */; };
+		340DAE741D58223A00EC285B /* AppAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 341741AF1C5D8243000EF209 /* AppAuth.h */; };
+		340DAEBC1D582AF100EC285B /* OIDRedirectHTTPHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAEBA1D582AF100EC285B /* OIDRedirectHTTPHandler.m */; };
+		340DAECB1D582DE100EC285B /* OIDAuthorizationService+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */; };
+		340DAECC1D582DE100EC285B /* OIDAuthState+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB01D2BFEFE00325CB3 /* OIDAuthState+IOS.m */; };
+		340DAECD1D582DE100EC285B /* OIDAuthorizationUICoordinatorIOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB21D2BFEFE00325CB3 /* OIDAuthorizationUICoordinatorIOS.m */; };
 		341741DB1C5D8243000EF209 /* OIDAuthorizationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B51C5D8243000EF209 /* OIDAuthorizationRequest.m */; };
 		341741DC1C5D8243000EF209 /* OIDAuthorizationResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B71C5D8243000EF209 /* OIDAuthorizationResponse.m */; };
 		341741DD1C5D8243000EF209 /* OIDAuthorizationService.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B91C5D8243000EF209 /* OIDAuthorizationService.m */; };
@@ -40,9 +65,8 @@
 		341742241C5D8317000EF209 /* UnitTestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 341742231C5D8317000EF209 /* UnitTestsInfo.plist */; };
 		3417422B1C5D8502000EF209 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417422A1C5D8502000EF209 /* SafariServices.framework */; };
 		3417422D1C5D850C000EF209 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417422C1C5D850C000EF209 /* Security.framework */; };
-		F6F60FB61D2BFEFE00325CB3 /* OIDAuthState+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB01D2BFEFE00325CB3 /* OIDAuthState+IOS.m */; };
-		F6F60FB71D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */; };
-		F6F60FB81D2BFEFE00325CB3 /* OIDAuthorizationUICoordinatorIOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB21D2BFEFE00325CB3 /* OIDAuthorizationUICoordinatorIOS.m */; };
+		34FEA6AE1DB6E083005C9212 /* OIDLoopbackHTTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 34FEA6AC1DB6E083005C9212 /* OIDLoopbackHTTPServer.h */; };
+		34FEA6AF1DB6E083005C9212 /* OIDLoopbackHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +92,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		340DAE251D581FE700EC285B /* OIDAuthorizationService+Mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OIDAuthorizationService+Mac.h"; sourceTree = "<group>"; };
+		340DAE261D581FE700EC285B /* OIDAuthorizationService+Mac.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OIDAuthorizationService+Mac.m"; sourceTree = "<group>"; };
+		340DAE271D581FE700EC285B /* OIDAuthorizationUICoordinatorMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDAuthorizationUICoordinatorMac.h; sourceTree = "<group>"; };
+		340DAE281D581FE700EC285B /* OIDAuthorizationUICoordinatorMac.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDAuthorizationUICoordinatorMac.m; sourceTree = "<group>"; };
+		340DAE291D581FE700EC285B /* OIDAuthState+Mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OIDAuthState+Mac.h"; sourceTree = "<group>"; };
+		340DAE2A1D581FE700EC285B /* OIDAuthState+Mac.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OIDAuthState+Mac.m"; sourceTree = "<group>"; };
+		340DAE4E1D58216A00EC285B /* libAppAuth-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libAppAuth-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		340DAEB91D582AF100EC285B /* OIDRedirectHTTPHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDRedirectHTTPHandler.h; sourceTree = "<group>"; };
+		340DAEBA1D582AF100EC285B /* OIDRedirectHTTPHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDRedirectHTTPHandler.m; sourceTree = "<group>"; };
 		340E737C1C5D819B0076B1F6 /* libAppAuth.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAppAuth.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		341741AF1C5D8243000EF209 /* AppAuth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppAuth.h; sourceTree = "<group>"; };
 		341741B41C5D8243000EF209 /* OIDAuthorizationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDAuthorizationRequest.h; sourceTree = "<group>"; };
@@ -131,6 +164,8 @@
 		341742231C5D8317000EF209 /* UnitTestsInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = UnitTestsInfo.plist; sourceTree = "<group>"; };
 		3417422A1C5D8502000EF209 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		3417422C1C5D850C000EF209 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		34FEA6AC1DB6E083005C9212 /* OIDLoopbackHTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDLoopbackHTTPServer.h; sourceTree = "<group>"; };
+		34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDLoopbackHTTPServer.m; sourceTree = "<group>"; };
 		F68103B61D2568D10053658E /* OIDAuthorizationUICoordinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDAuthorizationUICoordinator.h; sourceTree = "<group>"; };
 		F6F60FB01D2BFEFE00325CB3 /* OIDAuthState+IOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthState+IOS.m"; path = "iOS/OIDAuthState+IOS.m"; sourceTree = "<group>"; };
 		F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthorizationService+IOS.m"; path = "iOS/OIDAuthorizationService+IOS.m"; sourceTree = "<group>"; };
@@ -141,6 +176,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		340DAE4B1D58216A00EC285B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		340E73791C5D819B0076B1F6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -161,6 +203,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		340DAE241D581FE700EC285B /* macOS */ = {
+			isa = PBXGroup;
+			children = (
+				34FEA6AB1DB6E083005C9212 /* LoopbackHTTPServer */,
+				340DAEB91D582AF100EC285B /* OIDRedirectHTTPHandler.h */,
+				340DAEBA1D582AF100EC285B /* OIDRedirectHTTPHandler.m */,
+				340DAE251D581FE700EC285B /* OIDAuthorizationService+Mac.h */,
+				340DAE261D581FE700EC285B /* OIDAuthorizationService+Mac.m */,
+				340DAE271D581FE700EC285B /* OIDAuthorizationUICoordinatorMac.h */,
+				340DAE281D581FE700EC285B /* OIDAuthorizationUICoordinatorMac.m */,
+				340DAE291D581FE700EC285B /* OIDAuthState+Mac.h */,
+				340DAE2A1D581FE700EC285B /* OIDAuthState+Mac.m */,
+			);
+			path = macOS;
+			sourceTree = "<group>";
+		};
 		340E73731C5D819B0076B1F6 = {
 			isa = PBXGroup;
 			children = (
@@ -176,6 +234,7 @@
 			children = (
 				340E737C1C5D819B0076B1F6 /* libAppAuth.a */,
 				341741F01C5D8283000EF209 /* AppAuthTests.xctest */,
+				340DAE4E1D58216A00EC285B /* libAppAuth-macOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -183,6 +242,7 @@
 		341741AE1C5D8243000EF209 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				340DAE241D581FE700EC285B /* macOS */,
 				F6F60FAF1D2BFEF000325CB3 /* iOS */,
 				341741AF1C5D8243000EF209 /* AppAuth.h */,
 				341741B41C5D8243000EF209 /* OIDAuthorizationRequest.h */,
@@ -264,6 +324,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		34FEA6AB1DB6E083005C9212 /* LoopbackHTTPServer */ = {
+			isa = PBXGroup;
+			children = (
+				34FEA6AC1DB6E083005C9212 /* OIDLoopbackHTTPServer.h */,
+				34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */,
+			);
+			path = LoopbackHTTPServer;
+			sourceTree = "<group>";
+		};
 		F6F60FAF1D2BFEF000325CB3 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -279,7 +348,36 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		340DAE4C1D58216A00EC285B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				340DAE741D58223A00EC285B /* AppAuth.h in Headers */,
+				34FEA6AE1DB6E083005C9212 /* OIDLoopbackHTTPServer.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		340DAE4D1D58216A00EC285B /* AppAuth-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 340DAE541D58216A00EC285B /* Build configuration list for PBXNativeTarget "AppAuth-macOS" */;
+			buildPhases = (
+				340DAE4A1D58216A00EC285B /* Sources */,
+				340DAE4B1D58216A00EC285B /* Frameworks */,
+				340DAE4C1D58216A00EC285B /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "AppAuth-macOS";
+			productName = "AppAuth-macOS";
+			productReference = 340DAE4E1D58216A00EC285B /* libAppAuth-macOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		340E737B1C5D819B0076B1F6 /* AppAuth */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 340E73851C5D819B0076B1F6 /* Build configuration list for PBXNativeTarget "AppAuth" */;
@@ -324,6 +422,9 @@
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Google Inc";
 				TargetAttributes = {
+					340DAE4D1D58216A00EC285B = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 					340E737B1C5D819B0076B1F6 = {
 						CreatedOnToolsVersion = 7.2;
 					};
@@ -346,6 +447,7 @@
 			targets = (
 				340E737B1C5D819B0076B1F6 /* AppAuth */,
 				341741EF1C5D8283000EF209 /* AppAuthTests */,
+				340DAE4D1D58216A00EC285B /* AppAuth-macOS */,
 			);
 		};
 /* End PBXProject section */
@@ -362,6 +464,35 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		340DAE4A1D58216A00EC285B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34FEA6AF1DB6E083005C9212 /* OIDLoopbackHTTPServer.m in Sources */,
+				340DAEBC1D582AF100EC285B /* OIDRedirectHTTPHandler.m in Sources */,
+				340DAE631D5821AB00EC285B /* OIDScopes.m in Sources */,
+				340DAE5D1D5821AB00EC285B /* OIDAuthState.m in Sources */,
+				340DAE5B1D5821AB00EC285B /* OIDAuthorizationResponse.m in Sources */,
+				340DAE571D5821A100EC285B /* OIDAuthorizationService+Mac.m in Sources */,
+				340DAE5E1D5821AB00EC285B /* OIDError.m in Sources */,
+				340DAE661D5821AB00EC285B /* OIDServiceDiscovery.m in Sources */,
+				340DAE5C1D5821AB00EC285B /* OIDAuthorizationService.m in Sources */,
+				340DAE641D5821AB00EC285B /* OIDScopeUtilities.m in Sources */,
+				340DAE581D5821A100EC285B /* OIDAuthorizationUICoordinatorMac.m in Sources */,
+				340DAE5A1D5821AB00EC285B /* OIDAuthorizationRequest.m in Sources */,
+				340DAE671D5821AB00EC285B /* OIDTokenRequest.m in Sources */,
+				340DAE681D5821AB00EC285B /* OIDTokenResponse.m in Sources */,
+				340DAE651D5821AB00EC285B /* OIDServiceConfiguration.m in Sources */,
+				340DAE591D5821A100EC285B /* OIDAuthState+Mac.m in Sources */,
+				340DAE691D5821AB00EC285B /* OIDTokenUtilities.m in Sources */,
+				340DAE601D5821AB00EC285B /* OIDFieldMapping.m in Sources */,
+				340DAE621D5821AB00EC285B /* OIDResponseTypes.m in Sources */,
+				340DAE6A1D5821AB00EC285B /* OIDURLQueryComponent.m in Sources */,
+				340DAE5F1D5821AB00EC285B /* OIDErrorUtilities.m in Sources */,
+				340DAE611D5821AB00EC285B /* OIDGrantTypes.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		340E73781C5D819B0076B1F6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -369,20 +500,20 @@
 				341741E01C5D8243000EF209 /* OIDErrorUtilities.m in Sources */,
 				341741EA1C5D8243000EF209 /* OIDTokenUtilities.m in Sources */,
 				341741E21C5D8243000EF209 /* OIDGrantTypes.m in Sources */,
-				F6F60FB71D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m in Sources */,
 				341741E81C5D8243000EF209 /* OIDTokenRequest.m in Sources */,
+				340DAECC1D582DE100EC285B /* OIDAuthState+IOS.m in Sources */,
 				341741E91C5D8243000EF209 /* OIDTokenResponse.m in Sources */,
 				341741E51C5D8243000EF209 /* OIDScopeUtilities.m in Sources */,
 				341741DC1C5D8243000EF209 /* OIDAuthorizationResponse.m in Sources */,
 				341741E61C5D8243000EF209 /* OIDServiceConfiguration.m in Sources */,
 				341741DE1C5D8243000EF209 /* OIDAuthState.m in Sources */,
 				341741DD1C5D8243000EF209 /* OIDAuthorizationService.m in Sources */,
-				F6F60FB81D2BFEFE00325CB3 /* OIDAuthorizationUICoordinatorIOS.m in Sources */,
-				F6F60FB61D2BFEFE00325CB3 /* OIDAuthState+IOS.m in Sources */,
+				340DAECD1D582DE100EC285B /* OIDAuthorizationUICoordinatorIOS.m in Sources */,
 				341741EB1C5D8243000EF209 /* OIDURLQueryComponent.m in Sources */,
 				341741E11C5D8243000EF209 /* OIDFieldMapping.m in Sources */,
 				341741DF1C5D8243000EF209 /* OIDError.m in Sources */,
 				341741DB1C5D8243000EF209 /* OIDAuthorizationRequest.m in Sources */,
+				340DAECB1D582DE100EC285B /* OIDAuthorizationService+IOS.m in Sources */,
 				341741E31C5D8243000EF209 /* OIDResponseTypes.m in Sources */,
 				341741E41C5D8243000EF209 /* OIDScopes.m in Sources */,
 				341741E71C5D8243000EF209 /* OIDServiceDiscovery.m in Sources */,
@@ -419,6 +550,30 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		340DAE551D58216A00EC285B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CODE_SIGN_IDENTITY = "-";
+				EXECUTABLE_PREFIX = lib;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		340DAE561D58216A00EC285B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CODE_SIGN_IDENTITY = "-";
+				EXECUTABLE_PREFIX = lib;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		340E73831C5D819B0076B1F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -542,6 +697,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		340DAE541D58216A00EC285B /* Build configuration list for PBXNativeTarget "AppAuth-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				340DAE551D58216A00EC285B /* Debug */,
+				340DAE561D58216A00EC285B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		340E73771C5D819B0076B1F6 /* Build configuration list for PBXProject "AppAuth" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Example-Mac/Example-Mac.xcodeproj/project.pbxproj
+++ b/Example-Mac/Example-Mac.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		622D29EC65BD3F0E38822AF1 /* libPods-Example-Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 653C5E3C17C4D280AA39A08B /* libPods-Example-Mac.a */; };
+		EFEF6E9CC6F12EA4870987D5 /* libPods-Example-Mac.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FED92DEDC2639A35907A5D4D /* libPods-Example-Mac.a */; };
 		F6016E951D2BD988003497D7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F6016E8B1D2BD988003497D7 /* AppDelegate.m */; };
 		F6016E971D2BD988003497D7 /* AppAuthExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F6016E8D1D2BD988003497D7 /* AppAuthExampleViewController.m */; };
 		F6016E981D2BD988003497D7 /* AppAuthExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F6016E8F1D2BD988003497D7 /* AppAuthExampleViewController.xib */; };
@@ -17,9 +17,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		653C5E3C17C4D280AA39A08B /* libPods-Example-Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example-Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A707A6A09FEE94A105421FD6 /* Pods-Example-Mac.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Mac.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example-Mac/Pods-Example-Mac.release.xcconfig"; sourceTree = "<group>"; };
-		C16FBAA1467EEE61F09B9C78 /* Pods-Example-Mac.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Mac.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example-Mac/Pods-Example-Mac.debug.xcconfig"; sourceTree = "<group>"; };
+		60553B3AB5BA3E1BB259E487 /* Pods-Example-Mac.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Mac.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example-Mac/Pods-Example-Mac.release.xcconfig"; sourceTree = "<group>"; };
+		7FF583C8F7036437BE8875B3 /* Pods-Example-Mac.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-Mac.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example-Mac/Pods-Example-Mac.debug.xcconfig"; sourceTree = "<group>"; };
 		F6016E701D2AC11F003497D7 /* Example-Mac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-Mac.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6016E8B1D2BD988003497D7 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Source/AppDelegate.m; sourceTree = "<group>"; };
 		F6016E8D1D2BD988003497D7 /* AppAuthExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppAuthExampleViewController.m; path = Source/AppAuthExampleViewController.m; sourceTree = "<group>"; };
@@ -30,6 +29,7 @@
 		F6016E941D2BD988003497D7 /* AppAuthExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppAuthExampleViewController.h; path = Source/AppAuthExampleViewController.h; sourceTree = "<group>"; };
 		F6016E9B1D2BD9C0003497D7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Source/Assets.xcassets; sourceTree = "<group>"; };
 		F6016E9D1D2BD9C7003497D7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = "<group>"; };
+		FED92DEDC2639A35907A5D4D /* libPods-Example-Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example-Mac.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,28 +37,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				622D29EC65BD3F0E38822AF1 /* libPods-Example-Mac.a in Frameworks */,
+				EFEF6E9CC6F12EA4870987D5 /* libPods-Example-Mac.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		405789D7DCF3C985E2E5D070 /* Frameworks */ = {
+		186006823FF563B11A81B036 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				653C5E3C17C4D280AA39A08B /* libPods-Example-Mac.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		8ADFA8B34C1A7009C6F624AF /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				C16FBAA1467EEE61F09B9C78 /* Pods-Example-Mac.debug.xcconfig */,
-				A707A6A09FEE94A105421FD6 /* Pods-Example-Mac.release.xcconfig */,
+				7FF583C8F7036437BE8875B3 /* Pods-Example-Mac.debug.xcconfig */,
+				60553B3AB5BA3E1BB259E487 /* Pods-Example-Mac.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		27454E5D219A9EBB94F74197 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FED92DEDC2639A35907A5D4D /* libPods-Example-Mac.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		F6016E671D2AC11E003497D7 = {
@@ -66,8 +66,8 @@
 			children = (
 				F6016E8A1D2BD973003497D7 /* Source */,
 				F6016E711D2AC11F003497D7 /* Products */,
-				8ADFA8B34C1A7009C6F624AF /* Pods */,
-				405789D7DCF3C985E2E5D070 /* Frameworks */,
+				186006823FF563B11A81B036 /* Pods */,
+				27454E5D219A9EBB94F74197 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -327,7 +327,7 @@
 		};
 		F6016E821D2AC11F003497D7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C16FBAA1467EEE61F09B9C78 /* Pods-Example-Mac.debug.xcconfig */;
+			baseConfigurationReference = 7FF583C8F7036437BE8875B3 /* Pods-Example-Mac.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -340,7 +340,7 @@
 		};
 		F6016E831D2AC11F003497D7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A707A6A09FEE94A105421FD6 /* Pods-Example-Mac.release.xcconfig */;
+			baseConfigurationReference = 60553B3AB5BA3E1BB259E487 /* Pods-Example-Mac.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/Example-Mac/Source/AppAuthExampleViewController.h
+++ b/Example-Mac/Source/AppAuthExampleViewController.h
@@ -23,62 +23,61 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*! @class AppAuthExampleViewController
-    @brief The example application's view controller.
+/*! @brief The example application's view controller.
  */
 @interface AppAuthExampleViewController : NSViewController
 
 @property(nullable) IBOutlet NSButton *authAutoButton;
 @property(nullable) IBOutlet NSButton *authManual;
+@property(nullable) IBOutlet NSButton *authAutoHTTPButton;
 @property(nullable) IBOutlet NSButton *codeExchangeButton;
 @property(nullable) IBOutlet NSButton *userinfoButton;
 @property(nullable) IBOutlet NSButton *clearAuthStateButton;
 @property(nullable) IBOutlet NSTextView *logTextView;
 
-/*! @property appDelegate
-    @brief The application delegate. This is used to store the current authorization flow.
+/*! @brief The application delegate. This is used to store the current authorization flow.
  */
 @property (nonatomic, weak, nullable) AppDelegate *appDelegate;
 
-/*! @property authState
-    @brief The authorization state. This is the AppAuth object that you should keep around and
+/*! @brief The authorization state. This is the AppAuth object that you should keep around and
         serialize to disk.
  */
 @property(nonatomic, readonly, nullable) OIDAuthState *authState;
 
-/*! @fn authWithAutoCodeExchange:
-    @brief Authorization code flow using @c OIDAuthState automatic code exchanges.
+/*! @brief Authorization code flow using @c OIDAuthState automatic code exchanges and a custom URI
+        scheme-based redirect.
     @param sender IBAction sender.
  */
 - (IBAction)authWithAutoCodeExchange:(nullable id)sender;
 
-/*! @fn authNoCodeExchange:
-    @brief Authorization code flow without a the code exchange (need to call @c codeExchange:
-        manually)
+/*! @brief Authorization code flow using a manual code exchanges and a custom URI scheme-based
+        redirect.
     @param sender IBAction sender.
  */
 - (IBAction)authNoCodeExchange:(nullable id)sender;
 
-/*! @fn codeExchange:
-    @brief Performs the authorization code exchange at the token endpoint.
+/*! @brief Authorization code flow using @c OIDAuthState automatic code exchanges and a
+        loopback HTTP-based redirect.
+    @param sender IBAction sender.
+ */
+- (IBAction)authWithAutoCodeExchangeHTTP:(nullable id)sender;
+
+/*! @brief Performs the authorization code exchange at the token endpoint.
     @param sender IBAction sender.
  */
 - (IBAction)codeExchange:(nullable id)sender;
 
-/*! @fn userinfo:
-    @brief Performs a Userinfo API call using @c OIDAuthState.withFreshTokensPerformAction.
+/*! @brief Performs a Userinfo API call using @c OIDAuthState.withFreshTokensPerformAction.
     @param sender IBAction sender.
  */
 - (IBAction)userinfo:(nullable id)sender;
 
-/*! @fn clearAuthState:
-    @brief Nils the @c OIDAuthState object.
+/*! @brief Nils the @c OIDAuthState object.
     @param sender IBAction sender.
  */
 - (IBAction)clearAuthState:(nullable id)sender;
 
-/*! @fn clearLog:
-    @brief Clears the UI log.
+/*! @brief Clears the UI log.
     @param sender IBAction sender.
  */
 - (IBAction)clearLog:(nullable id)sender;

--- a/Example-Mac/Source/Base.lproj/AppAuthExampleViewController.xib
+++ b/Example-Mac/Source/Base.lproj/AppAuthExampleViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
@@ -8,6 +8,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="AppAuthExampleViewController">
             <connections>
                 <outlet property="authAutoButton" destination="Mss-oI-oMy" id="3xw-3K-wRM"/>
+                <outlet property="authAutoHTTPButton" destination="uw4-1m-FoE" id="Jb5-wJ-ZGq"/>
                 <outlet property="authManual" destination="0s2-0W-UXR" id="bu7-op-tbr"/>
                 <outlet property="clearAuthStateButton" destination="wAL-hz-Luv" id="Dcn-9Q-qol"/>
                 <outlet property="codeExchangeButton" destination="4d1-F1-5Lx" id="Hnf-fa-P50"/>
@@ -22,9 +23,9 @@
             <rect key="frame" x="0.0" y="0.0" width="611" height="709"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mss-oI-oMy">
-                    <rect key="frame" x="65" y="629" width="138" height="32"/>
-                    <buttonCell key="cell" type="push" title="Authorize (auto)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="z0a-BU-rAC">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mss-oI-oMy">
+                    <rect key="frame" x="65" y="628" width="299" height="32"/>
+                    <buttonCell key="cell" type="push" title="Authorize (Custom Scheme Redirect, auto)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="z0a-BU-rAC">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -32,9 +33,9 @@
                         <action selector="authWithAutoCodeExchange:" target="-2" id="Ddj-4s-QIq"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0s2-0W-UXR">
-                    <rect key="frame" x="65" y="570" width="155" height="32"/>
-                    <buttonCell key="cell" type="push" title="Authorize (manual)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ASn-KU-cBH">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0s2-0W-UXR">
+                    <rect key="frame" x="65" y="595" width="316" height="32"/>
+                    <buttonCell key="cell" type="push" title="Authorize (Custom Scheme Redirect, manual)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ASn-KU-cBH">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -42,8 +43,8 @@
                         <action selector="authNoCodeExchange:" target="-2" id="ds6-mx-0Zw"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f22-Zx-cOh">
-                    <rect key="frame" x="65" y="492" width="155" height="32"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f22-Zx-cOh">
+                    <rect key="frame" x="65" y="493" width="155" height="32"/>
                     <buttonCell key="cell" type="push" title="API Call (User Info)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ogN-86-TEl">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -52,7 +53,7 @@
                         <action selector="userinfo:" target="-2" id="bXX-9M-VMS"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wAL-hz-Luv">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wAL-hz-Luv">
                     <rect key="frame" x="65" y="400" width="139" height="32"/>
                     <buttonCell key="cell" type="push" title="Clear Auth State" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="M4e-Oa-Bsh">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -63,7 +64,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4d1-F1-5Lx">
-                    <rect key="frame" x="273" y="570" width="134" height="32"/>
+                    <rect key="frame" x="386" y="595" width="134" height="32"/>
                     <buttonCell key="cell" type="push" title="Code exchange" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="g4C-L6-Rfr">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -80,20 +81,20 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView misplaced="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I8b-cL-GM8">
+                <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I8b-cL-GM8">
                     <rect key="frame" x="75" y="20" width="461" height="308"/>
                     <clipView key="contentView" id="WlW-fb-gTh">
-                        <rect key="frame" x="1" y="1" width="444" height="306"/>
+                        <rect key="frame" x="1" y="1" width="459" height="306"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" spellingCorrection="YES" smartInsertDelete="YES" id="9uf-dN-qIX">
-                                <rect key="frame" x="0.0" y="0.0" width="444" height="306"/>
+                                <rect key="frame" x="0.0" y="0.0" width="459" height="306"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <size key="minSize" width="444" height="306"/>
+                                <size key="minSize" width="459" height="306"/>
                                 <size key="maxSize" width="463" height="10000000"/>
                                 <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="444" height="306"/>
+                                <size key="minSize" width="459" height="306"/>
                                 <size key="maxSize" width="463" height="10000000"/>
                             </textView>
                         </subviews>
@@ -104,11 +105,11 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="D03-0I-zIY">
-                        <rect key="frame" x="445" y="1" width="15" height="306"/>
+                        <rect key="frame" x="444" y="1" width="16" height="306"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xey-KN-kpQ">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xey-KN-kpQ">
                     <rect key="frame" x="448" y="346" width="94" height="32"/>
                     <buttonCell key="cell" type="push" title="Clear log" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Bwe-Pg-NVC">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -118,25 +119,37 @@
                         <action selector="clearLog:" target="-2" id="NpO-8Y-WwK"/>
                     </connections>
                 </button>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uw4-1m-FoE">
+                    <rect key="frame" x="65" y="562" width="234" height="32"/>
+                    <buttonCell key="cell" type="push" title="Authorize (HTTP Redirect, auto)" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iH6-RU-00n">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="authWithAutoCodeExchangeHTTP:" target="-2" id="atO-3z-7SP"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
+                <constraint firstItem="uw4-1m-FoE" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="0I1-jl-Duy"/>
                 <constraint firstAttribute="bottom" secondItem="I8b-cL-GM8" secondAttribute="bottom" constant="20" id="28L-v0-sSu"/>
-                <constraint firstItem="wAL-hz-Luv" firstAttribute="top" secondItem="f22-Zx-cOh" secondAttribute="bottom" constant="69" id="6XW-jh-tqH"/>
+                <constraint firstItem="wAL-hz-Luv" firstAttribute="top" secondItem="f22-Zx-cOh" secondAttribute="bottom" constant="72" id="6XW-jh-tqH"/>
                 <constraint firstItem="wAL-hz-Luv" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="7M7-SU-yES"/>
-                <constraint firstItem="f22-Zx-cOh" firstAttribute="top" secondItem="0s2-0W-UXR" secondAttribute="bottom" constant="58" id="Au0-Sb-oqi"/>
-                <constraint firstItem="4d1-F1-5Lx" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="111" id="LIY-ZL-a6d"/>
-                <constraint firstItem="Xey-KN-kpQ" firstAttribute="top" secondItem="4d1-F1-5Lx" secondAttribute="bottom" constant="203" id="PfO-rf-bBk"/>
-                <constraint firstItem="Xey-KN-kpQ" firstAttribute="leading" secondItem="9CP-mT-oaL" secondAttribute="trailing" constant="289" id="S37-sV-Lva"/>
-                <constraint firstItem="0s2-0W-UXR" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="63" id="TDT-Pg-mg4"/>
-                <constraint firstItem="4d1-F1-5Lx" firstAttribute="leading" secondItem="0s2-0W-UXR" secondAttribute="trailing" constant="73" id="Tuj-e4-iia"/>
+                <constraint firstItem="4d1-F1-5Lx" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="86" id="LIY-ZL-a6d"/>
+                <constraint firstItem="Xey-KN-kpQ" firstAttribute="top" secondItem="4d1-F1-5Lx" secondAttribute="bottom" constant="228" id="PfO-rf-bBk"/>
+                <constraint firstItem="Xey-KN-kpQ" firstAttribute="leading" secondItem="9CP-mT-oaL" secondAttribute="trailing" constant="360" id="S37-sV-Lva"/>
+                <constraint firstItem="0s2-0W-UXR" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="TDT-Pg-mg4"/>
+                <constraint firstItem="4d1-F1-5Lx" firstAttribute="leading" secondItem="0s2-0W-UXR" secondAttribute="trailing" constant="17" id="Tuj-e4-iia"/>
                 <constraint firstItem="I8b-cL-GM8" firstAttribute="top" secondItem="Xey-KN-kpQ" secondAttribute="bottom" constant="25" id="WnG-fm-Ika"/>
-                <constraint firstItem="9CP-mT-oaL" firstAttribute="top" secondItem="wAL-hz-Luv" secondAttribute="bottom" constant="36" id="au8-Ni-D9e"/>
-                <constraint firstItem="f22-Zx-cOh" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="63" id="dyv-lc-KGU"/>
-                <constraint firstItem="Mss-oI-oMy" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="67" id="f4v-YZ-GoJ"/>
-                <constraint firstAttribute="trailing" secondItem="I8b-cL-GM8" secondAttribute="trailing" constant="94" id="gTh-t8-oaw"/>
-                <constraint firstItem="Mss-oI-oMy" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="52" id="loQ-8U-FyH"/>
-                <constraint firstItem="0s2-0W-UXR" firstAttribute="top" secondItem="Mss-oI-oMy" secondAttribute="bottom" constant="38" id="oNP-7c-hl5"/>
-                <constraint firstItem="I8b-cL-GM8" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="tez-VW-e72"/>
+                <constraint firstItem="9CP-mT-oaL" firstAttribute="top" secondItem="wAL-hz-Luv" secondAttribute="bottom" constant="35" id="au8-Ni-D9e"/>
+                <constraint firstItem="f22-Zx-cOh" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="dyv-lc-KGU"/>
+                <constraint firstItem="Mss-oI-oMy" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="f4v-YZ-GoJ"/>
+                <constraint firstAttribute="trailing" secondItem="I8b-cL-GM8" secondAttribute="trailing" constant="75" id="gTh-t8-oaw"/>
+                <constraint firstItem="f22-Zx-cOh" firstAttribute="top" secondItem="uw4-1m-FoE" secondAttribute="bottom" constant="48" id="kdn-QA-BgX"/>
+                <constraint firstItem="Mss-oI-oMy" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="53" id="loQ-8U-FyH"/>
+                <constraint firstItem="uw4-1m-FoE" firstAttribute="top" secondItem="0s2-0W-UXR" secondAttribute="bottom" constant="12" id="mQT-Z1-YCJ"/>
+                <constraint firstItem="0s2-0W-UXR" firstAttribute="top" secondItem="Mss-oI-oMy" secondAttribute="bottom" constant="12" id="oNP-7c-hl5"/>
+                <constraint firstItem="I8b-cL-GM8" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="75" id="tez-VW-e72"/>
                 <constraint firstItem="9CP-mT-oaL" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="71" id="vdy-tP-Bdf"/>
             </constraints>
             <point key="canvasLocation" x="756.5" y="670.5"/>

--- a/Source/AppAuth.h
+++ b/Source/AppAuth.h
@@ -40,6 +40,7 @@
 #elif TARGET_OS_MAC
 #import "OIDAuthState+Mac.h"
 #import "OIDAuthorizationService+Mac.h"
+#import "OIDRedirectHTTPHandler.h"
 #else
 #error "Platform Undefined"
 #endif

--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
@@ -63,15 +63,20 @@ typedef enum {
 - (BOOL)start:(NSError **)error;
 - (BOOL)stop;
 
-- (void)handleNewConnectionFromAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr;
 // called when a new connection comes in; by default, informs the delegate
+- (void)handleNewConnectionFromAddress:(NSData *)addr
+                           inputStream:(NSInputStream *)istr
+                          outputStream:(NSOutputStream *)ostr;
 
 @end
 
 @interface TCPServer (TCPServerDelegateMethods)
-- (void)TCPServer:(TCPServer *)server didReceiveConnectionFromAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr;
-// if the delegate implements this method, it is called when a new
+// if the delegate implements this method, it is called when a new 
 // connection comes in; a subclass may, of course, change that behavior
+- (void)TCPServer:(TCPServer *)server
+    didReceiveConnectionFromAddress:(NSData *)addr
+                        inputStream:(NSInputStream *)istr
+                       outputStream:(NSOutputStream *)ostr;
 @end
 
 @interface HTTPServer : TCPServer {
@@ -81,9 +86,9 @@ typedef enum {
 }
 
 - (Class)connectionClass;
-- (void)setConnectionClass:(Class)value;
-// used to configure the subclass of HTTPConnection to create when
+// used to configure the subclass of HTTPConnection to create when 
 // a new connection comes in; by default, this is HTTPConnection
+- (void)setConnectionClass:(Class)value;
 
 - (NSURL *)documentRoot;
 - (void)setDocumentRoot:(NSURL *)value;
@@ -91,11 +96,11 @@ typedef enum {
 @end
 
 @interface HTTPServer (HTTPServerDelegateMethods)
-- (void)HTTPServer:(HTTPServer *)serv didMakeNewConnection:(HTTPConnection *)conn;
-// If the delegate implements this method, this is called
+// If the delegate implements this method, this is called 
 // by an HTTPServer when a new connection comes in.  If the
 // delegate wishes to refuse the connection, then it should
 // invalidate the connection object from within this method.
+- (void)HTTPServer:(HTTPServer *)serv didMakeNewConnection:(HTTPConnection *)conn;
 @end
 
 
@@ -114,7 +119,10 @@ typedef enum {
     BOOL firstResponseDone;
 }
 
-- (id)initWithPeerAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr forServer:(HTTPServer *)serv;
+- (id)initWithPeerAddress:(NSData *)addr
+              inputStream:(NSInputStream *)istr
+             outputStream:(NSOutputStream *)ostr
+                forServer:(HTTPServer *)serv;
 
 - (id)delegate;
 - (void)setDelegate:(id)value;
@@ -123,24 +131,23 @@ typedef enum {
 
 - (HTTPServer *)server;
 
-- (HTTPServerRequest *)nextRequest;
 // get the next request that needs to be responded to
+- (HTTPServerRequest *)nextRequest;
 
 - (BOOL)isValid;
-- (void)invalidate;
 // shut down the connection
+- (void)invalidate;
 
-- (void)performDefaultRequestHandling:(HTTPServerRequest *)sreq;
 // perform the default handling action: GET and HEAD requests for files
 // in the local file system (relative to the documentRoot of the server)
+- (void)performDefaultRequestHandling:(HTTPServerRequest *)sreq;
 
 @end
 
 @interface HTTPConnection (HTTPConnectionDelegateMethods)
+// The "didReceiveRequest:" tells the delegate when a new request comes in.
 - (void)HTTPConnection:(HTTPConnection *)conn didReceiveRequest:(HTTPServerRequest *)mess;
 - (void)HTTPConnection:(HTTPConnection *)conn didSendResponse:(HTTPServerRequest *)mess;
-// The "didReceiveRequest:" is the most interesting --
-// tells the delegate when a new request comes in.
 @end
 
 
@@ -162,17 +169,17 @@ typedef enum {
 
 - (CFHTTPMessageRef)request;
 
-- (CFHTTPMessageRef)response;
-- (void)setResponse:(CFHTTPMessageRef)value;
 // The response may include a body.  As soon as the response is set,
 // the response may be written out to the network.
+- (CFHTTPMessageRef)response;
+- (void)setResponse:(CFHTTPMessageRef)value;
 
 - (NSInputStream *)responseBodyStream;
-- (void)setResponseBodyStream:(NSInputStream *)value;
 // If there is to be a response body stream (when, say, a big
 // file is to be returned, rather than reading the whole thing
 // into memory), then it must be set on the request BEFORE the
 // response [headers] itself.
+- (void)setResponseBodyStream:(NSInputStream *)value;
 
 @end
 

--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
@@ -1,0 +1,179 @@
+/*! @file OIDLoopbackHTTPServer.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth Authors.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+// Based on the MiniSOAP Sample
+// https://developer.apple.com/library/mac/samplecode/MiniSOAP/Introduction/Intro.html
+// Modified to limit connections to the loopback interface only.
+
+#import <Foundation/Foundation.h>
+#import <CoreServices/CoreServices.h>
+
+@class HTTPConnection, HTTPServerRequest;
+
+extern NSString * const TCPServerErrorDomain;
+
+typedef enum {
+    kTCPServerCouldNotBindToIPv4Address = 1,
+    kTCPServerCouldNotBindToIPv6Address = 2,
+    kTCPServerNoSocketsAvailable = 3,
+} TCPServerErrorCode;
+
+@interface TCPServer : NSObject {
+@private
+    id delegate;
+    NSString *domain;
+    NSString *name;
+    NSString *type;
+    uint16_t port;
+    CFSocketRef ipv4socket;
+    CFSocketRef ipv6socket;
+    NSNetService *netService;
+}
+
+- (id)delegate;
+- (void)setDelegate:(id)value;
+
+- (NSString *)domain;
+- (void)setDomain:(NSString *)value;
+
+- (NSString *)name;
+- (void)setName:(NSString *)value;
+
+- (NSString *)type;
+- (void)setType:(NSString *)value;
+
+- (uint16_t)port;
+- (void)setPort:(uint16_t)value;
+
+- (BOOL)start:(NSError **)error;
+- (BOOL)stop;
+
+- (void)handleNewConnectionFromAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr;
+// called when a new connection comes in; by default, informs the delegate
+
+@end
+
+@interface TCPServer (TCPServerDelegateMethods)
+- (void)TCPServer:(TCPServer *)server didReceiveConnectionFromAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr;
+// if the delegate implements this method, it is called when a new
+// connection comes in; a subclass may, of course, change that behavior
+@end
+
+@interface HTTPServer : TCPServer {
+@private
+    Class connClass;
+    NSURL *docRoot;
+}
+
+- (Class)connectionClass;
+- (void)setConnectionClass:(Class)value;
+// used to configure the subclass of HTTPConnection to create when
+// a new connection comes in; by default, this is HTTPConnection
+
+- (NSURL *)documentRoot;
+- (void)setDocumentRoot:(NSURL *)value;
+
+@end
+
+@interface HTTPServer (HTTPServerDelegateMethods)
+- (void)HTTPServer:(HTTPServer *)serv didMakeNewConnection:(HTTPConnection *)conn;
+// If the delegate implements this method, this is called
+// by an HTTPServer when a new connection comes in.  If the
+// delegate wishes to refuse the connection, then it should
+// invalidate the connection object from within this method.
+@end
+
+
+// This class represents each incoming client connection.
+@interface HTTPConnection : NSObject {
+@private
+    id delegate;
+    NSData *peerAddress;
+    HTTPServer *server;
+    NSMutableArray *requests;
+    NSInputStream *istream;
+    NSOutputStream *ostream;
+    NSMutableData *ibuffer;
+    NSMutableData *obuffer;
+    BOOL isValid;
+    BOOL firstResponseDone;
+}
+
+- (id)initWithPeerAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr forServer:(HTTPServer *)serv;
+
+- (id)delegate;
+- (void)setDelegate:(id)value;
+
+- (NSData *)peerAddress;
+
+- (HTTPServer *)server;
+
+- (HTTPServerRequest *)nextRequest;
+// get the next request that needs to be responded to
+
+- (BOOL)isValid;
+- (void)invalidate;
+// shut down the connection
+
+- (void)performDefaultRequestHandling:(HTTPServerRequest *)sreq;
+// perform the default handling action: GET and HEAD requests for files
+// in the local file system (relative to the documentRoot of the server)
+
+@end
+
+@interface HTTPConnection (HTTPConnectionDelegateMethods)
+- (void)HTTPConnection:(HTTPConnection *)conn didReceiveRequest:(HTTPServerRequest *)mess;
+- (void)HTTPConnection:(HTTPConnection *)conn didSendResponse:(HTTPServerRequest *)mess;
+// The "didReceiveRequest:" is the most interesting --
+// tells the delegate when a new request comes in.
+@end
+
+
+// As NSURLRequest and NSURLResponse are not entirely suitable for use from
+// the point of view of an HTTP server, we use CFHTTPMessageRef to encapsulate
+// requests and responses.  This class packages the (future) response with a
+// request and other info for convenience.
+@interface HTTPServerRequest : NSObject {
+@private
+    HTTPConnection *connection;
+    CFHTTPMessageRef request;
+    CFHTTPMessageRef response;
+    NSInputStream *responseStream;
+}
+
+- (id)initWithRequest:(CFHTTPMessageRef)req connection:(HTTPConnection *)conn;
+
+- (HTTPConnection *)connection;
+
+- (CFHTTPMessageRef)request;
+
+- (CFHTTPMessageRef)response;
+- (void)setResponse:(CFHTTPMessageRef)value;
+// The response may include a body.  As soon as the response is set,
+// the response may be written out to the network.
+
+- (NSInputStream *)responseBodyStream;
+- (void)setResponseBodyStream:(NSInputStream *)value;
+// If there is to be a response body stream (when, say, a big
+// file is to be returned, rather than reading the whole thing
+// into memory), then it must be set on the request BEFORE the
+// response [headers] itself.
+
+@end
+
+

--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.m
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.m
@@ -1,0 +1,646 @@
+/*! @file OIDLoopbackHTTPServer.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 The AppAuth Authors.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDLoopbackHTTPServer.h"
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+@implementation HTTPServer
+
+- (id)init {
+    connClass = [HTTPConnection self];
+    return self;
+}
+
+- (void)dealloc {
+    [super dealloc];
+}
+
+- (Class)connectionClass {
+    return connClass;
+}
+
+- (void)setConnectionClass:(Class)value {
+    connClass = value;
+}
+
+- (NSURL *)documentRoot {
+    return docRoot;
+}
+
+- (void)setDocumentRoot:(NSURL *)value {
+    if (docRoot != value) {
+        [docRoot release];
+        docRoot = [value copy];
+    }
+}
+
+// Converts the TCPServer delegate notification into the HTTPServer delegate method.
+- (void)handleNewConnectionFromAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr {
+    HTTPConnection *connection = [[connClass alloc] initWithPeerAddress:addr inputStream:istr outputStream:ostr forServer:self];
+    [connection setDelegate:[self delegate]];
+    if ([self delegate] && [[self delegate] respondsToSelector:@selector(HTTPServer:didMakeNewConnection:)]) {
+        [[self delegate] HTTPServer:self didMakeNewConnection:connection];
+    }
+    // The connection at this point is turned loose to exist on its
+    // own, and not released or autoreleased.  Alternatively, the
+    // HTTPServer could keep a list of connections, and HTTPConnection
+    // would have to tell the server to delete one at invalidation
+    // time.  This would perhaps be more correct and ensure no
+    // spurious leaks get reported by the tools, but HTTPServer
+    // has nothing further it wants to do with the HTTPConnections,
+    // and would just be "owning" the connections for form.
+}
+
+@end
+
+
+@implementation HTTPConnection
+
+- (id)init {
+    [self dealloc];
+    return nil;
+}
+
+- (id)initWithPeerAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr forServer:(HTTPServer *)serv {
+    peerAddress = [addr copy];
+    server = serv;
+    istream = [istr retain];
+    ostream = [ostr retain];
+    [istream setDelegate:self];
+    [ostream setDelegate:self];
+    [istream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:(id)kCFRunLoopCommonModes];
+    [ostream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:(id)kCFRunLoopCommonModes];
+    [istream open];
+    [ostream open];
+    isValid = YES;
+    return self;
+}
+
+- (void)dealloc {
+    [self invalidate];
+    [peerAddress release];
+    [super dealloc];
+}
+
+- (id)delegate {
+    return delegate;
+}
+
+- (void)setDelegate:(id)value {
+    delegate = value;
+}
+
+- (NSData *)peerAddress {
+    return peerAddress;
+}
+
+- (HTTPServer *)server {
+    return server;
+}
+
+- (HTTPServerRequest *)nextRequest {
+    unsigned idx, cnt = requests ? [requests count] : 0;
+    for (idx = 0; idx < cnt; idx++) {
+        id obj = [requests objectAtIndex:idx];
+        if ([obj response] == nil) {
+            return obj;
+        }
+    }
+    return nil;
+}
+
+- (BOOL)isValid {
+    return isValid;
+}
+
+- (void)invalidate {
+    if (isValid) {
+        isValid = NO;
+        [istream close];
+        [ostream close];
+        [istream release];
+        [ostream release];
+        istream = nil;
+        ostream = nil;
+        [ibuffer release];
+        [obuffer release];
+        ibuffer = nil;
+        obuffer = nil;
+        [requests release];
+        requests = nil;
+        [self release];
+        // This last line removes the implicit retain the HTTPConnection
+        // has on itself, given by the HTTPServer when it abandoned the
+        // new connection.
+    }
+}
+
+// YES return means that a complete request was parsed, and the caller
+// should call again as the buffered bytes may have another complete
+// request available.
+- (BOOL)processIncomingBytes {
+    CFHTTPMessageRef working = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, TRUE);
+    CFHTTPMessageAppendBytes(working, [ibuffer bytes], [ibuffer length]);
+
+    // This "try and possibly succeed" approach is potentially expensive
+    // (lots of bytes being copied around), but the only API available for
+    // the server to use, short of doing the parsing itself.
+
+    // HTTPConnection does not handle the chunked transfer encoding
+    // described in the HTTP spec.  And if there is no Content-Length
+    // header, then the request is the remainder of the stream bytes.
+
+    if (CFHTTPMessageIsHeaderComplete(working)) {
+        NSString *contentLengthValue = [(NSString *)CFHTTPMessageCopyHeaderFieldValue(working, (CFStringRef)@"Content-Length") autorelease];
+
+        unsigned contentLength = contentLengthValue ? [contentLengthValue intValue] : 0;
+        NSData *body = [(NSData *)CFHTTPMessageCopyBody(working) autorelease];
+        unsigned bodyLength = [body length];
+        if (contentLength <= bodyLength) {
+            NSData *newBody = [NSData dataWithBytes:[body bytes] length:contentLength];
+            [ibuffer setLength:0];
+            [ibuffer appendBytes:([body bytes] + contentLength) length:(bodyLength - contentLength)];
+            CFHTTPMessageSetBody(working, (CFDataRef)newBody);
+        } else {
+            CFRelease(working);
+            return NO;
+        }
+    } else {
+        return NO;
+    }
+
+    HTTPServerRequest *request = [[HTTPServerRequest alloc] initWithRequest:working connection:self];
+    if (!requests) {
+        requests = [[NSMutableArray alloc] init];
+    }
+    [requests addObject:request];
+    if (delegate && [delegate respondsToSelector:@selector(HTTPConnection:didReceiveRequest:)]) {
+        [delegate HTTPConnection:self didReceiveRequest:request];
+    } else {
+        [self performDefaultRequestHandling:request];
+    }
+
+    CFRelease(working);
+    return YES;
+}
+
+- (void)processOutgoingBytes {
+    // The HTTP headers, then the body if any, then the response stream get
+    // written out, in that order.  The Content-Length: header is assumed to
+    // be properly set in the response.  Outgoing responses are processed in
+    // the order the requests were received (required by HTTP).
+
+    // Write as many bytes as possible, from buffered bytes, response
+    // headers and body, and response stream.
+
+    if (![ostream hasSpaceAvailable]) {
+        return;
+    }
+
+    unsigned olen = [obuffer length];
+    if (0 < olen) {
+        int writ = [ostream write:[obuffer bytes] maxLength:olen];
+        // buffer any unwritten bytes for later writing
+        if (writ < olen) {
+            memmove([obuffer mutableBytes], [obuffer mutableBytes] + writ, olen - writ);
+            [obuffer setLength:olen - writ];
+            return;
+        }
+        [obuffer setLength:0];
+    }
+
+    unsigned cnt = requests ? [requests count] : 0;
+    HTTPServerRequest *req = (0 < cnt) ? [requests objectAtIndex:0] : nil;
+
+    CFHTTPMessageRef cfresp = req ? [req response] : NULL;
+    if (!cfresp) return;
+
+    if (!obuffer) {
+        obuffer = [[NSMutableData alloc] init];
+    }
+
+    if (!firstResponseDone) {
+        firstResponseDone = YES;
+        NSData *serialized = [(NSData *)CFHTTPMessageCopySerializedMessage(cfresp) autorelease];
+        unsigned olen = [serialized length];
+        if (0 < olen) {
+            int writ = [ostream write:[serialized bytes] maxLength:olen];
+            if (writ < olen) {
+                // buffer any unwritten bytes for later writing
+                [obuffer setLength:(olen - writ)];
+                memmove([obuffer mutableBytes], [serialized bytes] + writ, olen - writ);
+                return;
+            }
+        }
+    }
+
+    NSInputStream *respStream = [req responseBodyStream];
+    if (respStream) {
+        if ([respStream streamStatus] == NSStreamStatusNotOpen) {
+            [respStream open];
+        }
+        // read some bytes from the stream into our local buffer
+        [obuffer setLength:16 * 1024];
+        int read = [respStream read:[obuffer mutableBytes] maxLength:[obuffer length]];
+        [obuffer setLength:read];
+    }
+
+    if (0 == [obuffer length]) {
+        // When we get to this point with an empty buffer, then the
+        // processing of the response is done. If the input stream
+        // is closed or at EOF, then no more requests are coming in.
+        if (delegate && [delegate respondsToSelector:@selector(HTTPConnection:didSendResponse:)]) {
+            [delegate HTTPConnection:self didSendResponse:req];
+        }
+        [requests removeObjectAtIndex:0];
+        firstResponseDone = NO;
+        if ([istream streamStatus] == NSStreamStatusAtEnd && [requests count] == 0) {
+            [self invalidate];
+        }
+        return;
+    }
+
+    olen = [obuffer length];
+    if (0 < olen) {
+        int writ = [ostream write:[obuffer bytes] maxLength:olen];
+        // buffer any unwritten bytes for later writing
+        if (writ < olen) {
+            memmove([obuffer mutableBytes], [obuffer mutableBytes] + writ, olen - writ);
+        }
+        [obuffer setLength:olen - writ];
+    }
+}
+
+- (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)streamEvent {
+    switch(streamEvent) {
+    case NSStreamEventHasBytesAvailable:;
+        uint8_t buf[16 * 1024];
+        uint8_t *buffer = NULL;
+        unsigned int len = 0;
+        if (![istream getBuffer:&buffer length:&len]) {
+            int amount = [istream read:buf maxLength:sizeof(buf)];
+            buffer = buf;
+            len = amount;
+        }
+        if (0 < len) {
+            if (!ibuffer) {
+                ibuffer = [[NSMutableData alloc] init];
+            }
+            [ibuffer appendBytes:buffer length:len];
+        }
+        do {} while ([self processIncomingBytes]);
+        break;
+    case NSStreamEventHasSpaceAvailable:;
+        [self processOutgoingBytes];
+        break;
+    case NSStreamEventEndEncountered:;
+        [self processIncomingBytes];
+        if (stream == ostream) {
+            // When the output stream is closed, no more writing will succeed and
+            // will abandon the processing of any pending requests and further
+            // incoming bytes.
+            [self invalidate];
+        }
+        break;
+    case NSStreamEventErrorOccurred:;
+        NSLog(@"HTTPServer stream error: %@", [stream streamError]);
+        break;
+    default:
+        break;
+    }
+}
+
+- (void)performDefaultRequestHandling:(HTTPServerRequest *)mess {
+    CFHTTPMessageRef request = [mess request];
+
+    NSString *vers = [(id)CFHTTPMessageCopyVersion(request) autorelease];
+    if (!vers || ![vers isEqual:(id)kCFHTTPVersion1_1]) {
+        CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 505, NULL, (CFStringRef)vers); // Version Not Supported
+        [mess setResponse:response];
+        CFRelease(response);
+        return;
+    }
+
+    NSString *method = [(id)CFHTTPMessageCopyRequestMethod(request) autorelease];
+    if (!method) {
+        CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 400, NULL, kCFHTTPVersion1_1); // Bad Request
+        [mess setResponse:response];
+        CFRelease(response);
+        return;
+    }
+
+    if ([method isEqual:@"GET"] || [method isEqual:@"HEAD"]) {
+        NSURL *uri = [(NSURL *)CFHTTPMessageCopyRequestURL(request) autorelease];
+        NSURL *url = [NSURL URLWithString:[uri path] relativeToURL:[server documentRoot]];
+        NSData *data = [NSData dataWithContentsOfURL:url];
+
+        if (!data) {
+            CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 404, NULL, kCFHTTPVersion1_1); // Not Found
+            [mess setResponse:response];
+            CFRelease(response);
+            return;
+        }
+
+        CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 200, NULL, kCFHTTPVersion1_1); // OK
+        CFHTTPMessageSetHeaderFieldValue(response, (CFStringRef)@"Content-Length", (CFStringRef)[NSString stringWithFormat:@"%d", [data length]]);
+        if ([method isEqual:@"GET"]) {
+            CFHTTPMessageSetBody(response, (CFDataRef)data);
+        }
+        [mess setResponse:response];
+        CFRelease(response);
+        return;
+    }
+
+    CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 405, NULL, kCFHTTPVersion1_1); // Method Not Allowed
+    [mess setResponse:response];
+    CFRelease(response);
+}
+
+@end
+
+
+@implementation HTTPServerRequest
+
+- (id)init {
+    [self dealloc];
+    return nil;
+}
+
+- (id)initWithRequest:(CFHTTPMessageRef)req connection:(HTTPConnection *)conn {
+    connection = conn;
+    request = (CFHTTPMessageRef)CFRetain(req);
+    return self;
+}
+
+- (void)dealloc {
+    if (request) CFRelease(request);
+    if (response) CFRelease(response);
+    [responseStream release];
+    [super dealloc];
+}
+
+- (HTTPConnection *)connection {
+    return connection;
+}
+
+- (CFHTTPMessageRef)request {
+    return request;
+}
+
+- (CFHTTPMessageRef)response {
+    return response;
+}
+
+- (void)setResponse:(CFHTTPMessageRef)value {
+    if (value != response) {
+        if (response) CFRelease(response);
+        response = (CFHTTPMessageRef)CFRetain(value);
+        if (response) {
+            // check to see if the response can now be sent out
+            [connection processOutgoingBytes];
+        }
+    }
+}
+
+- (NSInputStream *)responseBodyStream {
+    return responseStream;
+}
+
+- (void)setResponseBodyStream:(NSInputStream *)value {
+    if (value != responseStream) {
+        [responseStream release];
+        responseStream = [value retain];
+    }
+}
+
+@end
+
+NSString * const TCPServerErrorDomain = @"TCPServerErrorDomain";
+
+@implementation TCPServer
+
+- (id)init {
+    return self;
+}
+
+- (void)dealloc {
+    [self stop];
+    [domain release];
+    [name release];
+    [type release];
+    [super dealloc];
+}
+
+- (id)delegate {
+    return delegate;
+}
+
+- (void)setDelegate:(id)value {
+    delegate = value;
+}
+
+- (NSString *)domain {
+    return domain;
+}
+
+- (void)setDomain:(NSString *)value {
+    if (domain != value) {
+        [domain release];
+        domain = [value copy];
+    }
+}
+
+- (NSString *)name {
+    return name;
+}
+
+- (void)setName:(NSString *)value {
+    if (name != value) {
+        [name release];
+        name = [value copy];
+    }
+}
+
+- (NSString *)type {
+    return type;
+}
+
+- (void)setType:(NSString *)value {
+    if (type != value) {
+        [type release];
+        type = [value copy];
+    }
+}
+
+- (uint16_t)port {
+    return port;
+}
+
+- (void)setPort:(uint16_t)value {
+    port = value;
+}
+
+- (void)handleNewConnectionFromAddress:(NSData *)addr inputStream:(NSInputStream *)istr outputStream:(NSOutputStream *)ostr {
+    // if the delegate implements the delegate method, call it
+    if (delegate && [delegate respondsToSelector:@selector(TCPServer:didReceiveConnectionFrom:inputStream:outputStream:)]) {
+        [delegate TCPServer:self didReceiveConnectionFromAddress:addr inputStream:istr outputStream:ostr];
+    }
+}
+
+// This function is called by CFSocket when a new connection comes in.
+// We gather some data here, and convert the function call to a method
+// invocation on TCPServer.
+static void TCPServerAcceptCallBack(CFSocketRef socket, CFSocketCallBackType type, CFDataRef address, const void *data, void *info) {
+    TCPServer *server = (TCPServer *)info;
+    if (kCFSocketAcceptCallBack == type) {
+        // for an AcceptCallBack, the data parameter is a pointer to a CFSocketNativeHandle
+        CFSocketNativeHandle nativeSocketHandle = *(CFSocketNativeHandle *)data;
+        uint8_t name[SOCK_MAXADDRLEN];
+        socklen_t namelen = sizeof(name);
+        NSData *peer = nil;
+        if (0 == getpeername(nativeSocketHandle, (struct sockaddr *)name, &namelen)) {
+            peer = [NSData dataWithBytes:name length:namelen];
+        }
+        CFReadStreamRef readStream = NULL;
+	CFWriteStreamRef writeStream = NULL;
+        CFStreamCreatePairWithSocket(kCFAllocatorDefault, nativeSocketHandle, &readStream, &writeStream);
+        if (readStream && writeStream) {
+            CFReadStreamSetProperty(readStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanTrue);
+            CFWriteStreamSetProperty(writeStream, kCFStreamPropertyShouldCloseNativeSocket, kCFBooleanTrue);
+            [server handleNewConnectionFromAddress:peer inputStream:(NSInputStream *)readStream outputStream:(NSOutputStream *)writeStream];
+        } else {
+            // on any failure, need to destroy the CFSocketNativeHandle
+            // since we are not going to use it any more
+            close(nativeSocketHandle);
+        }
+        if (readStream) CFRelease(readStream);
+        if (writeStream) CFRelease(writeStream);
+    }
+}
+
+- (BOOL)start:(NSError **)error {
+    CFSocketContext socketCtxt = {0, self, NULL, NULL, NULL};
+    ipv4socket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_STREAM, IPPROTO_TCP, kCFSocketAcceptCallBack, (CFSocketCallBack)&TCPServerAcceptCallBack, &socketCtxt);
+    ipv6socket = CFSocketCreate(kCFAllocatorDefault, PF_INET6, SOCK_STREAM, IPPROTO_TCP, kCFSocketAcceptCallBack, (CFSocketCallBack)&TCPServerAcceptCallBack, &socketCtxt);
+
+    if (NULL == ipv4socket || NULL == ipv6socket) {
+        if (error) *error = [[NSError alloc] initWithDomain:TCPServerErrorDomain code:kTCPServerNoSocketsAvailable userInfo:nil];
+        if (ipv4socket) CFRelease(ipv4socket);
+        if (ipv6socket) CFRelease(ipv6socket);
+        ipv4socket = NULL;
+        ipv6socket = NULL;
+        return NO;
+    }
+
+    int yes = 1;
+    setsockopt(CFSocketGetNative(ipv4socket), SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+    setsockopt(CFSocketGetNative(ipv6socket), SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+
+    // set up the IPv4 endpoint; if port is 0, this will cause the kernel to choose a port for us
+    struct sockaddr_in addr4;
+    memset(&addr4, 0, sizeof(addr4));
+    addr4.sin_len = sizeof(addr4);
+    addr4.sin_family = AF_INET;
+    addr4.sin_port = htons(port);
+    addr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    NSData *address4 = [NSData dataWithBytes:&addr4 length:sizeof(addr4)];
+
+    if (kCFSocketSuccess != CFSocketSetAddress(ipv4socket, (CFDataRef)address4)) {
+        if (error) *error = [[NSError alloc] initWithDomain:TCPServerErrorDomain code:kTCPServerCouldNotBindToIPv4Address userInfo:nil];
+        if (ipv4socket) CFRelease(ipv4socket);
+        if (ipv6socket) CFRelease(ipv6socket);
+        ipv4socket = NULL;
+        ipv6socket = NULL;
+        return NO;
+    }
+
+    if (0 == port) {
+        // now that the binding was successful, we get the port number
+        // -- we will need it for the v6 endpoint and for the NSNetService
+        NSData *addr = [(NSData *)CFSocketCopyAddress(ipv4socket) autorelease];
+        memcpy(&addr4, [addr bytes], [addr length]);
+        port = ntohs(addr4.sin_port);
+    }
+
+    // set up the IPv6 endpoint
+    struct sockaddr_in6 addr6;
+    memset(&addr6, 0, sizeof(addr6));
+    addr6.sin6_len = sizeof(addr6);
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_port = htons(port);
+    memcpy(&(addr6.sin6_addr), &in6addr_loopback, sizeof(addr6.sin6_addr));
+    NSData *address6 = [NSData dataWithBytes:&addr6 length:sizeof(addr6)];
+
+    if (kCFSocketSuccess != CFSocketSetAddress(ipv6socket, (CFDataRef)address6)) {
+        if (error) *error = [[NSError alloc] initWithDomain:TCPServerErrorDomain code:kTCPServerCouldNotBindToIPv6Address userInfo:nil];
+        if (ipv4socket) CFRelease(ipv4socket);
+        if (ipv6socket) CFRelease(ipv6socket);
+        ipv4socket = NULL;
+        ipv6socket = NULL;
+        return NO;
+    }
+
+    // set up the run loop sources for the sockets
+    CFRunLoopRef cfrl = CFRunLoopGetCurrent();
+    CFRunLoopSourceRef source4 = CFSocketCreateRunLoopSource(kCFAllocatorDefault, ipv4socket, 0);
+    CFRunLoopAddSource(cfrl, source4, kCFRunLoopCommonModes);
+    CFRelease(source4);
+
+    CFRunLoopSourceRef source6 = CFSocketCreateRunLoopSource(kCFAllocatorDefault, ipv6socket, 0);
+    CFRunLoopAddSource(cfrl, source6, kCFRunLoopCommonModes);
+    CFRelease(source6);
+
+    // we can only publish the service if we have a type to publish with
+    if (nil != type) {
+        NSString *publishingDomain = domain ? domain : @"";
+        NSString *publishingName = nil;
+        if (nil != name) {
+            publishingName = name;
+        } else {
+            NSString * thisHostName = [[NSProcessInfo processInfo] hostName];
+            if ([thisHostName hasSuffix:@".local"]) {
+                publishingName = [thisHostName substringToIndex:([thisHostName length] - 6)];
+            }
+        }
+        netService = [[NSNetService alloc] initWithDomain:publishingDomain type:type name:publishingName port:port];
+        [netService publish];
+    }
+
+    return YES;
+}
+
+- (BOOL)stop {
+    [netService stop];
+    [netService release];
+    netService = nil;
+    if (ipv4socket) {
+      CFSocketInvalidate(ipv4socket);
+      CFRelease(ipv4socket);
+      ipv4socket = NULL;
+    }
+    if (ipv6socket) {
+      CFSocketInvalidate(ipv6socket);
+      CFRelease(ipv6socket);
+      ipv6socket = NULL;
+    }
+    return YES;
+}
+
+@end

--- a/Source/macOS/OIDRedirectHTTPHandler.h
+++ b/Source/macOS/OIDRedirectHTTPHandler.h
@@ -1,0 +1,61 @@
+/*! @file OIDRedirectHTTPHandler.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol OIDAuthorizationFlowSession;
+
+
+/*! @brief Start a HTTP server on the loopback interface (e.g. 127.0.0.1) to receive OAuth
+        authorization result redirects.
+ */
+@interface OIDRedirectHTTPHandler : NSObject
+
+/*! @brief The authorization flow session which receives the return URL from the browser.
+    @discussion The loopback HTTP server will try sending incoming request URLs to the OAuth
+        redirect handler to continue the flow. This should be set while an authorization flow is
+        in progress.
+ */
+@property(nonatomic, strong, nullable) id<OIDAuthorizationFlowSession> currentAuthorizationFlow;
+
+/*! @brief Creates an a loopback HTTP redirect URI handler with the given success URL.
+    @param successURL The URL that the user is redirected to after the authorization flow completes
+        either with a result of success or error. The contents of this page should instruct the user
+        to return to the app.
+    @discussion Once you have initiated the authorization request, be sure to set
+        @c currentAuthorizationFlow on this object so that any authorization responses received by
+        this listener will be routed accordingly.
+ */
+- (instancetype)initWithSuccessURL:(nullable NSURL *)successURL;
+
+/*! @brief Starts listening on the loopback interface on a random available port, and returns a URL
+        with the base address.
+    @param error The error if an error occurred.
+    @return The URL containing the address of the server with the randomly assigned available port.
+ */
+- (NSURL *)startHTTPListener:(NSError **)error;
+
+/*! @brief Stops listening the loopback interface.
+ */
+- (void)stopHTTPListener;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/macOS/OIDRedirectHTTPHandler.m
+++ b/Source/macOS/OIDRedirectHTTPHandler.m
@@ -1,0 +1,104 @@
+/*! @file OIDRedirectHTTPHandler.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2016 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDRedirectHTTPHandler.h"
+
+#import "OIDLoopbackHTTPServer.h"
+#import "OIDAuthorizationService.h"
+
+@implementation OIDRedirectHTTPHandler {
+  HTTPServer *_httpServ;
+  NSURL *_successURL;
+}
+
+- (instancetype)init {
+  return [self initWithSuccessURL:nil];
+}
+
+- (instancetype)initWithSuccessURL:(nullable NSURL *)successURL {
+  self = [super init];
+  if (self) {
+    _successURL = [successURL copy];
+  }
+  return self;
+}
+
+- (NSURL *)startHTTPListener:(NSError **)returnError {
+  // Starts a HTTP server on the loopback interface.
+  // By not specifying a port, a random available one will be assigned.
+  _httpServ = [[HTTPServer alloc] init];
+  [_httpServ setDelegate:self];
+  NSError *error = nil;
+  if (![_httpServ start:&error]) {
+    if (returnError) {
+      *returnError = error;
+    }
+    return nil;
+  } else {
+    NSString *serverURL = [NSString stringWithFormat:@"http://127.0.0.1:%d/", [_httpServ port]];
+    return [NSURL URLWithString:serverURL];
+  }
+}
+
+- (void)stopHTTPListener {
+  _httpServ.delegate = nil;
+  [_httpServ stop];
+  _httpServ = nil;
+}
+
+- (void)HTTPConnection:(HTTPConnection *)conn didReceiveRequest:(HTTPServerRequest *)mess {
+  // Sends URL to AppAuth.
+  CFURLRef url = CFHTTPMessageCopyRequestURL(mess.request);
+  BOOL success = [_currentAuthorizationFlow resumeAuthorizationFlowWithURL:(__bridge NSURL *)url];
+
+  // Responds to browser request.
+  NSString *bodyText;
+  NSInteger httpResponseCode;
+  if (success) {
+    bodyText = @"<html><body>Return to the app.</body></html>";
+    httpResponseCode = (_successURL) ? 302 : 200;
+  } else {
+    bodyText = @"<html><body>Error.</body></html>";
+    httpResponseCode = 400;
+  }
+  NSData *data = [bodyText dataUsingEncoding:NSUTF8StringEncoding];
+
+  CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault,
+                                                          httpResponseCode,
+                                                          NULL,
+                                                          kCFHTTPVersion1_1);
+  if (success && _successURL) {
+    CFHTTPMessageSetHeaderFieldValue(response,
+                                     (__bridge CFStringRef)@"Location",
+                                     (__bridge CFStringRef)_successURL.absoluteString);
+  }
+  CFHTTPMessageSetHeaderFieldValue(response,
+                                   (__bridge CFStringRef)@"Content-Length",
+                                   (__bridge CFStringRef)[NSString stringWithFormat:@"%lu",
+                                       (unsigned long)data.length]);
+  CFHTTPMessageSetBody(response, (__bridge CFDataRef)data);
+
+  [mess setResponse:response];
+  CFRelease(response);
+}
+
+- (void)dealloc {
+  [self stopHTTPListener];
+}
+
+@end


### PR DESCRIPTION
This PR adds the option to handle loopback IP HTTP redirects for macOS.  Loopback redirects are an alternative redirect choice to custom URI scheme based redirects on macOS. Both choices have their pros and cons, this gives developers the choice.

To enable this, I have introduced some third-party code (taken from an Apple sample), clearly marked as such, to provide the HTTP server functionality, modified to listen only on the loopback interface.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/42)

<!-- Reviewable:end -->
