### PR TITLE
Fix for Issue #105

### DIFF
--- a/Source/OIDError.h
+++ b/Source/OIDError.h
@@ -378,8 +378,4 @@ typedef NS_ENUM(NSInteger, OIDErrorCodeOAuthRegistration) {
  */
 extern NSString *const OIDOAuthExceptionInvalidAuthorizationFlow;
 
-/*! @brief Exception for unsupported response types.
- */
-extern NSString *const OIDOAuthExceptionUnsupportedResponseType;
-
 NS_ASSUME_NONNULL_END

--- a/Source/OIDError.m
+++ b/Source/OIDError.m
@@ -33,8 +33,6 @@ NSString *const OIDHTTPErrorDomain = @"org.openid.appauth.remote-http";
 NSString *const OIDOAuthExceptionInvalidAuthorizationFlow = @"An OAuth redirect was sent to a "
     "OIDAuthorizationFlowSession after it already completed.";
 
-NSString *const OIDOAuthExceptionUnsupportedResponseType = @"Unsupported response type";
-
 NSString *const OIDOAuthErrorResponseErrorKey = @"OIDOAuthErrorResponseErrorKey";
 
 NSString *const OIDOAuthErrorFieldError = @"error";


### PR DESCRIPTION
This is a fix for Issue #105 

Summarizing Findings:

- Root cause is in GTMAppAuth.
- Which is synthesizing an OIDTokenRequest with grant type "token" when it should be "refresh_token".
- And which is synthesizing an OIDAuthorizationRequest with response type "token" when it should be "code".
- Fixing root cause is a necessary, but not a sufficient, fix for this problem.
- Existing clients have incorrect OIDAuthorizationRequest instances stored in their keychains as a result of the root cause issue.
- Apps which upgraded to a version of AppAuth-iOS after March 25th when PR #99 was merged into master, who had clients with GTMOAuth2Touch, will be experiencing crashes for the reasons reported in this issue.
- GTMAppAuth will be fixed in a separate issue.
- A workaround will be applied here.

The workaround is as follows:

- We are 'guaranteeing' via the designated initializer that we can only ever have "OIDAuthorizationRequest" instances with response type of "code".
- The value of the field is never mutated.
- QED, it's relatively safe to assume the value must have been @"code" at deserialization time.

The risk here is that, if some point in time, we relax the requirement in the initializer, that we'll have broken deserialization code. A simple comment addresses that concern.

Having said all that, and with the benefit of hindsight, I believe throwing an exception, while a completely reasonable approach, was probably not the best approach. I propose an alternative here.

Using an assertion instead of an exception has the following benefits:

- It preserves the intention of the original change; to alert the developer they're probably doing something wrong.
- When building for the app store, assertions are often disabled - therefore we don't force the app to crash (which can be very rude! You shouldn't assume this sort of error is 'the end of the world'.)
- We return nil in the case where assertions are disabled to indicate we weren't able to satisfy the request - which is the appropriate runtime response to such a condition when the application is not under developer control (exceptions should never be used to control logic)
- I don't feel it's necessary to update the initializer's nullability (again) because this should represent a developer error anyways. If someone felt strongly that this warranted changing the declaration back to nullable, I'm willing.

All tests are still passing on iOS.
