### PR TITLE
fix to SFSafariViewController loading URL on iOS 10.

### DIFF
--- a/Source/iOS/OIDAuthorizationUICoordinatorIOS.m
+++ b/Source/iOS/OIDAuthorizationUICoordinatorIOS.m
@@ -84,7 +84,8 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
         [[[self class] safariViewControllerFactory] safariViewControllerWithURL:URL];
     safariVC.delegate = self;
     _safariVC = safariVC;
-    [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
+    //[_presentingViewController presentViewController:safariVC animated:YES completion:nil];
+    [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:safariVC animated:YES completion:nil];
     return YES;
   }
   BOOL openedSafari = [[UIApplication sharedApplication] openURL:URL];


### PR DESCRIPTION
See below for bug details at Apple
https://forums.developer.apple.com/thread/62012

This change keeps the SFSafariViewController, but fixes a known URL loading issue with it on iOS 10. The previous code worked fine on iOS 9.3, but is broken in iOS 10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openid/appauth-ios/73)
<!-- Reviewable:end -->
