### PR TITLE
Add an accept header to token request

### DIFF
--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -264,6 +264,8 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   static NSString *const kHTTPContentTypeHeaderKey = @"Content-Type";
   static NSString *const kHTTPContentTypeHeaderValue =
       @"application/x-www-form-urlencoded; charset=UTF-8";
+  static NSString *const kHTTPAcceptHeaderKey = @"Accept";
+  static NSString *const kHTTPAcceptHeaderValue = @"application/json";
 
   NSURL *tokenRequestURL = [self tokenRequestURL];
   NSMutableURLRequest *URLRequest = [[NSURLRequest requestWithURL:tokenRequestURL] mutableCopy];
@@ -272,6 +274,13 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
   OIDURLQueryComponent *bodyParameters = [self tokenRequestBody];
   NSMutableDictionary *httpHeaders = [[NSMutableDictionary alloc] init];
+
+  /**
+   * GitHub will only return a spec-compliant response if JSON is explicitly defined
+   * as an acceptable response type. This is essentially harmless for all other
+   * spec-compliant IDPs.
+   */
+  [httpHeaders setObject:kHTTPAcceptHeaderValue forKey:kHTTPAcceptHeaderKey];
 
   if (_clientSecret) {
     NSString *credentials = [NSString stringWithFormat:@"%@:%@", _clientID, _clientSecret];

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -275,11 +275,7 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   OIDURLQueryComponent *bodyParameters = [self tokenRequestBody];
   NSMutableDictionary *httpHeaders = [[NSMutableDictionary alloc] init];
 
-  /**
-   * GitHub will only return a spec-compliant response if JSON is explicitly defined
-   * as an acceptable response type. This is essentially harmless for all other
-   * spec-compliant IDPs.
-   */
+  // Response should be in JSON (not e.g. XML)
   [httpHeaders setObject:kHTTPAcceptHeaderValue forKey:kHTTPAcceptHeaderKey];
 
   if (_clientSecret) {


### PR DESCRIPTION
The specific use case for this is that GitHub OAuth defaults to [returning the token response in xml](https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/), which causes the library to throw a JSON serialization exception. Thankfully, the result will be returned as JSON if the `Accept: application/json` header is set.

AppAuth-Android already has this header for the same reason, as you can see from the [comments](https://github.com/openid/AppAuth-Android/blob/619e9b0f6d27fd393a8332ceb324d8d243082251/library/java/net/openid/appauth/AuthorizationService.java#L503).

This change should not affect any other spec compliant IDPs.

We are maintaining the [react-native-app-auth](https://github.com/FormidableLabs/react-native-app-auth) library which bridges this and the Android libraries to React Native, hence our desire to expose an api with a consistent behaviour across both platforms 😊