### PR TITLE
Support for Basic Client Authentication

### DIFF
--- a/UnitTests/OIDAuthorizationRequestTests.h
+++ b/UnitTests/OIDAuthorizationRequestTests.h
@@ -34,6 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (OIDAuthorizationRequest *)testInstanceCodeFlow;
 
+/*! @brief Creates a new @c OIDAuthorizationRequest testing a code flow request
+        with client authentication.
+ */
++ (OIDAuthorizationRequest *)testInstanceCodeFlowClientAuth;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -138,7 +138,7 @@ static int const kCodeVerifierRecommendedLength = 43;
       [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
                       clientId:kTestClientID
                   clientSecret:kTestClientSecret
-                        scope:[OIDScopeUtilities scopesWithArray:@[ kTestScope, kTestScopeA ]]
+                         scope:[OIDScopeUtilities scopesWithArray:@[ kTestScope, kTestScopeA ]]
                    redirectURL:[NSURL URLWithString:kTestRedirectURL]
                   responseType:kTestResponseType
                          state:kTestState
@@ -154,8 +154,25 @@ static int const kCodeVerifierRecommendedLength = 43;
   OIDAuthorizationRequest *request =
       [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
                       clientId:kTestClientID
+                  clientSecret:nil
+                         scope:[OIDScopeUtilities scopesWithArray:@[ kTestScope, kTestScopeA ]]
+                   redirectURL:[NSURL URLWithString:kTestRedirectURL]
+                  responseType:OIDResponseTypeCode
+                         state:kTestState
+                  codeVerifier:kTestCodeVerifier
+                 codeChallenge:[[self class] codeChallenge]
+           codeChallengeMethod:[[self class] codeChallengeMethod]
+          additionalParameters:nil];
+  return request;
+}
+
++ (OIDAuthorizationRequest *)testInstanceCodeFlowClientAuth {
+  OIDServiceConfiguration *configuration = [OIDServiceConfigurationTests testInstance];
+  OIDAuthorizationRequest *request =
+      [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
+                      clientId:kTestClientID
                   clientSecret:kTestClientSecret
-                        scope:[OIDScopeUtilities scopesWithArray:@[ kTestScope, kTestScopeA ]]
+                         scope:[OIDScopeUtilities scopesWithArray:@[ kTestScope, kTestScopeA ]]
                    redirectURL:[NSURL URLWithString:kTestRedirectURL]
                   responseType:OIDResponseTypeCode
                          state:kTestState

--- a/UnitTests/OIDAuthorizationResponseTests.h
+++ b/UnitTests/OIDAuthorizationResponseTests.h
@@ -34,6 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (OIDAuthorizationResponse *)testInstanceCodeFlow;
 
+/*! @brief Creates a new @c OIDAuthorizationResponse with client authentication for testing the
+        code flow.
+ */
++ (OIDAuthorizationResponse *)testInstanceCodeFlowClientAuth;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/UnitTests/OIDAuthorizationResponseTests.m
+++ b/UnitTests/OIDAuthorizationResponseTests.m
@@ -95,6 +95,19 @@ static NSString *const kTestScope = @"Scope";
   return response;
 }
 
++ (OIDAuthorizationResponse *)testInstanceCodeFlowClientAuth {
+  OIDAuthorizationRequest *request = [OIDAuthorizationRequestTests testInstanceCodeFlowClientAuth];
+  OIDAuthorizationResponse *response =
+      [[OIDAuthorizationResponse alloc] initWithRequest:request parameters:@{
+        @"code" : kTestAuthorizationCode,
+        @"code_verifier" : kTestAuthorizationCodeVerifier,
+        @"state" : kTestState,
+        @"token_type" : OIDGrantTypeAuthorizationCode,
+        kTestAdditionalParameterKey : kTestAdditionalParameterValue
+      }];
+  return response;
+}
+
 /*! @brief Tests the @c NSCopying implementation by round-tripping an instance through the copying
         process and checking to make sure the source and destination instances are equivalent.
  */


### PR DESCRIPTION
With this change, AppAuth will support no-client-auth (suitable for clients without a secret) and Basic client auth (suitable for clients with a secret).

Previously AppAuth supported no-client-auth, and client credentials in the request body.

Basic auth support is [required](https://tools.ietf.org/html/rfc6749#section-2.3.1) by OAuth 2.0, which also recommends against client credentials in the request body when the client is capable of doing Basic auth (which AppAuth is capable of).

Replaces #24, but doesn't offer the extensibility that #24 did. 