### PR TITLE
State parameter mismatch

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -36,9 +36,6 @@
  */
 static NSString *const kOpenIDConfigurationWellKnownPath = @".well-known/openid-configuration";
 
-/*! @brief The state authorization parameter.
- */
-static NSString *const kStateParameter = @"state";
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -126,25 +123,25 @@ NS_ASSUME_NONNULL_BEGIN
                                     underlyingError:nil];
   }
 
-  // verifies that the state in the response matches the state in the request, or both are nil
-  if (!OIDIsEqualIncludingNil(_request.state, query.dictionaryValue[kStateParameter])) {
-    NSMutableDictionary *userInfo = [query.dictionaryValue mutableCopy];
-    userInfo[NSLocalizedDescriptionKey] =
-        [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
-                                    "response %@",
-                                   _request.state,
-                                   response.state,
-                                   response];
-    response = nil;
-    error = [NSError errorWithDomain:OIDOAuthAuthorizationErrorDomain
-                                code:OIDErrorCodeOAuthAuthorizationClientError
-                            userInfo:userInfo];
-  }
-
   // no error, should be a valid OAuth 2.0 response
   if (!error) {
     response = [[OIDAuthorizationResponse alloc] initWithRequest:_request
                                                       parameters:query.dictionaryValue];
+      
+    // verifies that the state in the response matches the state in the request, or both are nil
+    if (!OIDIsEqualIncludingNil(_request.state, response.state)) {
+      NSMutableDictionary *userInfo = [query.dictionaryValue mutableCopy];
+      userInfo[NSLocalizedDescriptionKey] =
+        [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
+                                   "response %@",
+                                   _request.state,
+                                   response.state,
+                                   response];
+      response = nil;
+      error = [NSError errorWithDomain:OIDOAuthAuthorizationErrorDomain
+                                  code:OIDErrorCodeOAuthAuthorizationClientError
+                              userInfo:userInfo];
+      }
   }
 
   [_UICoordinator dismissAuthorizationAnimated:YES


### PR DESCRIPTION
In case of “state” parameter mismatch between request and response, the
generated error was not populated with the right information. Also, the
OAuth 2 response is “valid” regardless of the state parameter so it
makes sense to create the response object before checking for the state
parameter.