### PR TITLE
Added withFreshTokensPerformActionWithAdditionalParameters to OIDAuthState

### DIFF
--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -206,16 +206,15 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
  */
 - (void)withFreshTokensPerformAction:(OIDAuthStateAction)action;
 
-/*! @fn withFreshTokensPerformActionWithAdditionalParameters:
+/*! @fn performActionWithFreshTokens:additionalRefreshParameters:
     @brief Calls the block with a valid access token (refreshing it first, if needed), or if a
         refresh was needed and failed, with the error that caused it to fail.
-    @param additionalParameters Additional parameters for the token request if token is refreshed.
-    @param action The block to execute with a fresh token. This block will be executed on the main
-        thread.
+    @param action The block to execute with a fresh token. This block will be executed on the main thread.
+    @param additionalRefreshParameters Additional parameters for the token request if token is refreshed.
+
  */
-- (void)withFreshTokensPerformActionWithAdditionalParameters:
-    (nullable NSDictionary<NSString *, NSString *> *)additionalParameters
-                                                     action:(OIDAuthStateAction)action;
+- (void)performActionWithFreshTokens:(OIDAuthStateAction)action
+         additionalRefreshParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 
 /*! @fn setNeedsTokenRefresh
     @brief Forces a token refresh the next time @c OIDAuthState.withFreshTokensPerformAction: is

--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -206,6 +206,17 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
  */
 - (void)withFreshTokensPerformAction:(OIDAuthStateAction)action;
 
+/*! @fn withFreshTokensPerformActionWithAdditionalParameters:
+    @brief Calls the block with a valid access token (refreshing it first, if needed), or if a
+        refresh was needed and failed, with the error that caused it to fail.
+    @param additionalParameters Additional parameters for the token request if token is refreshed.
+    @param action The block to execute with a fresh token. This block will be executed on the main
+        thread.
+ */
+- (void)withFreshTokensPerformActionWithAdditionalParameters:
+    (nullable NSDictionary<NSString *, NSString *> *)additionalParameters
+                                                     action:(OIDAuthStateAction)action;
+
 /*! @fn setNeedsTokenRefresh
     @brief Forces a token refresh the next time @c OIDAuthState.withFreshTokensPerformAction: is
         called, even if the current tokens are considered valid.

--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -408,6 +408,12 @@ static const NSUInteger kExpiryTimeTolerance = 60;
 }
 
 - (void)withFreshTokensPerformAction:(OIDAuthStateAction)action {
+  [self withFreshTokensPerformActionWithAdditionalParameters:nil action:action];
+}
+
+- (void)withFreshTokensPerformActionWithAdditionalParameters:
+    (NSDictionary<NSString *, NSString *> *)additionalParameters
+                                                     action:(OIDAuthStateAction)action {
   if (!_refreshToken) {
     [OIDErrorUtilities raiseException:kRefreshTokenRequestException];
   }
@@ -434,7 +440,8 @@ static const NSUInteger kExpiryTimeTolerance = 60;
     }
 
     // refresh the tokens
-    OIDTokenRequest *tokenRefreshRequest = [self tokenRefreshRequest];
+    OIDTokenRequest *tokenRefreshRequest =
+      [self tokenRefreshRequestWithAdditionalParameters:additionalParameters];
     [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
                                         callback:^(OIDTokenResponse *_Nullable response,
                                                    NSError *_Nullable error) {

--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -408,12 +408,11 @@ static const NSUInteger kExpiryTimeTolerance = 60;
 }
 
 - (void)withFreshTokensPerformAction:(OIDAuthStateAction)action {
-  [self withFreshTokensPerformActionWithAdditionalParameters:nil action:action];
+  [self performActionWithFreshTokens:action additionalRefreshParameters:nil];
 }
 
-- (void)withFreshTokensPerformActionWithAdditionalParameters:
-    (NSDictionary<NSString *, NSString *> *)additionalParameters
-                                                     action:(OIDAuthStateAction)action {
+- (void)performActionWithFreshTokens:(OIDAuthStateAction)action
+         additionalRefreshParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
   if (!_refreshToken) {
     [OIDErrorUtilities raiseException:kRefreshTokenRequestException];
   }
@@ -441,7 +440,7 @@ static const NSUInteger kExpiryTimeTolerance = 60;
 
     // refresh the tokens
     OIDTokenRequest *tokenRefreshRequest =
-      [self tokenRefreshRequestWithAdditionalParameters:additionalParameters];
+        [self tokenRefreshRequestWithAdditionalParameters:additionalParameters];
     [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
                                         callback:^(OIDTokenResponse *_Nullable response,
                                                    NSError *_Nullable error) {


### PR DESCRIPTION
This PR adds a way to include additional parameters when a token needs to be refreshed.  This way previously only achievable by constructing the request, performing the refresh, and updating the auth state manually.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/49)

<!-- Reviewable:end -->
