### PR TITLE
Added support for Mac OS X 32-bit Applications.

### DIFF
--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -1788,6 +1788,7 @@
 		340DAE551D58216A00EC285B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
 				EXECUTABLE_PREFIX = lib;
@@ -1800,6 +1801,7 @@
 		340DAE561D58216A00EC285B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
 				EXECUTABLE_PREFIX = lib;
@@ -1944,6 +1946,7 @@
 		341AA4D61E7F392C00FCA5C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1961,6 +1964,7 @@
 		341AA4D71E7F392C00FCA5C6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -2244,6 +2248,7 @@
 		343AAAD41E8348AA00F9D36E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -2270,6 +2275,7 @@
 		343AAAD51E8348AA00F9D36E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -2296,6 +2302,7 @@
 		343AAAD71E8348AA00F9D36E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -2313,6 +2320,7 @@
 		343AAAD81E8348AA00F9D36E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "-";

--- a/Examples/Example-macOS/Example-macOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-macOS/Example-macOS.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7FF583C8F7036437BE8875B3 /* Pods-Example-macOS.debug.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
@@ -455,6 +456,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 60553B3AB5BA3E1BB259E487 /* Pods-Example-macOS.release.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
@@ -474,6 +476,7 @@
 				341AA4C81E7F2E5000FCA5C6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		F6016E6B1D2AC11E003497D7 /* Build configuration list for PBXProject "Example-macOS" */ = {
 			isa = XCConfigurationList;

--- a/Examples/Example-macOS/Source/AppAuthExampleViewController.h
+++ b/Examples/Example-macOS/Source/AppAuthExampleViewController.h
@@ -20,12 +20,26 @@
 @class AppDelegate;
 @class OIDAuthState;
 @class OIDServiceConfiguration;
+@class OIDRedirectHTTPHandler;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @brief The example application's view controller.
  */
-@interface AppAuthExampleViewController : NSViewController
+@interface AppAuthExampleViewController : NSViewController {
+  // private variables
+  OIDRedirectHTTPHandler *_redirectHTTPHandler;
+  // property variables
+  NSButton *_authAutoButton;
+  NSButton *_authManual;
+  NSButton *_authAutoHTTPButton;
+  NSButton *_codeExchangeButton;
+  NSButton *_userinfoButton;
+  NSButton *_clearAuthStateButton;
+  NSTextView *_logTextView;
+  __weak AppDelegate *_appDelegate;
+  OIDAuthState *_authState;
+}
 
 @property(nullable) IBOutlet NSButton *authAutoButton;
 @property(nullable) IBOutlet NSButton *authManual;

--- a/Examples/Example-macOS/Source/AppAuthExampleViewController.m
+++ b/Examples/Example-macOS/Source/AppAuthExampleViewController.m
@@ -60,9 +60,17 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 @interface AppAuthExampleViewController () <OIDAuthStateChangeDelegate, OIDAuthStateErrorDelegate>
 @end
 
-@implementation AppAuthExampleViewController {
-  OIDRedirectHTTPHandler *_redirectHTTPHandler;
-}
+@implementation AppAuthExampleViewController
+
+@synthesize authAutoButton = _authAutoButton;
+@synthesize authManual = _authManual;
+@synthesize authAutoHTTPButton = _authAutoHTTPButton;
+@synthesize codeExchangeButton = _codeExchangeButton;
+@synthesize userinfoButton = _userinfoButton;
+@synthesize clearAuthStateButton = _clearAuthStateButton;
+@synthesize logTextView = _logTextView;
+@synthesize appDelegate = _appDelegate;
+@synthesize authState = _authState;
 
 - (void)viewDidLoad {
   [super viewDidLoad];

--- a/Examples/Example-macOS/Source/AppDelegate.h
+++ b/Examples/Example-macOS/Source/AppDelegate.h
@@ -25,7 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @class AppDelegate
     @brief The example application's delegate.
  */
-@interface AppDelegate : NSObject <NSApplicationDelegate>
+@interface AppDelegate : NSObject <NSApplicationDelegate> {
+  // property variables
+  NSWindow *_window;
+  id<OIDAuthorizationFlowSession> _currentAuthorizationFlow;
+}
 
 /*! @property currentAuthorizationFlow
     @brief The authorization flow session which receives the return URL from the browser.
@@ -33,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
         incoming URL. This property will be nil, except when an authorization flow is in progress.
  */
 @property(nonatomic, strong, nullable) id<OIDAuthorizationFlowSession> currentAuthorizationFlow;
+
+@property(nullable) IBOutlet NSWindow *window;
 
 @end
 

--- a/Examples/Example-macOS/Source/AppDelegate.m
+++ b/Examples/Example-macOS/Source/AppDelegate.m
@@ -24,11 +24,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface AppDelegate ()
-@property(nullable) IBOutlet NSWindow *window;
-@end
-
 @implementation AppDelegate
+
+@synthesize window = _window;
+@synthesize currentAuthorizationFlow = _currentAuthorizationFlow;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   _window.title = @"AppAuth Example for macOS";

--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -51,7 +51,30 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
 /*! @brief A convenience class that retains the auth state between @c OIDAuthorizationResponse%s
         and @c OIDTokenResponse%s.
  */
-@interface OIDAuthState : NSObject <NSSecureCoding>
+@interface OIDAuthState : NSObject <NSSecureCoding> {
+  // private variables
+  /*! @brief Array of pending actions (use @c _pendingActionsSyncObject to synchronize access).
+   */
+  NSMutableArray *_pendingActions;
+
+  /*! @brief Object for synchronizing access to @c pendingActions.
+   */
+  id _pendingActionsSyncObject;
+
+  /*! @brief If YES, tokens will be refreshed on the next API call regardless of expiry.
+   */
+  BOOL _needsTokenRefresh;
+
+  // property variables
+  NSString *_refreshToken;
+  NSString *_scope;
+  OIDAuthorizationResponse *_lastAuthorizationResponse;
+  OIDTokenResponse *_lastTokenResponse;
+  OIDRegistrationResponse *_lastRegistrationResponse;
+  NSError *_authorizationError;
+  __weak id<OIDAuthStateChangeDelegate> _stateChangeDelegate;
+  __weak id<OIDAuthStateErrorDelegate> _errorDelegate;
+}
 
 /*! @brief The most recent refresh token received from the server.
     @discussion Rather than using this property directly, you should call

--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -87,19 +87,16 @@ static const NSUInteger kExpiryTimeTolerance = 60;
 @end
 
 
-@implementation OIDAuthState {
-  /*! @brief Array of pending actions (use @c _pendingActionsSyncObject to synchronize access).
-   */
-  NSMutableArray *_pendingActions;
+@implementation OIDAuthState
 
-  /*! @brief Object for synchronizing access to @c pendingActions.
-   */
-  id _pendingActionsSyncObject;
-
-  /*! @brief If YES, tokens will be refreshed on the next API call regardless of expiry.
-   */
-  BOOL _needsTokenRefresh;
-}
+@synthesize refreshToken = _refreshToken;
+@synthesize scope = _scope;
+@synthesize lastAuthorizationResponse = _lastAuthorizationResponse;
+@synthesize lastTokenResponse = _lastTokenResponse;
+@synthesize lastRegistrationResponse = _lastRegistrationResponse;
+@synthesize authorizationError = _authorizationError;
+@synthesize stateChangeDelegate = _stateChangeDelegate;
+@synthesize errorDelegate = _errorDelegate;
 
 #pragma mark - Convenience initializers
 

--- a/Source/OIDAuthorizationRequest.h
+++ b/Source/OIDAuthorizationRequest.h
@@ -37,7 +37,20 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
     @see https://tools.ietf.org/html/rfc6749#section-4
     @see https://tools.ietf.org/html/rfc6749#section-4.1.1
  */
-@interface OIDAuthorizationRequest : NSObject <NSCopying, NSSecureCoding>
+@interface OIDAuthorizationRequest : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  OIDServiceConfiguration *_configuration;
+  NSString *_responseType;
+  NSString *_clientID;
+  NSString *_clientSecret;
+  NSString *_scope;
+  NSURL *_redirectURL;
+  NSString *_state;
+  NSString *_codeVerifier;
+  NSString *_codeChallenge;
+  NSString *_codeChallengeMethod;
+  NSDictionary<NSString *, NSString *> *_additionalParameters;
+}
 
 /*! @brief The service's configuration.
     @remarks This configuration specifies how to connect to a particular OAuth provider.

--- a/Source/OIDAuthorizationRequest.m
+++ b/Source/OIDAuthorizationRequest.m
@@ -92,6 +92,18 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
 
 @implementation OIDAuthorizationRequest
 
+@synthesize configuration = _configuration;
+@synthesize responseType = _responseType;
+@synthesize clientID = _clientID;
+@synthesize clientSecret = _clientSecret;
+@synthesize scope = _scope;
+@synthesize redirectURL = _redirectURL;
+@synthesize state = _state;
+@synthesize codeVerifier = _codeVerifier;
+@synthesize codeChallenge = _codeChallenge;
+@synthesize codeChallengeMethod = _codeChallengeMethod;
+@synthesize additionalParameters = _additionalParameters;
+
 - (instancetype)init
     OID_UNAVAILABLE_USE_INITIALIZER(
         @selector(initWithConfiguration:

--- a/Source/OIDAuthorizationResponse.h
+++ b/Source/OIDAuthorizationResponse.h
@@ -28,7 +28,18 @@ NS_ASSUME_NONNULL_BEGIN
     @see https://tools.ietf.org/html/rfc6749#section-5.1
     @see http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse
  */
