### PR TITLE
Fix compilation on macOS

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -30,7 +30,7 @@ It follows the OAuth 2.0 for Native Apps best current practice
   #       classes of AppAuth with tokens on watchOS and tvOS, but currently the
   #       library won't help you obtain authorization grants on those platforms.
 
-  s.platforms    = { :ios => "7.0", :osx => "10.8", :watchos => "2.0", :tvos => "9.0" }
+  s.platforms    = { :ios => "7.0", :osx => "10.10", :watchos => "2.0", :tvos => "9.0" }
 
   s.source       = { :git => "https://github.com/openid/AppAuth-iOS.git", :tag => s.version }
 
@@ -44,5 +44,5 @@ It follows the OAuth 2.0 for Native Apps best current practice
 
   # macOS
   s.osx.source_files = "Source/macOS/**/*.{h,m}"
-  s.osx.deployment_target = '10.8'
+  s.osx.deployment_target = '10.10'
 end

--- a/Source/OIDURLQueryComponent.m
+++ b/Source/OIDURLQueryComponent.m
@@ -112,7 +112,7 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
     @discussion The parameter names and values are NOT URL encoded.
     @return An array of unencoded @c NSURLQueryItem objects.
  */
-- (NSMutableArray<NSURLQueryItem *> *)queryItems NS_AVAILABLE_IOS(8.0) {
+- (NSMutableArray<NSURLQueryItem *> *)queryItems NS_AVAILABLE(10.10, 8.0) {
   NSMutableArray<NSURLQueryItem *> *queryParameters = [NSMutableArray array];
   for (NSString *parameterName in _parameters.allKeys) {
     NSArray<NSString *> *values = _parameters[parameterName];


### PR DESCRIPTION
The macOS deployment target is incorrectly specified, causing the pod to fail to compile.