### PR TITLE
Fixed handling of client_secret for token endpoint requests.

### DIFF
--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -244,7 +244,7 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   if (_clientID) {
     [query addParameter:kClientIDKey value:_clientID];
   }
-  if (_clientSecret && [_grantType isEqualToString:OIDGrantTypeAuthorizationCode]) {
+  if (_clientSecret) {
     [query addParameter:kClientSecretKey value:_clientSecret];
   }
   if (_redirectURL) {


### PR DESCRIPTION
If client_secret is present, it should be used on all token endpoint requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/43)
<!-- Reviewable:end -->
