### PR TITLE
Removed `scope` from authorization code exchange token request.

### DIFF
--- a/Source/OIDAuthorizationResponse.m
+++ b/Source/OIDAuthorizationResponse.m
@@ -210,7 +210,7 @@ static NSString *const kTokenExchangeRequestException =
                                             redirectURL:_request.redirectURL
                                                clientID:_request.clientID
                                            clientSecret:_request.clientSecret
-                                                  scope:_scope
+                                                  scope:nil
                                            refreshToken:nil
                                            codeVerifier:_request.codeVerifier
                                    additionalParameters:additionalParameters];


### PR DESCRIPTION
Section 4.1.3 of RFC 6749 does not document scope as an allowed parameter.

Fix for #156.