### PR TITLE
Loopback HTTP server automatically shuts down following authorization.

### DIFF
--- a/Example-Mac/Source/AppAuthExampleViewController.m
+++ b/Example-Mac/Source/AppAuthExampleViewController.m
@@ -297,33 +297,27 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
                                                   responseType:OIDResponseTypeCode
                                           additionalParameters:nil];
     // performs authentication request
+    __weak __typeof(self) weakSelf = self;
     _redirectHTTPHandler.currentAuthorizationFlow =
         [OIDAuthState authStateByPresentingAuthorizationRequest:request
                             callback:^(OIDAuthState *_Nullable authState,
                                        NSError *_Nullable error) {
-
       // Brings this app to the foreground.
       [[NSRunningApplication currentApplication]
           activateWithOptions:(NSApplicationActivateAllWindows |
                                NSApplicationActivateIgnoringOtherApps)];
 
-      // The loopback HTTP listener is no longer needed, stops it.
-      [_redirectHTTPHandler stopHTTPListener];
-      _redirectHTTPHandler = nil;
-
+      // Processes the authorization response.
       if (authState) {
-        [self logMessage:@"Got authorization tokens. Access token: %@",
+        [weakSelf logMessage:@"Got authorization tokens. Access token: %@",
                          authState.lastTokenResponse.accessToken];
       } else {
-        [self logMessage:@"Authorization error: %@", error.localizedDescription];
+        [weakSelf logMessage:@"Authorization error: %@", error.localizedDescription];
       }
-
-      [self setAuthState:authState];
+      [weakSelf setAuthState:authState];
     }];
   }];
 }
-
-
 
 - (IBAction)authNoCodeExchange:(nullable id)sender {
   NSURL *issuer = [NSURL URLWithString:kIssuer];

--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
@@ -92,9 +92,6 @@ typedef enum {
 // a new connection comes in; by default, this is HTTPConnection
 - (void)setConnectionClass:(Class)value;
 
-- (NSURL *)documentRoot;
-- (void)setDocumentRoot:(NSURL *)value;
-
 @end
 
 @interface HTTPServer (HTTPServerDelegateMethods)

--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.m
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.m
@@ -38,16 +38,6 @@
     connClass = value;
 }
 
-- (NSURL *)documentRoot {
-    return docRoot;
-}
-
-- (void)setDocumentRoot:(NSURL *)value {
-    if (docRoot != value) {
-        docRoot = [value copy];
-    }
-}
-
 // Removes the connection from the list of active connections.
 - (void)removeConnection:(HTTPConnection *)connection {
     [connections removeObject:connection];
@@ -323,37 +313,8 @@
         return;
     }
 
-    NSString *method = (__bridge_transfer id)CFHTTPMessageCopyRequestMethod(request);
-    if (!method) {
-        CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 400, NULL, kCFHTTPVersion1_1); // Bad Request
-        [mess setResponse:response];
-        CFRelease(response);
-        return;
-    }
-
-    if ([method isEqual:@"GET"] || [method isEqual:@"HEAD"]) {
-        NSURL *uri = (__bridge_transfer NSURL *)CFHTTPMessageCopyRequestURL(request);
-        NSURL *url = [NSURL URLWithString:[uri path] relativeToURL:[server documentRoot]];
-        NSData *data = [NSData dataWithContentsOfURL:url];
-
-        if (!data) {
-            CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 404, NULL, kCFHTTPVersion1_1); // Not Found
-            [mess setResponse:response];
-            CFRelease(response);
-            return;
-        }
-
-        CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 200, NULL, kCFHTTPVersion1_1); // OK
-        CFHTTPMessageSetHeaderFieldValue(response, (CFStringRef)@"Content-Length", (__bridge CFStringRef)[NSString stringWithFormat:@"%lu", (unsigned long) [data length]]);
-        if ([method isEqual:@"GET"]) {
-            CFHTTPMessageSetBody(response, (__bridge CFDataRef)data);
-        }
-        [mess setResponse:response];
-        CFRelease(response);
-        return;
-    }
-
-    CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 405, NULL, kCFHTTPVersion1_1); // Method Not Allowed
+    // 500s all requests when no delegate set to handle them.
+    CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 500, NULL, kCFHTTPVersion1_1); // Bad Request
     [mess setResponse:response];
     CFRelease(response);
 }

--- a/Source/macOS/OIDRedirectHTTPHandler.h
+++ b/Source/macOS/OIDRedirectHTTPHandler.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OIDAuthorizationFlowSession;
 
-
 /*! @brief Start a HTTP server on the loopback interface (e.g. 127.0.0.1) to receive OAuth
         authorization result redirects.
  */
@@ -46,15 +45,25 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSuccessURL:(nullable NSURL *)successURL;
 
 /*! @brief Starts listening on the loopback interface on a random available port, and returns a URL
-        with the base address.
-    @param error The error if an error occurred.
+        with the base address. Use the returned redirect URI to build an @c OIDAuthorizationRequest,
+        and once you initiate the request, set the resulting @c OIDAuthorizationFlowSession to
+        @c currentAuthorizationFlow so the response can be handled.
+    @param error The error if an error occurred while starting the local HTTP server.
     @return The URL containing the address of the server with the randomly assigned available port.
+    @discussion Each instance of @c OIDRedirectHTTPHandler can only listen for a single
+        authorization response. Calling this more than once will result in the previous listener
+        being cancelled (equivalent of @c cancelHTTPListener being called).
  */
 - (NSURL *)startHTTPListener:(NSError **)error;
 
