### PR TITLE
xctool build is broken; use xcodebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: objective-c
 osx_image: xcode9
 xcode_project: AppAuth.xcodeproj
 xcode_scheme: AppAuth-iOS
+before_script:
+  - sudo gem install xcpretty
+script:
+  - xcodebuild -project AppAuth.xcodeproj -scheme "AppAuth-iOS" -sdk iphonesimulator11.0 -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.0' test | xcpretty


### PR DESCRIPTION
Travis uses xctool by default to build and test the project, but
this is currently broken for xcode 9:

https://github.com/facebook/xctool/issues/738

Switch to xcodebuild for now.