-@interface OIDAuthorizationResponse : NSObject <NSCopying, NSSecureCoding>
+@interface OIDAuthorizationResponse : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  OIDAuthorizationRequest *_request;
+  NSString *_authorizationCode;
+  NSString *_state;
+  NSString *_accessToken;
+  NSDate *_accessTokenExpirationDate;
+  NSString *_tokenType;
+  NSString *_idToken;
+  NSString *_scope;
+  NSDictionary<NSString *, NSObject<NSCopying> *> *_additionalParameters;
+}
 
 /*! @brief The request which was serviced.
  */

--- a/Source/OIDAuthorizationResponse.m
+++ b/Source/OIDAuthorizationResponse.m
@@ -73,6 +73,16 @@ static NSString *const kTokenExchangeRequestException =
 
 @implementation OIDAuthorizationResponse
 
+@synthesize request = _request;
+@synthesize authorizationCode = _authorizationCode;
+@synthesize state = _state;
+@synthesize accessToken = _accessToken;
+@synthesize accessTokenExpirationDate = _accessTokenExpirationDate;
+@synthesize tokenType = _tokenType;
+@synthesize idToken = _idToken;
+@synthesize scope = _scope;
+@synthesize additionalParameters = _additionalParameters;
+
 /*! @brief Returns a mapping of incoming parameters to instance variables.
     @return A mapping of incoming parameters to instance variables.
  */

