### PR TITLE
#167 Fix macOS support issue

### DIFF
--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
@@ -275,13 +275,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-iOS_ObjC-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Examples/Example-iOS_ObjC/Podfile.lock
+++ b/Examples/Example-iOS_ObjC/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - AppAuth (0.90.0)
+
+DEPENDENCIES:
+  - AppAuth (from `../../`)
+
+EXTERNAL SOURCES:
+  AppAuth:
+    :path: ../../
+
+SPEC CHECKSUMS:
+  AppAuth: 7de40c8b357ff84ad359c405acbf0be89a6b4c79
+
+PODFILE CHECKSUM: abe079692b9a7fd43182b3039b95489b56d257e1
+
+COCOAPODS: 1.3.1

--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -31,6 +31,12 @@
 #import "OIDTokenResponse.h"
 #import "OIDURLQueryComponent.h"
 
+#if TARGET_OS_IOS
+#import "OIDURLQueryComponent+IOS.h"
+#elif TARGET_OS_MAC
+#import "OIDURLQueryComponent+Mac.h"
+#endif
+
 /*! @brief Path appended to an OpenID Connect issuer for discovery
     @see https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
  */

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -23,6 +23,13 @@
 #import "OIDServiceConfiguration.h"
 #import "OIDURLQueryComponent.h"
 
+#if TARGET_OS_IOS
+#import "OIDURLQueryComponent+IOS.h"
+#elif TARGET_OS_MAC
+#import "OIDURLQueryComponent+Mac.h"
+#endif
+
+
 /*! @brief The key for the @c configuration property for @c NSSecureCoding
  */
 static NSString *const kConfigurationKey = @"configuration";

--- a/Source/OIDURLQueryComponent.h
+++ b/Source/OIDURLQueryComponent.h
@@ -47,11 +47,6 @@ extern BOOL gOIDURLQueryComponentForceIOS7Handling;
  */
 @property(nonatomic, readonly) NSDictionary<NSString *, NSObject<NSCopying> *> *dictionaryValue;
 
-/*! @brief Creates an @c OIDURLQueryComponent by parsing the query string in a URL.
-    @param URL The URL from which to extract a query component.
- */
-- (nullable instancetype)initWithURL:(NSURL *)URL;
-
 /*! @brief The value (or values) for a named parameter in the query.
     @param parameter The parameter name. Case sensitive.
     @return The value (or values) for a named parameter in the query.
@@ -74,10 +69,13 @@ extern BOOL gOIDURLQueryComponentForceIOS7Handling;
  */
 - (NSURL *)URLByReplacingQueryInURL:(NSURL *)URL;
 
-/*! @brief Builds an x-www-form-urlencoded string representing the parameters.
-    @return The x-www-form-urlencoded string representing the parameters.
+/*! @brief Builds a query string that can be set to @c NSURLComponents.percentEncodedQuery
+ @discussion This string is percent encoded, and shouldn't be used with
+ @c NSURLComponents.query.
+ @return An percentage encoded query string.
  */
-- (NSString *)URLEncodedParameters;
+- (NSString *)percentEncodedQueryString;
+
 
 @end
 

--- a/Source/OIDURLQueryComponent.m
+++ b/Source/OIDURLQueryComponent.m
@@ -18,6 +18,12 @@
 
 #import "OIDURLQueryComponent.h"
 
