### PR TITLE
Fixes #164 - The iOS Library requires the 9.0 SDK to compile

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -39,7 +39,7 @@ It follows the OAuth 2.0 for Native Apps best current practice
 
   # iOS
   s.ios.source_files      = "Source/iOS/**/*.{h,m}"
-  s.ios.deployment_target = "7.0"
+  s.ios.deployment_target = "9.0"
   s.ios.framework         = "SafariServices"
 
   # macOS


### PR DESCRIPTION
I'm running into this issue when using version `0.90.0`. I have had to manually fix this each time I run pod install. 