-/*! @brief Stops listening the loopback interface.
+/*! @brief Stops listening the loopback interface and sends an cancellation error (in the domain
+        ::OIDGeneralErrorDomain, with the code ::OIDErrorCodeProgramCanceledAuthorizationFlow) to
+        the @c currentAuthorizationFlow.  Has no effect if called when no requests are pending.
+    @discussion The HTTP listener is stopped automatically on receiving a valid authorization
+        response (regardless of whether the authorization succeeded or not), this method should not
+        be called except when abandoning the authorization request.
  */
-- (void)stopHTTPListener;
+- (void)cancelHTTPListener;
 
 @end
 

--- a/Source/macOS/OIDRedirectHTTPHandler.m
+++ b/Source/macOS/OIDRedirectHTTPHandler.m
@@ -18,8 +18,9 @@
 
 #import "OIDRedirectHTTPHandler.h"
 
-#import "OIDLoopbackHTTPServer.h"
 #import "OIDAuthorizationService.h"
+#import "OIDErrorUtilities.h"
+#import "OIDLoopbackHTTPServer.h"
 
 @implementation OIDRedirectHTTPHandler {
   HTTPServer *_httpServ;
@@ -39,6 +40,9 @@
 }
 
 - (NSURL *)startHTTPListener:(NSError **)returnError {
+  // Cancels any pending requests.
+  [self cancelHTTPListener];
+
   // Starts a HTTP server on the loopback interface.
   // By not specifying a port, a random available one will be assigned.
   _httpServ = [[HTTPServer alloc] init];
@@ -55,6 +59,22 @@
   }
 }
 
+- (void)cancelHTTPListener {
+  [self stopHTTPListener];
+
+  // Cancels the pending authorization flow (if any) with error.
+  NSError *cancelledError =
+      [OIDErrorUtilities errorWithCode:OIDErrorCodeProgramCanceledAuthorizationFlow
+                       underlyingError:nil
+                           description:@"The HTTP listener was cancelled programmatically."];
+  [_currentAuthorizationFlow failAuthorizationFlowWithError:cancelledError];
+  _currentAuthorizationFlow = nil;
+}
+
+/*! @brief Stops listening on the loopback interface without modifying the state of the
+        @c currentAuthorizationFlow. Should be called when the authorization flow completes or is
+        cancelled.
+ */
 - (void)stopHTTPListener {
   _httpServ.delegate = nil;
   [_httpServ stop];
@@ -64,15 +84,20 @@
 - (void)HTTPConnection:(HTTPConnection *)conn didReceiveRequest:(HTTPServerRequest *)mess {
   // Sends URL to AppAuth.
   CFURLRef url = CFHTTPMessageCopyRequestURL(mess.request);
-  BOOL success = [_currentAuthorizationFlow resumeAuthorizationFlowWithURL:(__bridge NSURL *)url];
+  BOOL handled = [_currentAuthorizationFlow resumeAuthorizationFlowWithURL:(__bridge NSURL *)url];
+
+  // Stops listening to further requests after the first valid authorization response.
+  if (handled) {
+    _currentAuthorizationFlow = nil;
+    [self stopHTTPListener];
+  }
 
   // Responds to browser request.
-  NSString *bodyText;
-  NSInteger httpResponseCode;
-  if (success) {
-    bodyText = @"<html><body>Return to the app.</body></html>";
-    httpResponseCode = (_successURL) ? 302 : 200;
-  } else {
+  NSString *bodyText = @"<html><body>Authorization complete.<br> Return to the app.</body></html>";
+  NSInteger httpResponseCode = (_successURL) ? 302 : 200;
+  // Returns an error page in the unlikely event the user lands on the loopback server on a URL
+  // other than the expected authorization response.
+  if (!handled) {
     bodyText = @"<html><body>Error.</body></html>";
     httpResponseCode = 400;
   }
@@ -82,7 +107,7 @@
                                                           httpResponseCode,
                                                           NULL,
                                                           kCFHTTPVersion1_1);
-  if (success && _successURL) {
+  if (httpResponseCode == 302) {
     CFHTTPMessageSetHeaderFieldValue(response,
                                      (__bridge CFStringRef)@"Location",
                                      (__bridge CFStringRef)_successURL.absoluteString);
@@ -98,7 +123,7 @@
 }
 
 - (void)dealloc {
-  [self stopHTTPListener];
+  [self cancelHTTPListener];
 }
 
 @end


### PR DESCRIPTION
- Automatically closes the loopback HTTP server once an authorization response is received.
- Now cancels the previous request if OIDRedirectHTTPHandler::startHTTPListener is called more than once.
- Removed dead code in OIDLoopbackHTTPServer related to the default behavior when no delegate set to handle connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/53)
<!-- Reviewable:end -->
