### PR TITLE
Resolved the "-Wpartial-availability" warning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ xcode_scheme: AppAuth-iOS
 before_script:
   - sudo gem install xcpretty
 script:
-  - xcodebuild -project AppAuth.xcodeproj -scheme "AppAuth-iOS" -sdk iphonesimulator11.0 -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.0' -enableCodeCoverage YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES test | xcpretty
+  - xcodebuild -project AppAuth.xcodeproj -scheme "AppAuth-iOS" -sdk iphonesimulator11.0 -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.0' -enableCodeCoverage YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES OTHERCFLAGS="-Werror" test | xcpretty
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -34,11 +34,6 @@ It follows the OAuth 2.0 for Native Apps best current practice
 
   s.source       = { :git => "https://github.com/openid/AppAuth-iOS.git", :tag => s.version }
 
-  s.pod_target_xcconfig = {
-    # Treat warnings as errors.
-    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES',
-  }
-
   s.source_files = "Source/*.{h,m}"
   s.requires_arc = true
 

--- a/Source/OIDURLQueryComponent.m
+++ b/Source/OIDURLQueryComponent.m
@@ -39,30 +39,34 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
 - (nullable instancetype)initWithURL:(NSURL *)URL {
   self = [self init];
   if (self) {
-    if (!gOIDURLQueryComponentForceIOS7Handling && [NSURLQueryItem class]) {
+    if (@available(iOS 8.0, *)) {
       // If NSURLQueryItem is available, use it for deconstructing the new URL. (iOS 8+)
-      NSURLComponents *components =
-          [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
-      NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
-      for (NSURLQueryItem *queryItem in queryItems) {
-        [self addParameter:queryItem.name value:queryItem.value];
-      }
-    } else {
-      // Fallback for iOS 7
-      NSString *query = URL.query;
-      NSArray<NSString *> *queryParts = [query componentsSeparatedByString:@"&"];
-      for (NSString *queryPart in queryParts) {
-        NSRange equalsRange = [queryPart rangeOfString:@"="];
-        if (equalsRange.location == NSNotFound) {
-          continue;
+      if (!gOIDURLQueryComponentForceIOS7Handling) {
+        NSURLComponents *components =
+            [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+        NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+        for (NSURLQueryItem *queryItem in queryItems) {
+          [self addParameter:queryItem.name value:queryItem.value];
         }
-        NSString *name = [queryPart substringToIndex:equalsRange.location];
-        name = name.stringByRemovingPercentEncoding;
-        NSString *value = [queryPart substringFromIndex:equalsRange.location + equalsRange.length];
-        value = value.stringByRemovingPercentEncoding;
-        [self addParameter:name value:value];
+        return self;
       }
     }
+    
+    // Fallback for iOS 7
+    NSString *query = URL.query;
+    NSArray<NSString *> *queryParts = [query componentsSeparatedByString:@"&"];
+    for (NSString *queryPart in queryParts) {
+      NSRange equalsRange = [queryPart rangeOfString:@"="];
+      if (equalsRange.location == NSNotFound) {
+        continue;
+      }
+      NSString *name = [queryPart substringToIndex:equalsRange.location];
+      name = name.stringByRemovingPercentEncoding;
+      NSString *value = [queryPart substringFromIndex:equalsRange.location + equalsRange.length];
+      value = value.stringByRemovingPercentEncoding;
+      [self addParameter:name value:value];
+    }
+    return self;
   }
   return self;
 }
@@ -108,7 +112,7 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
     @discussion The parameter names and values are NOT URL encoded.
     @return An array of unencoded @c NSURLQueryItem objects.
  */
-- (NSMutableArray<NSURLQueryItem *> *)queryItems {
+- (NSMutableArray<NSURLQueryItem *> *)queryItems NS_AVAILABLE_IOS(8.0) {
   NSMutableArray<NSURLQueryItem *> *queryParameters = [NSMutableArray array];
   for (NSString *parameterName in _parameters.allKeys) {
     NSArray<NSString *> *values = _parameters[parameterName];
@@ -154,15 +158,17 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
 
 - (NSString *)URLEncodedParameters {
   // If NSURLQueryItem is available, uses it for constructing the encoded parameters. (iOS 8+)
-  if (!gOIDURLQueryComponentForceIOS7Handling && [NSURLQueryItem class]) {
-    NSURLComponents *components = [[NSURLComponents alloc] init];
-    components.queryItems = [self queryItems];
-    NSString *encodedQuery = components.percentEncodedQuery;
-    // NSURLComponents.percentEncodedQuery creates a validly escaped URL query component, but
-    // doesn't encode the '+' leading to potential ambiguity with application/x-www-form-urlencoded
-    // encoding. Percent encodes '+' to avoid this ambiguity.
-    encodedQuery = [encodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
-    return encodedQuery;
+  if (@available(iOS 8.0, *)) {
+    if (!gOIDURLQueryComponentForceIOS7Handling) {
+      NSURLComponents *components = [[NSURLComponents alloc] init];
+      components.queryItems = [self queryItems];
+      NSString *encodedQuery = components.percentEncodedQuery;
+      // NSURLComponents.percentEncodedQuery creates a validly escaped URL query component, but
+      // doesn't encode the '+' leading to potential ambiguity with application/x-www-form-urlencoded
+      // encoding. Percent encodes '+' to avoid this ambiguity.
+      encodedQuery = [encodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
+      return encodedQuery;
+    }
   }
 
   // else, falls back to building query string manually (iOS 7)


### PR DESCRIPTION
Implemented dismiss functionality for SFAuthenticationSession on iOS 11.
Removed GCC_TREAT_WARNINGS_AS_ERRORS=YES from the Podspec, enabled `-Werror` for TravisCI instead to catch new warnings at the library-developer level.
AppAuth now requires a Base SDK of iOS 11 (still supports iOS 7 as a Deployment Target).

Fixes #146