--- a/Source/OIDAuthorizationService.h
+++ b/Source/OIDAuthorizationService.h
@@ -71,7 +71,10 @@ typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable reg
 /*! @brief Performs various OAuth and OpenID Connect related calls via the user agent or
         \NSURLSession.
  */
-@interface OIDAuthorizationService : NSObject
+@interface OIDAuthorizationService : NSObject {
+  // property variables
+  OIDServiceConfiguration *_configuration;
+}
 
 /*! @brief The service's configuration.
     @remarks Each authorization service is initialized with a configuration. This configuration

--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -42,7 +42,12 @@ static NSString *const kStateParameter = @"state";
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OIDAuthorizationFlowSessionImplementation : NSObject<OIDAuthorizationFlowSession>
+@interface OIDAuthorizationFlowSessionImplementation : NSObject<OIDAuthorizationFlowSession> {
+  // private variables
+  OIDAuthorizationRequest *_request;
+  id<OIDAuthorizationUICoordinator> _UICoordinator;
+  OIDAuthorizationCallback _pendingauthorizationFlowCallback;
+}
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -51,11 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation OIDAuthorizationFlowSessionImplementation {
-  OIDAuthorizationRequest *_request;
-  id<OIDAuthorizationUICoordinator> _UICoordinator;
-  OIDAuthorizationCallback _pendingauthorizationFlowCallback;
-}
+@implementation OIDAuthorizationFlowSessionImplementation
 
 - (instancetype)initWithRequest:(OIDAuthorizationRequest *)request {
   self = [super init];
@@ -175,6 +176,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation OIDAuthorizationService
+
+@synthesize configuration = _configuration;
 
 + (void)discoverServiceConfigurationForIssuer:(NSURL *)issuerURL
                                    completion:(OIDDiscoveryCallback)completion {

--- a/Source/OIDFieldMapping.h
+++ b/Source/OIDFieldMapping.h
@@ -28,7 +28,12 @@ typedef _Nullable id(^OIDFieldMappingConversionFunction)(NSObject *_Nullable val
 /*! @brief Describes the mapping of a key/value pair to an iVar with an optional conversion
         function.
  */