+#if TARGET_OS_IOS
+#import "OIDURLQueryComponent+IOS.h"
+#elif TARGET_OS_MAC
+#import "OIDURLQueryComponent+Mac.h"
+#endif
+
 BOOL gOIDURLQueryComponentForceIOS7Handling = NO;
 
 /*! @brief String representing the set of characters that are valid for the URL query
@@ -32,41 +38,6 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
   self = [super init];
   if (self) {
     _parameters = [NSMutableDictionary dictionary];
-  }
-  return self;
-}
-
-- (nullable instancetype)initWithURL:(NSURL *)URL {
-  self = [self init];
-  if (self) {
-    if (@available(iOS 8.0, *)) {
-      // If NSURLQueryItem is available, use it for deconstructing the new URL. (iOS 8+)
-      if (!gOIDURLQueryComponentForceIOS7Handling) {
-        NSURLComponents *components =
-            [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
-        NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
-        for (NSURLQueryItem *queryItem in queryItems) {
-          [self addParameter:queryItem.name value:queryItem.value];
-        }
-        return self;
-      }
-    }
-    
-    // Fallback for iOS 7
-    NSString *query = URL.query;
-    NSArray<NSString *> *queryParts = [query componentsSeparatedByString:@"&"];
-    for (NSString *queryPart in queryParts) {
-      NSRange equalsRange = [queryPart rangeOfString:@"="];
-      if (equalsRange.location == NSNotFound) {
-        continue;
-      }
-      NSString *name = [queryPart substringToIndex:equalsRange.location];
-      name = name.stringByRemovingPercentEncoding;
-      NSString *value = [queryPart substringFromIndex:equalsRange.location + equalsRange.length];
-      value = value.stringByRemovingPercentEncoding;
-      [self addParameter:name value:value];
-    }
-    return self;
   }
   return self;
 }
@@ -108,22 +79,6 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
   }
 }
 
-/*! @brief Builds a query items array that can be set to @c NSURLComponents.queryItems
-    @discussion The parameter names and values are NOT URL encoded.
-    @return An array of unencoded @c NSURLQueryItem objects.
- */
-- (NSMutableArray<NSURLQueryItem *> *)queryItems NS_AVAILABLE_IOS(8.0) {
-  NSMutableArray<NSURLQueryItem *> *queryParameters = [NSMutableArray array];
-  for (NSString *parameterName in _parameters.allKeys) {
-    NSArray<NSString *> *values = _parameters[parameterName];
-    for (NSString *value in values) {
-      NSURLQueryItem *item = [NSURLQueryItem queryItemWithName:parameterName value:value];
-      [queryParameters addObject:item];
-    }
-  }
-  return queryParameters;
-}
-
 /*! @brief Builds a query string that can be set to @c NSURLComponents.percentEncodedQuery
     @discussion This string is percent encoded, and shouldn't be used with
         @c NSURLComponents.query.
@@ -154,25 +109,6 @@ static NSString *const kQueryStringParamAdditionalDisallowedCharacters = @"=&+";
 
   NSString *queryString = [parameterizedValues componentsJoinedByString:@"&"];
   return queryString;
-}
-
-- (NSString *)URLEncodedParameters {
-  // If NSURLQueryItem is available, uses it for constructing the encoded parameters. (iOS 8+)
-  if (@available(iOS 8.0, *)) {
-    if (!gOIDURLQueryComponentForceIOS7Handling) {
-      NSURLComponents *components = [[NSURLComponents alloc] init];
-      components.queryItems = [self queryItems];
-      NSString *encodedQuery = components.percentEncodedQuery;
-      // NSURLComponents.percentEncodedQuery creates a validly escaped URL query component, but
-      // doesn't encode the '+' leading to potential ambiguity with application/x-www-form-urlencoded
-      // encoding. Percent encodes '+' to avoid this ambiguity.
-      encodedQuery = [encodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
-      return encodedQuery;
-    }
-  }
-
-  // else, falls back to building query string manually (iOS 7)
-  return [self percentEncodedQueryString];
 }
 
 - (NSURL *)URLByReplacingQueryInURL:(NSURL *)URL {

--- a/Source/iOS/OIDURLQueryComponent+IOS.h
+++ b/Source/iOS/OIDURLQueryComponent+IOS.h
@@ -1,0 +1,22 @@
+#import "OIDURLQueryComponent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OIDURLQueryComponent (Mac)
+
+/*! @brief Creates an @c OIDURLQueryComponent by parsing the query string in a URL.
+ @param URL The URL from which to extract a query component.
+ */
+- (nullable instancetype)initWithURL:(NSURL *)URL;
+
+
+/**
+ @brief Builds an x-www-form-urlencoded string representing the parameters.
+ @return The x-www-form-urlencoded string representing the parameters.
+ */
+- (NSString *)URLEncodedParameters;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Source/iOS/OIDURLQueryComponent+IOS.m
+++ b/Source/iOS/OIDURLQueryComponent+IOS.m
@@ -1,0 +1,78 @@
+#import "OIDURLQueryComponent+IOS.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OIDURLQueryComponent (Mac)
+
+- (nullable instancetype)initWithURL:(NSURL *)URL {
+    self = [self init];
+    if (self) {
+        if (@available(iOS 8.0, *)) {
+            // If NSURLQueryItem is available, use it for deconstructing the new URL. (iOS 8+)
+            if (!gOIDURLQueryComponentForceIOS7Handling) {
+                NSURLComponents *components =
+                [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+                NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+                for (NSURLQueryItem *queryItem in queryItems) {
+                    [self addParameter:queryItem.name value:queryItem.value];
+                }
+                return self;
+            }
+        }
+        
+        NSString *query = URL.query;
+        NSArray<NSString *> *queryParts = [query componentsSeparatedByString:@"&"];
+        for (NSString *queryPart in queryParts) {
+            NSRange equalsRange = [queryPart rangeOfString:@"="];
+            if (equalsRange.location == NSNotFound) {
+                continue;
+            }
+            NSString *name = [queryPart substringToIndex:equalsRange.location];
+            name = name.stringByRemovingPercentEncoding;
+            NSString *value = [queryPart substringFromIndex:equalsRange.location + equalsRange.length];
+            value = value.stringByRemovingPercentEncoding;
+            [self addParameter:name value:value];
+        }
+        return self;
+    }
+    return self;
+}
+
+- (NSString *)URLEncodedParameters {
+    // If NSURLQueryItem is available, uses it for constructing the encoded parameters. (iOS 8+)
+    if (@available(iOS 8.0, *)) {
+        if (!gOIDURLQueryComponentForceIOS7Handling) {
+            NSURLComponents *components = [[NSURLComponents alloc] init];
+            components.queryItems = [self queryItems];
+            NSString *encodedQuery = components.percentEncodedQuery;
+            // NSURLComponents.percentEncodedQuery creates a validly escaped URL query component, but
+            // doesn't encode the '+' leading to potential ambiguity with application/x-www-form-urlencoded
+            // encoding. Percent encodes '+' to avoid this ambiguity.
+            encodedQuery = [encodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
+            return encodedQuery;
+        }
+    }
+    
+    return [self percentEncodedQueryString];
+}
+
+/*! @brief Builds a query items array that can be set to @c NSURLComponents.queryItems
+ @discussion The parameter names and values are NOT URL encoded.
+ @return An array of unencoded @c NSURLQueryItem objects.
+ */
+- (NSMutableArray<NSURLQueryItem *> *)queryItems CF_AVAILABLE_IOS(8.0) {
+    NSMutableArray<NSURLQueryItem *> *queryParameters = [NSMutableArray array];
+    for (NSString *parameterName in _parameters.allKeys) {
+        NSArray<NSString *> *values = _parameters[parameterName];
+        for (NSString *value in values) {
+            NSURLQueryItem *item = [NSURLQueryItem queryItemWithName:parameterName value:value];
+            [queryParameters addObject:item];
+        }
+    }
+    return queryParameters;
+}
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/macOS/OIDURLQueryComponent+Mac.h
+++ b/Source/macOS/OIDURLQueryComponent+Mac.h
@@ -1,0 +1,22 @@
+#import "OIDURLQueryComponent.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OIDURLQueryComponent (Mac)
+
+/*! @brief Creates an @c OIDURLQueryComponent by parsing the query string in a URL.
+ @param URL The URL from which to extract a query component.
+ */
+- (nullable instancetype)initWithURL:(NSURL *)URL;
+
+
+/**
+ @brief Builds an x-www-form-urlencoded string representing the parameters.
+ @return The x-www-form-urlencoded string representing the parameters.
+ */
+- (NSString *)URLEncodedParameters;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Source/macOS/OIDURLQueryComponent+Mac.m
+++ b/Source/macOS/OIDURLQueryComponent+Mac.m
@@ -1,0 +1,63 @@
+#import "OIDURLQueryComponent+Mac.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OIDURLQueryComponent (Mac)
+
+- (nullable instancetype)initWithURL:(NSURL *)URL {
+    self = [self init];
+    if (self) {
+        if (@available(macOS 10.10, *)) {
+            // If NSURLQueryItem is available, use it for deconstructing the new URL. (iOS 8+)
+            if (!gOIDURLQueryComponentForceIOS7Handling) {
+                NSURLComponents *components =
+                [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:NO];
+                NSArray<NSURLQueryItem *> *queryItems = components.queryItems;
+                for (NSURLQueryItem *queryItem in queryItems) {
+                    [self addParameter:queryItem.name value:queryItem.value];
+                }
+                return self;
+            }
+        }
+    }
+    return self;
+}
+
+- (NSString *)URLEncodedParameters {
+    // If NSURLQueryItem is available, uses it for constructing the encoded parameters. (iOS 8+)
+    if (@available(macOS 10.10, *)) {
+        if (!gOIDURLQueryComponentForceIOS7Handling) {
+            NSURLComponents *components = [[NSURLComponents alloc] init];
+            components.queryItems = [self queryItems];
+            NSString *encodedQuery = components.percentEncodedQuery;
+            // NSURLComponents.percentEncodedQuery creates a validly escaped URL query component, but
+            // doesn't encode the '+' leading to potential ambiguity with application/x-www-form-urlencoded
+            // encoding. Percent encodes '+' to avoid this ambiguity.
+            encodedQuery = [encodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
+            return encodedQuery;
+        }
+    }
+    
+    return [self percentEncodedQueryString];
+}
+
+/*! @brief Builds a query items array that can be set to @c NSURLComponents.queryItems
+ @discussion The parameter names and values are NOT URL encoded.
+ @return An array of unencoded @c NSURLQueryItem objects.
+ */
+- (NSMutableArray<NSURLQueryItem *> *)queryItems NS_AVAILABLE_MAC(10.10) {
+    NSMutableArray<NSURLQueryItem *> *queryParameters = [NSMutableArray array];
+    for (NSString *parameterName in _parameters.allKeys) {
+        NSArray<NSString *> *values = _parameters[parameterName];
+        for (NSString *value in values) {
+            NSURLQueryItem *item = [NSURLQueryItem queryItemWithName:parameterName value:value];
+            [queryParameters addObject:item];
+        }
+    }
+    return queryParameters;
+}
+
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Move methods that use @available(iOS 8.0, *) in OIDURLQueryComponent.m to OIDURLQueryComponent+IOS.m/h, and add corresponded methods for macOS in OIDURLQueryComponent+Mac.m/h.