### PR TITLE
Added iOS example app using Swift

### DIFF
--- a/Examples/Example-iOS_Swift-Carthage/.gitignore
+++ b/Examples/Example-iOS_Swift-Carthage/.gitignore
@@ -1,0 +1,40 @@
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# Pods are ignored in the samples as all Pods & their dependencies are either
+# development Pods (this repo) or sourced from repos in the same organization.
+# Generally we recommend committing Pod artifacts to version control, read about
+# the pros & cons here:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+Pods
+
+# Carthage
+#
+# Add these lines if you want to avoid checking in source code from Carthage
+# dependencies. Generally we recommend committing Carthage artifacts to version
+# control.
+Carthage/Checkouts
+Carthage/Build

--- a/Examples/Example-iOS_Swift-Carthage/Cartfile
+++ b/Examples/Example-iOS_Swift-Carthage/Cartfile
@@ -1,0 +1,2 @@
+github "openid/AppAuth-iOS" "master"
+

--- a/Examples/Example-iOS_Swift-Carthage/Cartfile.resolved
+++ b/Examples/Example-iOS_Swift-Carthage/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "openid/AppAuth-iOS" "96ea3e3dc691d76d814015ce7c47a6c1ccaf8d10"

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
@@ -1,0 +1,365 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9F265BD11F9AC69300DC14BF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BC91F9AC69300DC14BF /* Assets.xcassets */; };
+		9F265BD31F9AC69300DC14BF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BCB1F9AC69300DC14BF /* LaunchScreen.storyboard */; };
+		9F265BD41F9AC69300DC14BF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BCD1F9AC69300DC14BF /* Main.storyboard */; };
+		9F265BD51F9AC69300DC14BF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F265BCF1F9AC69300DC14BF /* AppDelegate.swift */; };
+		9F265BDA1F9AE50400DC14BF /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F265BD91F9AE50400DC14BF /* AppAuth.framework */; };
+		9FD378231FB7C6F800436204 /* AppAuthExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD378221FB7C6F800436204 /* AppAuthExampleViewController.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9F265B971F9AC5D600DC14BF /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F265BC91F9AC69300DC14BF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9F265BCC1F9AC69300DC14BF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9F265BCE1F9AC69300DC14BF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		9F265BCF1F9AC69300DC14BF /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		9F265BD01F9AC69300DC14BF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9F265BD91F9AE50400DC14BF /* AppAuth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppAuth.framework; path = Carthage/Build/iOS/AppAuth.framework; sourceTree = "<group>"; };
+		9FD378221FB7C6F800436204 /* AppAuthExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppAuthExampleViewController.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9F265B941F9AC5D600DC14BF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F265BDA1F9AE50400DC14BF /* AppAuth.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9F265B8E1F9AC5D600DC14BF = {
+			isa = PBXGroup;
+			children = (
+				9F265BC81F9AC69300DC14BF /* Source */,
+				9F265BD81F9AE4CA00DC14BF /* Frameworks */,
+				9F265B981F9AC5D600DC14BF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9F265B981F9AC5D600DC14BF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9F265B971F9AC5D600DC14BF /* Example.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9F265BC81F9AC69300DC14BF /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				9F265BCF1F9AC69300DC14BF /* AppDelegate.swift */,
+				9FD378221FB7C6F800436204 /* AppAuthExampleViewController.swift */,
+				9F265BCB1F9AC69300DC14BF /* LaunchScreen.storyboard */,
+				9F265BCD1F9AC69300DC14BF /* Main.storyboard */,
+				9F265BC91F9AC69300DC14BF /* Assets.xcassets */,
+				9F265BD01F9AC69300DC14BF /* Info.plist */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		9F265BD81F9AE4CA00DC14BF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9F265BD91F9AE50400DC14BF /* AppAuth.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9F265B961F9AC5D600DC14BF /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9F265BBF1F9AC5D600DC14BF /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				9F265B931F9AC5D600DC14BF /* Sources */,
+				9F265B941F9AC5D600DC14BF /* Frameworks */,
+				9F265B951F9AC5D600DC14BF /* Resources */,
+				9F265BDB1F9AE52C00DC14BF /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Example;
+			productName = Example;
+			productReference = 9F265B971F9AC5D600DC14BF /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9F265B8F1F9AC5D600DC14BF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0900;
+				LastUpgradeCheck = 0900;
+				ORGANIZATIONNAME = "Google Inc.";
+				TargetAttributes = {
+					9F265B961F9AC5D600DC14BF = {
+						CreatedOnToolsVersion = 9.0.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 9F265B921F9AC5D600DC14BF /* Build configuration list for PBXProject "Example" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9F265B8E1F9AC5D600DC14BF;
+			productRefGroup = 9F265B981F9AC5D600DC14BF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9F265B961F9AC5D600DC14BF /* Example */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9F265B951F9AC5D600DC14BF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F265BD41F9AC69300DC14BF /* Main.storyboard in Resources */,
+				9F265BD11F9AC69300DC14BF /* Assets.xcassets in Resources */,
+				9F265BD31F9AC69300DC14BF /* LaunchScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9F265BDB1F9AE52C00DC14BF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/AppAuth.framework",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9F265B931F9AC5D600DC14BF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9FD378231FB7C6F800436204 /* AppAuthExampleViewController.swift in Sources */,
+				9F265BD51F9AC69300DC14BF /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		9F265BCB1F9AC69300DC14BF /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				9F265BCC1F9AC69300DC14BF /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		9F265BCD1F9AC69300DC14BF /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				9F265BCE1F9AC69300DC14BF /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		9F265BBD1F9AC5D600DC14BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9F265BBE1F9AC5D600DC14BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9F265BC01F9AC5D600DC14BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Source/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.Example;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9F265BC11F9AC5D600DC14BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Source/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.Example;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9F265B921F9AC5D600DC14BF /* Build configuration list for PBXProject "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F265BBD1F9AC5D600DC14BF /* Debug */,
+				9F265BBE1F9AC5D600DC14BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9F265BBF1F9AC5D600DC14BF /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F265BC01F9AC5D600DC14BF /* Debug */,
+				9F265BC11F9AC5D600DC14BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9F265B8F1F9AC5D600DC14BF /* Project object */;
+}

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Example.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/Example-iOS_Swift-Carthage/Source/AppAuthExampleViewController.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Source/AppAuthExampleViewController.swift
@@ -1,0 +1,529 @@
+//
+//  AppAuthExampleViewController.swift
+//
+//  Copyright (c) 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppAuth
+import UIKit
+
+typealias PostRegistrationCallback = (_ configuration: OIDServiceConfiguration?, _ registrationResponse: OIDRegistrationResponse?) -> Void
+
+/**
+ The OIDC issuer from which the configuration will be discovered.
+*/
+let kIssuer: String = "https://issuer.example.com";
+
+/**
+ The OAuth client ID.
+
+ For client configuration instructions, see the [README](https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md).
+ Set to nil to use dynamic registration with this example.
+*/
+let kClientID: String? = "YOUR_CLIENT_ID";
+
+/**
+ The OAuth redirect URI for the client @c kClientID.
+
+ For client configuration instructions, see the [README](https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md).
+*/
+let kRedirectURI: String = "com.example.app:/oauth2redirect/example-provider";
+
+/**
+ NSCoding key for the authState property.
+*/
+let kAppAuthExampleAuthStateKey: String = "authState";
+
+
+
+class AppAuthExampleViewController: UIViewController {
+
+    @IBOutlet private weak var authAutoButton: UIButton!
+    @IBOutlet private weak var authManual: UIButton!
+    @IBOutlet private weak var codeExchangeButton: UIButton!
+    @IBOutlet private weak var userinfoButton: UIButton!
+    @IBOutlet private weak var logTextView: UITextView!
+    @IBOutlet private weak var trashButton: UIBarButtonItem!
+
+    private var authState: OIDAuthState?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.validateOAuthConfiguration()
+
+        self.loadState()
+        self.updateUI()
+    }
+}
+
+extension AppAuthExampleViewController {
+
+    func validateOAuthConfiguration() {
+
+        // The example needs to be configured with your own client details.
+        // See: https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md
+
+        assert(kIssuer != "https://issuer.example.com",
+                "Update kIssuer with your own issuer.\n" +
+                "Instructions: https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md");
+
+        assert(kClientID != "YOUR_CLIENT_ID",
+                "Update kClientID with your own client ID.\n" +
+                "Instructions: https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md");
+
+        assert(kRedirectURI != "com.example.app:/oauth2redirect/example-provider",
+                "Update kRedirectURI with your own redirect URI.\n" +
+                "Instructions: https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md");
+
+        // verifies that the custom URI scheme has been updated in the Info.plist
+        guard let urlTypes: [AnyObject] = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [AnyObject], urlTypes.count > 0 else {
+            assertionFailure("No custom URI scheme has been configured for the project.")
+            return
+        }
+
+        guard let items = urlTypes[0] as? [String: AnyObject],
+            let urlSchemes = items["CFBundleURLSchemes"] as? [AnyObject], urlSchemes.count > 0 else {
+            assertionFailure("No custom URI scheme has been configured for the project.")
+            return
+        }
+
+        guard let urlScheme = urlSchemes[0] as? String else {
+            assertionFailure("No custom URI scheme has been configured for the project.")
+            return
+        }
+
+        assert(urlScheme != "com.example.app",
+                "Configure the URI scheme in Info.plist (URL Types -> Item 0 -> URL Schemes -> Item 0) " +
+                "with the scheme of your redirect URI. Full instructions: " +
+                "https://github.com/openid/AppAuth-iOS/blob/master/Examples/Example-iOS_ObjC/README.md")
+    }
+
+}
+
+//MARK: IBActions
+extension AppAuthExampleViewController {
+
+    @IBAction func authWithAutoCodeExchange(_ sender: UIButton) {
+
+        guard let issuer = URL(string: kIssuer) else {
+            self.logMessage("Error creating URL for : \(kIssuer)")
+            return
+        }
+
+        self.logMessage("Fetching configuration for issuer: \(issuer)")
+
+        // discovers endpoints
+        OIDAuthorizationService.discoverConfiguration(forIssuer: issuer) { configuration, error in
+
+            guard let config = configuration else {
+                self.logMessage("Error retrieving discovery document: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+                self.setAuthState(nil)
+                return
+            }
+
+            self.logMessage("Got configuration: \(config)")
+
+            if let clientId = kClientID {
+                self.doAuthWithAutoCodeExchange(configuration: config, clientID: clientId, clientSecret: nil)
+            } else {
+                self.doClientRegistration(configuration: config) { configuration, response in
+
+                    guard let configuration = configuration, let clientID = response?.clientID else {
+                        self.logMessage("Error retrieving configuration OR clientID")
+                        return
+                    }
+
+                    self.doAuthWithAutoCodeExchange(configuration: configuration,
+                                                    clientID: clientID,
+                                                    clientSecret: response?.clientSecret)
+                }
+            }
+        }
+
+    }
+
+    @IBAction func authNoCodeExchange(_ sender: UIButton) {
+
+        guard let issuer = URL(string: kIssuer) else {
+            self.logMessage("Error creating URL for : \(kIssuer)")
+            return
+        }
+
+        self.logMessage("Fetching configuration for issuer: \(issuer)")
+
+        OIDAuthorizationService.discoverConfiguration(forIssuer: issuer) { configuration, error in
+
+            if let error = error  {
+                self.logMessage("Error retrieving discovery document: \(error.localizedDescription)")
+                return
+            }
+
+            guard let configuration = configuration else {
+                self.logMessage("Error retrieving discovery document. Error & Configuration both are NIL!")
+                return
+            }
+
+            self.logMessage("Got configuration: \(configuration)")
+
+            if let clientId = kClientID {
+
+                self.doAuthWithoutCodeExchange(configuration: configuration, clientID: clientId, clientSecret: nil)
+
+            } else {
+
+                self.doClientRegistration(configuration: configuration) { configuration, response in
+
+                    guard let configuration = configuration, let response = response else {
+                        return
+                    }
+
+                    self.doAuthWithoutCodeExchange(configuration: configuration,
+                                                   clientID: response.clientID,
+                                                   clientSecret: response.clientSecret)
+                }
+            }
+        }
+    }
+
+    @IBAction func codeExchange(_ sender: UIButton) {
+
+        guard let tokenExchangeRequest = self.authState?.lastAuthorizationResponse.tokenExchangeRequest() else {
+            self.logMessage("Error creating authorization code exchange request")
+            return
+        }
+
+        self.logMessage("Performing authorization code exchange with request \(tokenExchangeRequest)")
+
+        OIDAuthorizationService.perform(tokenExchangeRequest) { response, error in
+
+            if let tokenResponse = response {
+                self.logMessage("Received token response with accessToken: \(tokenResponse.accessToken ?? "DEFAULT_TOKEN")")
+            } else {
+                self.logMessage("Token exchange error: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+            }
+            self.authState?.update(with: response, error: error)
+        }
+    }
+
+    @IBAction func userinfo(_ sender: UIButton) {
+
+        guard let userinfoEndpoint = self.authState?.lastAuthorizationResponse.request.configuration.discoveryDocument?.userinfoEndpoint else {
+            self.logMessage("Userinfo endpoint not declared in discovery document")
+            return
+        }
+
+        self.logMessage("Performing userinfo request")
+
+        let currentAccessToken: String? = self.authState?.lastTokenResponse?.accessToken
+
+        self.authState?.performAction() { (accessToken, idTOken, error) in
+
+            if error != nil  {
+                self.logMessage("Error fetching fresh tokens: \(error?.localizedDescription ?? "ERROR")")
+                return
+            }
+
+            guard let accessToken = accessToken else {
+                self.logMessage("Error getting accessToken")
+                return
+            }
+
+            if currentAccessToken != accessToken {
+                self.logMessage("Access token was refreshed automatically (\(currentAccessToken ?? "CURRENT_ACCESS_TOKEN") to \(accessToken))")
+            } else {
+                self.logMessage("Access token was fresh and not updated \(accessToken)")
+            }
+
+            var urlRequest = URLRequest(url: userinfoEndpoint)
+            urlRequest.allHTTPHeaderFields = ["Authorization":"Bearer \(accessToken)"]
+
+            let task = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+
+                DispatchQueue.main.async {
+                    
+                    guard error == nil else {
+                        self.logMessage("HTTP request failed \(error?.localizedDescription ?? "ERROR")")
+                        return
+                    }
+
+                    guard let response = response as? HTTPURLResponse else {
+                        self.logMessage("Non-HTTP response")
+                        return
+                    }
+
+                    guard let data = data else {
+                        self.logMessage("HTTP response data is empty")
+                        return
+                    }
+
+                    var json: [AnyHashable: Any]?
+
+                    do {
+                        json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                    } catch {
+                        self.logMessage("JSON Serialization Error")
+                    }
+
+                    if response.statusCode != 200 {
+                        // server replied with an error
+                        let responseText: String? = String(data: data, encoding: String.Encoding.utf8)
+
+                        if response.statusCode == 401 {
+                            // "401 Unauthorized" generally indicates there is an issue with the authorization
+                            // grant. Puts OIDAuthState into an error state.
+                            let oauthError = OIDErrorUtilities.resourceServerAuthorizationError(withCode: 0,
+                                                                                                errorResponse: json,
+                                                                                                underlyingError: error)
+                            self.authState?.update(withAuthorizationError: oauthError)
+                            self.logMessage("Authorization Error (\(oauthError)). Response: \(responseText ?? "RESPONSE_TEXT")")
+                        } else {
+                            self.logMessage("HTTP: \(response.statusCode), Response: \(responseText ?? "RESPONSE_TEXT")")
+                        }
+
+                        return
+                    }
+
+                    if let json = json {
+                        self.logMessage("Success: \(json)")
+                    }
+                }
+            }
+
+            task.resume()
+        }
+    }
+
+    @IBAction func trashClicked(_ sender: UIBarButtonItem) {
+
+        let alert = UIAlertController(title: nil,
+                                      message: nil,
+                                      preferredStyle: UIAlertControllerStyle.actionSheet)
+
+        let clearAuthAction = UIAlertAction(title: "Clear OAuthState", style: .destructive) { (_: UIAlertAction) in
+            self.setAuthState(nil)
+            self.updateUI()
+        }
+        alert.addAction(clearAuthAction)
+        
+        let clearLogs = UIAlertAction(title: "Clear Logs", style: .default) { (_: UIAlertAction) in
+            DispatchQueue.main.async {
+                self.logTextView.text = ""
+            }
+        }
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+
+
+        alert.addAction(clearLogs)
+        alert.addAction(cancelAction)
+        self.present(alert, animated: true, completion: nil)
+
+    }
+}
+
+//MARK: AppAuth Methods
+extension AppAuthExampleViewController {
+
+    func doClientRegistration(configuration: OIDServiceConfiguration, callback: @escaping PostRegistrationCallback) {
+
+        guard let redirectURI = URL(string: kRedirectURI) else {
+            self.logMessage("Error creating URL for : \(kRedirectURI)")
+            return
+        }
+
+        let request: OIDRegistrationRequest = OIDRegistrationRequest(configuration: configuration,
+                                                                     redirectURIs: [redirectURI],
+                                                                     responseTypes: nil,
+                                                                     grantTypes: nil,
+                                                                     subjectType: nil,
+                                                                     tokenEndpointAuthMethod: "client_secret_post",
+                                                                     additionalParameters: nil)
+
+        // performs registration request
+        self.logMessage("Initiating registration request")
+
+        OIDAuthorizationService.perform(request) { response, error in
+
+            if let regResponse = response {
+                self.setAuthState(OIDAuthState(registrationResponse: regResponse))
+                self.logMessage("Got registration response: \(regResponse)")
+                callback(configuration, regResponse)
+            } else {
+                self.logMessage("Registration error: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+                self.setAuthState(nil)
+            }
+        }
+    }
+
+    func doAuthWithAutoCodeExchange(configuration: OIDServiceConfiguration, clientID: String, clientSecret: String?) {
+
+        guard let redirectURI = URL(string: kRedirectURI) else {
+            self.logMessage("Error creating URL for : \(kRedirectURI)")
+            return
+        }
+
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            self.logMessage("Error accessing AppDelegate")
+            return
+        }
+
+        // builds authentication request
+        let request = OIDAuthorizationRequest(configuration: configuration,
+                                              clientId: clientID,
+                                              clientSecret: clientSecret,
+                                              scopes: [OIDScopeOpenID, OIDScopeProfile],
+                                              redirectURL: redirectURI,
+                                              responseType: OIDResponseTypeCode,
+                                              additionalParameters: nil)
+
+        // performs authentication request
+        logMessage("Initiating authorization request with scope: \(request.scope ?? "DEFAULT_SCOPE")")
+
+        appDelegate.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request, presenting: self) { authState, error in
+
+            if let authState = authState {
+                self.setAuthState(authState)
+                self.logMessage("Got authorization tokens. Access token: \(authState.lastTokenResponse?.accessToken ?? "DEFAULT_TOKEN")")
+            } else {
+                self.logMessage("Authorization error: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+                self.setAuthState(nil)
+            }
+        }
+    }
+
+    func doAuthWithoutCodeExchange(configuration: OIDServiceConfiguration, clientID: String, clientSecret: String?) {
+
+        guard let redirectURI = URL(string: kRedirectURI) else {
+            self.logMessage("Error creating URL for : \(kRedirectURI)")
+            return
+        }
+
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            self.logMessage("Error accessing AppDelegate")
+            return
+        }
+
+        // builds authentication request
+        let request = OIDAuthorizationRequest(configuration: configuration,
+                                              clientId: clientID,
+                                              clientSecret: clientSecret,
+                                              scopes: [OIDScopeOpenID, OIDScopeProfile],
+                                              redirectURL: redirectURI,
+                                              responseType: OIDResponseTypeCode,
+                                              additionalParameters: nil)
+
+        // performs authentication request
+        logMessage("Initiating authorization request with scope: \(request.scope ?? "DEFAULT_SCOPE")")
+
+        appDelegate.currentAuthorizationFlow = OIDAuthorizationService.present(request, presenting: self) { (response, error) in
+
+            if let response = response {
+                let authState = OIDAuthState(authorizationResponse: response)
+                self.setAuthState(authState)
+                self.logMessage("Authorization response with code: \(response.authorizationCode ?? "DEFAULT_CODE")")
+                // could just call [self tokenExchange:nil] directly, but will let the user initiate it.
+            } else {
+                self.logMessage("Authorization error: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+            }
+        }
+    }
+}
+
+//MARK: OIDAuthState Delegate
+extension AppAuthExampleViewController: OIDAuthStateChangeDelegate, OIDAuthStateErrorDelegate {
+
+    func didChange(_ state: OIDAuthState) {
+        self.stateChanged()
+    }
+
+    func authState(_ state: OIDAuthState, didEncounterAuthorizationError error: Error) {
+        self.logMessage("Received authorization error: \(error)")
+    }
+}
+
+//MARK: Helper Methods
+extension AppAuthExampleViewController {
+
+    func saveState() {
+
+        var data: Data? = nil
+
+        if let authState = self.authState {
+            data = NSKeyedArchiver.archivedData(withRootObject: authState)
+        }
+
+        UserDefaults.standard.set(data, forKey: kAppAuthExampleAuthStateKey)
+        UserDefaults.standard.synchronize()
+    }
+
+    func loadState() {
+        guard let data = UserDefaults.standard.object(forKey: kAppAuthExampleAuthStateKey) as? Data else {
+            return
+        }
+
+        if let authState = NSKeyedUnarchiver.unarchiveObject(with: data) as? OIDAuthState {
+            self.setAuthState(authState)
+        }
+    }
+
+    func setAuthState(_ authState: OIDAuthState?) {
+        if (self.authState == authState) {
+            return;
+        }
+        self.authState = authState;
+        self.authState?.stateChangeDelegate = self;
+        self.stateChanged()
+    }
+
+    func updateUI() {
+
+        self.codeExchangeButton.isEnabled = self.authState?.lastAuthorizationResponse.authorizationCode != nil && !((self.authState?.lastTokenResponse) != nil)
+
+        if let authState = self.authState {
+            self.authAutoButton.setTitle("1. Re-Auth", for: .normal)
+            self.authManual.setTitle("1(A) Re-Auth", for: .normal)
+            self.userinfoButton.isEnabled = authState.isAuthorized ? true : false
+        } else {
+            self.authAutoButton.setTitle("1. Auto", for: .normal)
+            self.authManual.setTitle("1(A) Manual", for: .normal)
+            self.userinfoButton.isEnabled = false
+        }
+    }
+
+    func stateChanged() {
+        self.saveState()
+        self.updateUI()
+    }
+
+    func logMessage(_ message: String?) {
+
+        guard let message = message else {
+            return
+        }
+
+        print(message);
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "hh:mm:ss";
+        let dateString = dateFormatter.string(from: Date())
+
+        // appends to output log
+        DispatchQueue.main.async {
+            let logText = "\(self.logTextView.text ?? "")\n\(dateString): \(message)"
+            self.logTextView.text = logText
+        }
+    }
+}

--- a/Examples/Example-iOS_Swift-Carthage/Source/AppDelegate.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Source/AppDelegate.swift
@@ -1,0 +1,44 @@
+//
+//  AppDelegate.swift
+//
+//  Copyright (c) 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppAuth
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+    var currentAuthorizationFlow: OIDAuthorizationFlowSession?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+
+        if let authorizationFlow = self.currentAuthorizationFlow, authorizationFlow.resumeAuthorizationFlow(with: url) {
+            self.currentAuthorizationFlow = nil
+            return true
+        }
+
+        return false
+    }
+    
+}
+

--- a/Examples/Example-iOS_Swift-Carthage/Source/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Example-iOS_Swift-Carthage/Source/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/Example-iOS_Swift-Carthage/Source/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/Example-iOS_Swift-Carthage/Source/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Example-iOS_Swift-Carthage/Source/Base.lproj/Main.storyboard
+++ b/Examples/Example-iOS_Swift-Carthage/Source/Base.lproj/Main.storyboard
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y9n-3V-Se3">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="WzM-d6-Jzv">
+            <objects>
+                <navigationController id="Y9n-3V-Se3" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gzp-nc-Gia">
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="barTintColor" red="0.2627450980392157" green="0.60784313725490191" blue="0.82352941176470584" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="0PH-Kh-abc" kind="relationship" relationship="rootViewController" id="g3b-yd-lis"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="cnr-3F-cMn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-812" y="-128"/>
+        </scene>
+        <!--AppAuth-->
+        <scene sceneID="MSK-bT-qb2">
+            <objects>
+                <viewController id="0PH-Kh-abc" customClass="AppAuthExampleViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="nd0-IK-b4Q">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="obJ-Tk-c6j">
+                                <rect key="frame" x="10" y="84" width="110" height="90"/>
+                                <color key="backgroundColor" red="0.14509803921568626" green="0.29019607843137252" blue="0.43529411764705883" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="110" id="1ig-3c-vTG"/>
+                                    <constraint firstAttribute="height" constant="90" id="6Qd-0g-63B"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="1. Auto">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="authWithAutoCodeExchange:" destination="0PH-Kh-abc" eventType="touchUpInside" id="RHK-WH-W7c"/>
+                                    <action selector="autoAutorize:" destination="Ngk-Gu-KKv" eventType="touchUpInside" id="8rP-n0-wCY"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ufQ-5S-yNY">
+                                <rect key="frame" x="151.5" y="84" width="158.5" height="40"/>
+                                <color key="backgroundColor" red="0.14509803921568626" green="0.29019607843137252" blue="0.43529411764705883" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="ilB-xZ-2Lb"/>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="170" id="p5s-wr-nwV"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="1(A) Manual">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="authNoCodeExchange:" destination="0PH-Kh-abc" eventType="touchUpInside" id="hfb-EK-mau"/>
+                                    <action selector="manualAuthorize:" destination="Ngk-Gu-KKv" eventType="touchUpInside" id="ACX-TA-jXB"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u6R-2v-kwT">
+                                <rect key="frame" x="151.5" y="134" width="158.5" height="40"/>
+                                <color key="backgroundColor" red="0.14509803921568626" green="0.29019607843137252" blue="0.43529411764705883" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="170" id="cRT-sb-Ciq"/>
+                                    <constraint firstAttribute="height" constant="40" id="sBP-Bl-ko3"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="1(B) Code Exchange">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <state key="disabled">
+                                    <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="codeExchange:" destination="0PH-Kh-abc" eventType="touchUpInside" id="lg3-BK-fMD"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1cc-fk-sgv">
+                                <rect key="frame" x="120" y="118.5" width="31.5" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="pet-Cy-6A1"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vK8-R2-FEz">
+                                <rect key="frame" x="60" y="189" width="200" height="40"/>
+                                <color key="backgroundColor" red="0.14509803921568626" green="0.29019607843137252" blue="0.43529411764705883" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="2NJ-ap-W8k"/>
+                                    <constraint firstAttribute="height" constant="40" id="dcg-O5-UKO"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="2. User Info">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <state key="disabled">
+                                    <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="userinfo:" destination="0PH-Kh-abc" eventType="touchUpInside" id="dU3-JR-rib"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="MVQ-Pt-k9A">
+                                <rect key="frame" x="15" y="244" width="290" height="309"/>
+                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="obJ-Tk-c6j" firstAttribute="leading" secondItem="J0c-6M-Zog" secondAttribute="leading" constant="10" id="15g-3O-z6L"/>
+                            <constraint firstItem="u6R-2v-kwT" firstAttribute="bottom" secondItem="obJ-Tk-c6j" secondAttribute="bottom" id="1ru-tQ-aUa"/>
+                            <constraint firstItem="J0c-6M-Zog" firstAttribute="trailing" secondItem="u6R-2v-kwT" secondAttribute="trailing" constant="10" id="3X5-og-1ex"/>
+                            <constraint firstItem="J0c-6M-Zog" firstAttribute="trailing" secondItem="ufQ-5S-yNY" secondAttribute="trailing" constant="10" id="3cN-Ee-ne7"/>
+                            <constraint firstItem="1cc-fk-sgv" firstAttribute="leading" secondItem="obJ-Tk-c6j" secondAttribute="trailing" id="F0a-D0-8ef"/>
+                            <constraint firstItem="vK8-R2-FEz" firstAttribute="centerX" secondItem="J0c-6M-Zog" secondAttribute="centerX" id="Gay-12-060"/>
+                            <constraint firstItem="J0c-6M-Zog" firstAttribute="trailing" secondItem="MVQ-Pt-k9A" secondAttribute="trailing" constant="15" id="LNA-xY-tiP"/>
+                            <constraint firstItem="ufQ-5S-yNY" firstAttribute="leading" secondItem="1cc-fk-sgv" secondAttribute="trailing" id="Ppr-2E-BpQ"/>
+                            <constraint firstItem="vK8-R2-FEz" firstAttribute="top" secondItem="obJ-Tk-c6j" secondAttribute="bottom" constant="15" id="QDD-F1-3Fc"/>
+                            <constraint firstItem="ufQ-5S-yNY" firstAttribute="top" secondItem="obJ-Tk-c6j" secondAttribute="top" id="RiR-RA-RJB"/>
+                            <constraint firstItem="1cc-fk-sgv" firstAttribute="centerY" secondItem="obJ-Tk-c6j" secondAttribute="centerY" id="Y2K-Xv-u2r"/>
+                            <constraint firstItem="obJ-Tk-c6j" firstAttribute="top" secondItem="J0c-6M-Zog" secondAttribute="top" constant="20" id="f4H-Mi-BaE"/>
+                            <constraint firstItem="MVQ-Pt-k9A" firstAttribute="top" secondItem="vK8-R2-FEz" secondAttribute="bottom" constant="15" id="hsk-Ix-R3s"/>
+                            <constraint firstItem="u6R-2v-kwT" firstAttribute="leading" secondItem="ufQ-5S-yNY" secondAttribute="leading" id="k1Y-b6-WCr"/>
+                            <constraint firstItem="u6R-2v-kwT" firstAttribute="top" secondItem="ufQ-5S-yNY" secondAttribute="bottom" constant="10" id="lre-4v-DMq"/>
+                            <constraint firstItem="J0c-6M-Zog" firstAttribute="bottom" secondItem="MVQ-Pt-k9A" secondAttribute="bottom" constant="15" id="qnp-Vb-2tZ"/>
+                            <constraint firstItem="MVQ-Pt-k9A" firstAttribute="leading" secondItem="J0c-6M-Zog" secondAttribute="leading" constant="15" id="sGT-9S-uPw"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="J0c-6M-Zog"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="AppAuth" id="aGf-MP-jNh">
+                        <barButtonItem key="rightBarButtonItem" systemItem="trash" id="aGf-Yh-5YJ">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <connections>
+                                <action selector="trashClicked:" destination="0PH-Kh-abc" id="8kU-aZ-pKL"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="authAutoButton" destination="obJ-Tk-c6j" id="BKJ-8d-Qzd"/>
+                        <outlet property="authManual" destination="ufQ-5S-yNY" id="Z2z-Tf-Wpb"/>
+                        <outlet property="codeExchangeButton" destination="u6R-2v-kwT" id="rOv-lM-NZc"/>
+                        <outlet property="logTextView" destination="MVQ-Pt-k9A" id="sch-Fk-OYL"/>
+                        <outlet property="trashButton" destination="aGf-Yh-5YJ" id="9sQ-v3-1RG"/>
+                        <outlet property="userinfoButton" destination="vK8-R2-FEz" id="6TU-XR-FfS"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="93N-4y-Tz1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="Ngk-Gu-KKv" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="20.625" y="-129.92957746478874"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Example-iOS_Swift-Carthage/Source/Info.plist
+++ b/Examples/Example-iOS_Swift-Carthage/Source/Info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.example.app</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Added iOS example app using Swift

Notes:
Example app supports iOS 9+
App differs in UI and code separations from Obj-C example. 
AppAuth workflow is same as other example apps. 