-@interface OIDFieldMapping : NSObject
+@interface OIDFieldMapping : NSObject {
+  // property variables
+  NSString *_name;
+  Class _expectedType;
+  OIDFieldMappingConversionFunction _conversion;
+}
 
 /*! @brief The name of the instance variable the field should be mapped to.
  */

--- a/Source/OIDFieldMapping.m
+++ b/Source/OIDFieldMapping.m
@@ -22,6 +22,10 @@
 
 @implementation OIDFieldMapping
 
+@synthesize name = _name;
+@synthesize expectedType = _expectedType;
+@synthesize conversion = _conversion;
+
 - (nonnull instancetype)init
     OID_UNAVAILABLE_USE_INITIALIZER(@selector(initWithName:type:conversion:));
 

--- a/Source/OIDRegistrationRequest.h
+++ b/Source/OIDRegistrationRequest.h
@@ -26,7 +26,17 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief Represents a registration request.
     @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationRequest
  */
-@interface OIDRegistrationRequest : NSObject <NSCopying, NSSecureCoding>
+@interface OIDRegistrationRequest : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  OIDServiceConfiguration *_configuration;
+  NSString *_applicationType;
+  NSArray<NSURL *> *_redirectURIs;
+  NSArray<NSString *> *_responseTypes;
+  NSArray<NSString *> *_grantTypes;
+  NSString *_subjectType;
+  NSString *_tokenEndpointAuthenticationMethod;
+  NSDictionary<NSString *, NSString *> *_additionalParameters;
+}
 
 /*! @brief The service's configuration.
     @remarks This configuration specifies how to connect to a particular OAuth provider.

--- a/Source/OIDRegistrationRequest.m
+++ b/Source/OIDRegistrationRequest.m
@@ -49,6 +49,15 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
 @implementation OIDRegistrationRequest
 
+@synthesize configuration = _configuration;
+@synthesize applicationType = _applicationType;
+@synthesize redirectURIs = _redirectURIs;
+@synthesize responseTypes = _responseTypes;
+@synthesize grantTypes = _grantTypes;
+@synthesize subjectType = _subjectType;
+@synthesize tokenEndpointAuthenticationMethod = _tokenEndpointAuthenticationMethod;
+@synthesize additionalParameters = _additionalParameters;
+
 #pragma mark - Initializers
 
 - (instancetype)init

--- a/Source/OIDRegistrationResponse.h
+++ b/Source/OIDRegistrationResponse.h
@@ -50,7 +50,18 @@ extern NSString *const OIDRegistrationClientURIParam;
 /*! @brief Represents a registration response.
     @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
  */
