### PR TITLE
Support for SFAuthenticationSession in iOS 11.

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -70,8 +70,8 @@ NS_ASSUME_NONNULL_BEGIN
                                    callback:(OIDAuthorizationCallback)authorizationFlowCallback {
   _UICoordinator = UICoordinator;
   _pendingauthorizationFlowCallback = authorizationFlowCallback;
-  NSURL *URL = [_request authorizationRequestURL];
-  BOOL authorizationFlowStarted = [_UICoordinator presentAuthorizationWithURL:URL session:self];
+  BOOL authorizationFlowStarted =
+      [_UICoordinator presentAuthorizationRequest:_request session:self];
   if (!authorizationFlowStarted) {
     NSError *safariError = [OIDErrorUtilities errorWithCode:OIDErrorCodeSafariOpenError
                                             underlyingError:nil

--- a/Source/OIDAuthorizationUICoordinator.h
+++ b/Source/OIDAuthorizationUICoordinator.h
@@ -18,6 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
+@class OIDAuthorizationRequest;
 @protocol OIDAuthorizationFlowSession;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -29,15 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol OIDAuthorizationUICoordinator<NSObject>
 
-/*! @brief Presents the authorization UI for the given URL.
-    @param URL The URL that should be used when presenting the authorization UI.
+/*! @brief Presents the authroization request in the user agent.
+    @param request The authorizatoin request to be presented in the user agent.
     @param session The @c OIDAuthorizationFlowSession instance that initiates presenting the
         authorization UI. Concrete implementations of a @c OIDAuthorizationUICoordinator may call
         resumeAuthorizationFlowWithURL or failAuthorizationFlowWithError on session to either
         resume or fail the authorization.
     @return YES If the authorization UI was successfully presented to the user.
  */
-- (BOOL)presentAuthorizationWithURL:(NSURL *)URL session:(id<OIDAuthorizationFlowSession>)session;
+- (BOOL)presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+                            session:(id<OIDAuthorizationFlowSession>)session;
 
 /*! @brief Dimisses the authorization UI and calls completion when the dismiss operation ends.
     @param animated Wheter or not the dismiss operation should be animated.

--- a/Source/iOS/OIDAuthorizationUICoordinatorIOS.m
+++ b/Source/iOS/OIDAuthorizationUICoordinatorIOS.m
@@ -20,6 +20,7 @@
 
 #import <SafariServices/SafariServices.h>
 
+#import "OIDAuthorizationRequest.h"
 #import "OIDAuthorizationService.h"
 #import "OIDErrorUtilities.h"
 
@@ -45,6 +46,9 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   BOOL _authorizationFlowInProgress;
   __weak id<OIDAuthorizationFlowSession> _session;
   __weak SFSafariViewController *_safariVC;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+  SFAuthenticationSession *_authenticationVC;
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
 }
 
 /** @brief Obtains the current @c OIDSafariViewControllerFactory; creating a new default instance if
@@ -71,7 +75,8 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   return self;
 }
 
-- (BOOL)presentAuthorizationWithURL:(NSURL *)URL session:(id<OIDAuthorizationFlowSession>)session {
+- (BOOL)presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+                            session:(id<OIDAuthorizationFlowSession>)session {
   if (_authorizationFlowInProgress) {
     // TODO: Handle errors as authorization is already in progress.
     return NO;
@@ -79,15 +84,44 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
 
   _authorizationFlowInProgress = YES;
   _session = session;
-  if ([SFSafariViewController class]) {
-    SFSafariViewController *safariVC =
-        [[[self class] safariViewControllerFactory] safariViewControllerWithURL:URL];
-    safariVC.delegate = self;
-    _safariVC = safariVC;
-    [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
-    return YES;
+  BOOL openedSafari = NO;
+  NSURL *requestURL = [request authorizationRequestURL];
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+  if (@available(iOS 11.0, *)) {
+    NSString *redirectScheme = request.redirectURL.scheme;
+    SFAuthenticationSession* authenticationVC =
+        [[SFAuthenticationSession alloc] initWithURL:requestURL
+                                   callbackURLScheme:redirectScheme
+                                   completionHandler:^(NSURL * _Nullable callbackURL,
+                                                       NSError * _Nullable error) {
+      _authenticationVC = nil;
+      if (callbackURL) {
+        [_session resumeAuthorizationFlowWithURL:callbackURL];
+      } else {
+        NSError *safariError =
+            [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+                             underlyingError:error
+                                 description:nil];
+        [_session failAuthorizationFlowWithError:safariError];
+      }
+    }];
+    _authenticationVC = authenticationVC;
+    openedSafari = [authenticationVC start];
+  } else
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+  {
+    if ([SFSafariViewController class]) {
+      SFSafariViewController *safariVC =
+      [[[self class] safariViewControllerFactory] safariViewControllerWithURL:requestURL];
+      safariVC.delegate = self;
+      _safariVC = safariVC;
+      [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
+      return YES;
+    }
+    openedSafari = [[UIApplication sharedApplication] openURL:requestURL];
   }
-  BOOL openedSafari = [[UIApplication sharedApplication] openURL:URL];
+
   if (!openedSafari) {
     [self cleanUp];
     NSError *safariError = [OIDErrorUtilities errorWithCode:OIDErrorCodeSafariOpenError

--- a/Source/macOS/OIDAuthorizationUICoordinatorMac.m
+++ b/Source/macOS/OIDAuthorizationUICoordinatorMac.m
@@ -20,6 +20,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+#import "OIDAuthorizationRequest.h"
 #import "OIDAuthorizationService.h"
 #import "OIDErrorUtilities.h"
 
@@ -27,7 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OIDAuthorizationUICoordinatorMac
 
-- (BOOL)presentAuthorizationWithURL:(NSURL *)URL session:(id<OIDAuthorizationFlowSession>)session {
+- (BOOL)presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+                            session:(id<OIDAuthorizationFlowSession>)session {
   if (_authorizationFlowInProgress) {
     // TODO: Handle errors as authorization is already in progress.
     return NO;
@@ -35,7 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   _authorizationFlowInProgress = YES;
   _session = session;
-  BOOL openedBrowser = [[NSWorkspace sharedWorkspace] openURL:URL];
+  NSURL *requestURL = [request authorizationRequestURL];
+
+  BOOL openedBrowser = [[NSWorkspace sharedWorkspace] openURL:requestURL];
   if (!openedBrowser) {
     [self cleanUp];
     NSError *safariError = [OIDErrorUtilities errorWithCode:OIDErrorCodeBrowserOpenError


### PR DESCRIPTION
Added support for SFAuthenticationSession to enable SSO with AppAuth in iOS 11.

https://twitter.com/rmondello/status/884458464470343682
https://developer.apple.com/documentation/safariservices/sfauthenticationsession?changes=latest_beta&language=objc