### PR TITLE
Sets the NSError localizedDescription in more cases.

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -126,7 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
   // verifies that the state in the response matches the state in the request, or both are nil
   if (!OIDIsEqualIncludingNil(_request.state, query.dictionaryValue[kStateParameter])) {
     NSMutableDictionary *userInfo = [query.dictionaryValue mutableCopy];
-    userInfo[NSLocalizedFailureReasonErrorKey] =
+    userInfo[NSLocalizedDescriptionKey] =
         [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
                                     "response %@",
                                    _request.state,
@@ -195,7 +195,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (error || !data) {
       error = [OIDErrorUtilities errorWithCode:OIDErrorCodeNetworkError
                                underlyingError:error
-                                   description:nil];
+                                   description:error.localizedDescription];
       dispatch_async(dispatch_get_main_queue(), ^{
         completion(nil, error);
       });

--- a/Source/OIDErrorUtilities.m
+++ b/Source/OIDErrorUtilities.m
@@ -28,7 +28,7 @@
     userInfo[NSUnderlyingErrorKey] = underlyingError;
   }
   if (description) {
-    userInfo[NSLocalizedFailureReasonErrorKey] = description;
+    userInfo[NSLocalizedDescriptionKey] = description;
   }
   // TODO: Populate localized description based on code.
   NSError *error = [NSError errorWithDomain:OIDGeneralErrorDomain
@@ -68,7 +68,7 @@
       || !errorResponse[OIDOAuthErrorFieldError]) {
     return [[self class] errorWithCode:OIDErrorCodeNetworkError
                        underlyingError:underlyingError
-                           description:@""];
+                           description:underlyingError.description];
   }
 
   // builds the userInfo dictionary with the full OAuth response and other information
@@ -84,7 +84,9 @@
 
   // builds the error description, using the information supplied by the server if possible
   NSMutableString *description = [NSMutableString string];
+  [description appendString:oauthErrorCodeString];
   if (oauthErrorMessage) {
+    [description appendString:@": "];
     [description appendString:oauthErrorMessage];
   }
   if (oauthErrorURI) {
@@ -98,7 +100,7 @@
     [description appendFormat:@"OAuth error: %@ - https://tools.ietf.org/html/rfc6749#section-5.2",
                               oauthErrorCodeString];
   }
-  userInfo[NSLocalizedFailureReasonErrorKey] = description;
+  userInfo[NSLocalizedDescriptionKey] = description;
 
   // looks up the error code based on the "error" response param
   OIDErrorCodeOAuth code = [[self class] OAuthErrorCodeFromString:oauthErrorCodeString];


### PR DESCRIPTION
I heard some reports that it was hard to diagnose issues in AppAuth. While testing #22 I noticed that they were fairly opaque.

I believe the issue is that `localizedDescription` will contain a default description if we don't set one.  We were setting a `localizedFailureReason`, but when the developer calls `localizedDescription` and they get a vague default error, they may not think to check `localizedFailureReason`.

This PR sets localizedDescription overriding the vague default, and leaves localizedFailureReason nil. In the future if we were to set localizedFailureReason, we should always ensure that localizedDescription is included to avoid this usability issue.

Also passed through the description for the non-OAuth errors (like network errors).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/65)
<!-- Reviewable:end -->
