### PR TITLE
ARC-ified the loopback HTTP server class.

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -40,12 +40,6 @@ tasks like performing an action with fresh tokens.
   s.ios.framework         = "SafariServices"
 
   # macOS
-  s.osx.source_files = "Source/macOS/*.{h,m}"
+  s.osx.source_files = "Source/macOS/**/*.{h,m}"
   s.osx.deployment_target = '10.8'
-
-  s.subspec 'no-arc' do |sp|
-    sp.source_files = ""
-    sp.osx.source_files = "Source/macOS/LoopbackHTTPServer/*.{h,m}"
-    sp.requires_arc = false
-  end
 end

--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		3417422B1C5D8502000EF209 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417422A1C5D8502000EF209 /* SafariServices.framework */; };
 		3417422D1C5D850C000EF209 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3417422C1C5D850C000EF209 /* Security.framework */; };
 		34FEA6AE1DB6E083005C9212 /* OIDLoopbackHTTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 34FEA6AC1DB6E083005C9212 /* OIDLoopbackHTTPServer.h */; };
-		34FEA6AF1DB6E083005C9212 /* OIDLoopbackHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		34FEA6AF1DB6E083005C9212 /* OIDLoopbackHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FEA6AD1DB6E083005C9212 /* OIDLoopbackHTTPServer.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
@@ -35,7 +35,7 @@ typedef enum {
 
 @interface TCPServer : NSObject {
 @private
-    id delegate;
+    __weak id delegate;
     NSString *domain;
     NSString *name;
     NSString *type;
@@ -83,6 +83,8 @@ typedef enum {
 @private
     Class connClass;
     NSURL *docRoot;
+    // Currently active connections spawned from the HTTPServer.
+    NSMutableArray<HTTPConnection *> *connections;
 }
 
 - (Class)connectionClass;
@@ -107,9 +109,9 @@ typedef enum {
 // This class represents each incoming client connection.
 @interface HTTPConnection : NSObject {
 @private
-    id delegate;
+    __weak id delegate;
     NSData *peerAddress;
-    HTTPServer *server;
+    __weak HTTPServer *server;
     NSMutableArray *requests;
     NSInputStream *istream;
     NSOutputStream *ostream;


### PR DESCRIPTION
Notes:
– `HTTPConnection` objects were previously self-retaining. HTTPServer now keeps track of them instead so they are retained correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/51)
<!-- Reviewable:end -->
