### PR TITLE
-[HTTPServer start:] will no longer fail if it can't bind an IPv6 socket

### DIFF
--- a/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
+++ b/Source/macOS/LoopbackHTTPServer/OIDLoopbackHTTPServer.h
@@ -72,6 +72,9 @@ typedef enum {
 - (BOOL)start:(NSError **)error;
 - (BOOL)stop;
 
+- (BOOL)hasIPv4Socket;
+- (BOOL)hasIPv6Socket;
+
 // called when a new connection comes in; by default, informs the delegate
 - (void)handleNewConnectionFromAddress:(NSData *)addr
                            inputStream:(NSInputStream *)istr

--- a/Source/macOS/OIDRedirectHTTPHandler.m
+++ b/Source/macOS/OIDRedirectHTTPHandler.m
@@ -76,10 +76,17 @@ static NSString *const kHTMLErrorRedirectNotValid =
       *returnError = error;
     }
     return nil;
-  } else {
+  } else if ([_httpServ hasIPv4Socket]) {
+    // Prefer the IPv4 loopback address
     NSString *serverURL = [NSString stringWithFormat:@"http://127.0.0.1:%d/", [_httpServ port]];
     return [NSURL URLWithString:serverURL];
+  } else if ([_httpServ hasIPv6Socket]) {
+    // Use the IPv6 loopback address if IPv4 isn't available
+    NSString *serverURL = [NSString stringWithFormat:@"http://[::1]:%d/", [_httpServ port]];
+    return [NSURL URLWithString:serverURL];
   }
+
+  return nil;
 }
 
 - (void)cancelHTTPListener {


### PR DESCRIPTION
We had a user with IPv6 completely disabled (on Mac), which was causing `-[HTTPServer start:]` to fail.
Since only the IPv4 loopback address is used, I've made `start:` succeed even if it can't bind an IPv6 socket.

I also added the option of using the IPv6 loopback address (`::1`) in the future if iPv6 should be preferred over IPv4.