-@interface OIDRegistrationResponse : NSObject <NSCopying, NSSecureCoding>
+@interface OIDRegistrationResponse : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  OIDRegistrationRequest *_request;
+  NSString *_clientID;
+  NSDate *_clientIDIssuedAt;
+  NSString *_clientSecret;
+  NSDate *_clientSecretExpiresAt;
+  NSString *_registrationAccessToken;
+  NSURL *_registrationClientURI;
+  NSString *_tokenEndpointAuthenticationMethod;
+  NSDictionary<NSString *, NSObject <NSCopying> *> *_additionalParameters;
+}
 
 /*! @brief The request which was serviced.
  */

--- a/Source/OIDRegistrationResponse.m
+++ b/Source/OIDRegistrationResponse.m
@@ -40,6 +40,16 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
 @implementation OIDRegistrationResponse
 
+@synthesize request = _request;
+@synthesize clientID = _clientID;
+@synthesize clientIDIssuedAt = _clientIDIssuedAt;
+@synthesize clientSecret = _clientSecret;
+@synthesize clientSecretExpiresAt = _clientSecretExpiresAt;
+@synthesize registrationAccessToken = _registrationAccessToken;
+@synthesize registrationClientURI = _registrationClientURI;
+@synthesize tokenEndpointAuthenticationMethod = _tokenEndpointAuthenticationMethod;
+@synthesize additionalParameters = _additionalParameters;
+
 /*! @brief Returns a mapping of incoming parameters to instance variables.
     @return A mapping of incoming parameters to instance variables.
  */

--- a/Source/OIDServiceConfiguration.h
+++ b/Source/OIDServiceConfiguration.h
@@ -32,7 +32,13 @@ typedef void (^OIDServiceConfigurationCreated)
 
 /*! @brief Represents the information needed to construct a @c OIDAuthorizationService.
  */
-@interface OIDServiceConfiguration : NSObject <NSCopying, NSSecureCoding>
+@interface OIDServiceConfiguration : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  NSURL *_authorizationEndpoint;
+  NSURL *_tokenEndpoint;
+  NSURL *_registrationEndpoint;
+  OIDServiceDiscovery *_discoveryDocument;
+}
 
 /*! @brief The authorization endpoint URI.
  */

--- a/Source/OIDServiceConfiguration.m
+++ b/Source/OIDServiceConfiguration.m
@@ -52,6 +52,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OIDServiceConfiguration
 
