### PR TITLE
Call completion block with redirect mismatch error

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -102,10 +102,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)resumeAuthorizationFlowWithURL:(NSURL *)URL {
-  // rejects URLs that don't match redirect (these may be completely unrelated to the authorization)
-  if (![self shouldHandleURL:URL]) {
-    return NO;
-  }
   // checks for an invalid state
   if (!_pendingauthorizationFlowCallback) {
     [NSException raise:OIDOAuthExceptionInvalidAuthorizationFlow
@@ -143,6 +139,18 @@ NS_ASSUME_NONNULL_BEGIN
                                   code:OIDErrorCodeOAuthAuthorizationClientError
                               userInfo:userInfo];
       }
+  }
+
+  // rejects URLs that don't match redirect (these may be completely unrelated to the authorization)
+  if (![self shouldHandleURL:URL]) {
+    error = [NSError errorWithDomain:OIDOAuthAuthorizationErrorDomain
+                                code:OIDErrorCodeOAuthInvalidRedirectURI
+                            userInfo:nil];
+    [_UICoordinator dismissAuthorizationAnimated:YES
+                                      completion:^{
+                                        [self didFinishWithResponse:response error:error];
+                                      }];
+    return NO;
   }
 
   [_UICoordinator dismissAuthorizationAnimated:YES


### PR DESCRIPTION
This PR fixes an iOS 11 issue for supporting redirect URI that redirects.

This is necessary if the client uses a redirect URI that redirects. For example, a provider may not support custom URI so that a backend component needs to redirect from `http://oauth.myapp.com/` to `myapp://`. Because `shouldHandleURL` returns false, we're not able to finish authentication process in iOS 11. This wasn't necessary for iOS 10 as we had to handle the URL manually. 

Let me know if this is appropriate. Other options I considered are: 
* Call openURL instead of resumeAuthFlow ([code](https://github.com/openid/AppAuth-iOS/blob/0.90.0/Source/iOS/OIDAuthorizationUICoordinatorIOS.m#L98)), but this launches a new instance of Safari.
* Pass in a list of accepted redirect URLs - this requires changes in the model code.
* We could rely on iOS to determine whether the given callback URL is valid if/when iOS supports it  down the road: http://www.openradar.me/35796658
