### PR TITLE
Pass authorizationRequest additionalParameters to tokenExchangeRequest

### DIFF
--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -119,7 +119,7 @@ static const NSUInteger kExpiryTimeTolerance = 60;
                                // code is intended for this client, and performs the authorization
                                // code exchange
                                OIDTokenRequest *tokenExchangeRequest =
-                                   [authorizationResponse tokenExchangeRequest];
+                                   [authorizationResponse tokenExchangeRequestWithAdditionalParameters:authorizationRequest.additionalParameters];
                                [OIDAuthorizationService
                                    performTokenRequest:tokenExchangeRequest
                                               callback:^(OIDTokenResponse *_Nullable tokenResponse,


### PR DESCRIPTION
A small change so that any additionalParameters on the authorizationRequest would now also get set on the subsequent tokenExchangeRequest. It seems that this is the way AppAuth-Android already functions.