+@synthesize authorizationEndpoint = _authorizationEndpoint;
+@synthesize tokenEndpoint = _tokenEndpoint;
+@synthesize registrationEndpoint = _registrationEndpoint;
+@synthesize discoveryDocument = _discoveryDocument;
+
 - (instancetype)init
     OID_UNAVAILABLE_USE_INITIALIZER(@selector(
         initWithAuthorizationEndpoint:

--- a/Source/OIDServiceDiscovery.h
+++ b/Source/OIDServiceDiscovery.h
@@ -23,7 +23,10 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief Represents an OpenID Connect 1.0 Discovery Document
     @see https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
  */
-@interface OIDServiceDiscovery : NSObject <NSCopying, NSSecureCoding>
+@interface OIDServiceDiscovery : NSObject <NSCopying, NSSecureCoding> {
+  // private variables
+  NSDictionary *_discoveryDictionary;
+}
 
 /*! @brief The decoded OpenID Connect 1.0 Discovery Document as a dictionary.
  */

--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -71,9 +71,7 @@ static NSString *const kRequireRequestURIRegistrationKey = @"require_request_uri
 static NSString *const kOPPolicyURIKey = @"op_policy_uri";
 static NSString *const kOPTosURIKey = @"op_tos_uri";
 
-@implementation OIDServiceDiscovery {
-  NSDictionary *_discoveryDictionary;
-}
+@implementation OIDServiceDiscovery
 
 - (nonnull instancetype)init OID_UNAVAILABLE_USE_INITIALIZER(@selector(initWithDictionary:error:));
 

--- a/Source/OIDTokenRequest.h
+++ b/Source/OIDTokenRequest.h
@@ -31,7 +31,19 @@ NS_ASSUME_NONNULL_BEGIN
     @see https://tools.ietf.org/html/rfc6749#section-3.2
     @see https://tools.ietf.org/html/rfc6749#section-4.1.3
  */
-@interface OIDTokenRequest : NSObject <NSCopying, NSSecureCoding>
+@interface OIDTokenRequest : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  OIDServiceConfiguration *_configuration;
+  NSString *_grantType;
+  NSString *_authorizationCode;
+  NSURL *_redirectURL;
+  NSString *_clientID;
+  NSString *_clientSecret;
+  NSString *_scope;
+  NSString *_refreshToken;
+  NSString *_codeVerifier;
+  NSDictionary<NSString *, NSString *> *_additionalParameters;
+}
 
 /*! @brief The service's configuration.
     @remarks This configuration specifies how to connect to a particular OAuth provider.

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -67,6 +67,17 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
 @implementation OIDTokenRequest
 
+@synthesize configuration = _configuration;
+@synthesize grantType = _grantType;
+@synthesize authorizationCode = _authorizationCode;
+@synthesize redirectURL = _redirectURL;
+@synthesize clientID = _clientID;
+@synthesize clientSecret = _clientSecret;
+@synthesize scope = _scope;
+@synthesize refreshToken = _refreshToken;
+@synthesize codeVerifier = _codeVerifier;
+@synthesize additionalParameters = _additionalParameters;
+
 - (instancetype)init
     OID_UNAVAILABLE_USE_INITIALIZER(
         @selector(initWithConfiguration:

--- a/Source/OIDTokenResponse.h
+++ b/Source/OIDTokenResponse.h
@@ -26,7 +26,17 @@ NS_ASSUME_NONNULL_BEGIN
     @see https://tools.ietf.org/html/rfc6749#section-3.2
     @see https://tools.ietf.org/html/rfc6749#section-4.1.3
  */
-@interface OIDTokenResponse : NSObject <NSCopying, NSSecureCoding>
+@interface OIDTokenResponse : NSObject <NSCopying, NSSecureCoding> {
+  // property variables
+  OIDTokenRequest *_request;
+  NSString *_accessToken;
+  NSDate *_accessTokenExpirationDate;
+  NSString *_tokenType;
+  NSString *_idToken;
+  NSString *_refreshToken;
+  NSString *_scope;
+  NSDictionary<NSString *, NSObject<NSCopying> *> *_additionalParameters;
+}
 
 /*! @brief The request which was serviced.
  */

--- a/Source/OIDTokenResponse.m
+++ b/Source/OIDTokenResponse.m
@@ -60,6 +60,15 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
 @implementation OIDTokenResponse
 
+@synthesize request = _request;
+@synthesize accessToken = _accessToken;
+@synthesize accessTokenExpirationDate = _accessTokenExpirationDate;
+@synthesize tokenType = _tokenType;
+@synthesize idToken = _idToken;
+@synthesize refreshToken = _refreshToken;
+@synthesize scope = _scope;
+@synthesize additionalParameters = _additionalParameters;
+
 /*! @brief Returns a mapping of incoming parameters to instance variables.
     @return A mapping of incoming parameters to instance variables.
  */

--- a/Source/OIDURLQueryComponent.h
+++ b/Source/OIDURLQueryComponent.h
@@ -30,7 +30,12 @@ extern BOOL gOIDURLQueryComponentForceIOS7Handling;
 
 /*! @brief A utility class for creating and parsing URL query components.
  */
-@interface OIDURLQueryComponent : NSObject
+@interface OIDURLQueryComponent : NSObject {
+  // private variables
+  /*! @brief A dictionary of parameter names and values representing the contents of the query.
+   */
+  NSMutableDictionary<NSString *, NSMutableArray<NSString *> *> *_parameters;
+}
 
 /*! @brief The parameter names in the query.
  */

--- a/Source/OIDURLQueryComponent.m
+++ b/Source/OIDURLQueryComponent.m
@@ -26,11 +26,7 @@ BOOL gOIDURLQueryComponentForceIOS7Handling = NO;
  */
 static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
 
-@implementation OIDURLQueryComponent {
-  /*! @brief A dictionary of parameter names and values representing the contents of the query.
-   */
-  NSMutableDictionary<NSString *, NSMutableArray<NSString *> *> *_parameters;
-}
+@implementation OIDURLQueryComponent
 
 - (nullable instancetype)init {
   self = [super init];

--- a/Source/macOS/OIDAuthorizationUICoordinatorMac.h
+++ b/Source/macOS/OIDAuthorizationUICoordinatorMac.h
@@ -23,7 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief An Mac specific authorization UI Coordinator that uses the default browser to
         present an authorization request.
  */
-@interface OIDAuthorizationUICoordinatorMac : NSObject <OIDAuthorizationUICoordinator>
+@interface OIDAuthorizationUICoordinatorMac : NSObject <OIDAuthorizationUICoordinator> {
+  // private variables
+  BOOL _authorizationFlowInProgress;
+  __weak id<OIDAuthorizationFlowSession> _session;
+}
 
 @end
 

--- a/Source/macOS/OIDAuthorizationUICoordinatorMac.m
+++ b/Source/macOS/OIDAuthorizationUICoordinatorMac.m
@@ -25,10 +25,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation OIDAuthorizationUICoordinatorMac {
-  BOOL _authorizationFlowInProgress;
-  __weak id<OIDAuthorizationFlowSession> _session;
-}
+@implementation OIDAuthorizationUICoordinatorMac
 
 - (BOOL)presentAuthorizationWithURL:(NSURL *)URL session:(id<OIDAuthorizationFlowSession>)session {
   if (_authorizationFlowInProgress) {

--- a/Source/macOS/OIDRedirectHTTPHandler.h
+++ b/Source/macOS/OIDRedirectHTTPHandler.h
@@ -20,12 +20,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class HTTPServer;
 @protocol OIDAuthorizationFlowSession;
 
 /*! @brief Start a HTTP server on the loopback interface (i.e. @c 127.0.0.1) to receive OAuth
         authorization response redirects on macOS.
  */
-@interface OIDRedirectHTTPHandler : NSObject
+@interface OIDRedirectHTTPHandler : NSObject {
+  // private variables
+  HTTPServer *_httpServ;
+  NSURL *_successURL;
+  // property variables
+  NSObject<OIDAuthorizationFlowSession> *_currentAuthorizationFlow;
+}
 
 /*! @brief The authorization flow session which receives the return URL from the browser.
     @discussion The loopback HTTP server will try sending incoming request URLs to the OAuth

--- a/Source/macOS/OIDRedirectHTTPHandler.m
+++ b/Source/macOS/OIDRedirectHTTPHandler.m
@@ -46,10 +46,9 @@ static NSString *const kHTMLErrorMissingCurrentAuthorizationFlow =
 static NSString *const kHTMLErrorRedirectNotValid =
     @"<html><body>AppAuth Error: Not a valid redirect.</body></html>";
 
-@implementation OIDRedirectHTTPHandler {
-  HTTPServer *_httpServ;
-  NSURL *_successURL;
-}
+@implementation OIDRedirectHTTPHandler
+
+@synthesize currentAuthorizationFlow = _currentAuthorizationFlow;
 
 - (instancetype)init {
   return [self initWithSuccessURL:nil];

--- a/UnitTests/OIDAuthStateTests.h
+++ b/UnitTests/OIDAuthStateTests.h
@@ -27,7 +27,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! @brief Unit tests for @c OIDAuthState.
  */
-@interface OIDAuthStateTests : XCTestCase
+@interface OIDAuthStateTests : XCTestCase {
+  // private variables
+  /*! @brief An expectation for tests waiting on OIDAuthStateChangeDelegate.didChangeState:.
+   */
+  XCTestExpectation *_didChangeStateExpectation;
+
+  /*! @brief An expectation for tests waiting on
+          OIDAuthStateErrorDelegate.didEncounterAuthorizationError:.
+   */
+  XCTestExpectation *_didEncounterAuthorizationErrorExpectation;
+
+  /*! @brief An expectation for tests waiting on
+          OIDAuthStateErrorDelegate.didEncounterTransientError:.
+   */
+  XCTestExpectation *_didEncounterTransientErrorExpectation;
+}
 
 /*! @brief Creates a new @c OIDAuthState for testing.
  */

--- a/UnitTests/OIDAuthStateTests.m
+++ b/UnitTests/OIDAuthStateTests.m
@@ -36,21 +36,7 @@
 @interface OIDAuthStateTests () <OIDAuthStateChangeDelegate, OIDAuthStateErrorDelegate>
 @end
 
-@implementation OIDAuthStateTests {
-  /*! @brief An expectation for tests waiting on OIDAuthStateChangeDelegate.didChangeState:.
-   */
-  XCTestExpectation *_didChangeStateExpectation;
-
-  /*! @brief An expectation for tests waiting on
-          OIDAuthStateErrorDelegate.didEncounterAuthorizationError:.
-   */
-  XCTestExpectation *_didEncounterAuthorizationErrorExpectation;
-
-  /*! @brief An expectation for tests waiting on
-          OIDAuthStateErrorDelegate.didEncounterTransientError:.
-   */
-  XCTestExpectation *_didEncounterTransientErrorExpectation;
-}
+@implementation OIDAuthStateTests
 
 + (OIDAuthState *)testInstance {
   OIDAuthorizationResponse *authorizationResponse =

--- a/UnitTests/OIDServiceConfigurationTests.h
+++ b/UnitTests/OIDServiceConfigurationTests.h
@@ -24,7 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! @brief Unit tests for @c OIDServiceConfiguration.
  */
-@interface OIDServiceConfigurationTests : XCTestCase
+@interface OIDServiceConfigurationTests : XCTestCase {
+  // private variables
+  /*! @brief A list of tasks to perform during tearDown.
+   */
+  NSMutableArray *_teardownTasks;
+}
 
 /*! @brief Creates a new @c OIDServiceConfiguration for testing.
  */

--- a/UnitTests/OIDServiceConfigurationTests.m
+++ b/UnitTests/OIDServiceConfigurationTests.m
@@ -76,11 +76,7 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
     @"https://accounts.google.com/.well-known/openid-configuration";
 
 
-@implementation OIDServiceConfigurationTests {
-  /*! @brief A list of tasks to perform during tearDown.
-   */
-  NSMutableArray<TeardownTask> *_teardownTasks;
-}
+@implementation OIDServiceConfigurationTests
 
 + (OIDServiceConfiguration *)testInstance {
   NSURL *authEndpoint = [NSURL URLWithString:kInitializerTestAuthEndpoint];


### PR DESCRIPTION
Support of the legacy Objective-C Runtime by:
– Manually synthesized properties.
– Manually declared ivars
– Moved ivars from implementation to header.