### PR TITLE
Rename "UICoordinator" parameter to "externalUserAgent"

### DIFF
--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -143,7 +143,7 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
 /*! @brief Convenience method to create a @c OIDAuthState by presenting an authorization request
         and performing the authorization code exchange in the case of code flow requests.
     @param authorizationRequest The authorization request to present.
-    @param UICoordinator A external user agent that can present an external user-agent request.
+    @param externalUserAgent A external user agent that can present an external user-agent request.
     @param callback The method called when the request has completed or failed.
     @return A @c OIDExternalUserAgentSession instance which will terminate when it
         receives a @c OIDExternalUserAgentSession.cancel message, or after processing a
@@ -151,7 +151,7 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
  */
 + (id<OIDExternalUserAgentSession, OIDAuthorizationFlowSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
-                                UICoordinator:(id<OIDExternalUserAgent>)externalUserAgent
+                            externalUserAgent:(id<OIDExternalUserAgent>)externalUserAgent
                                      callback:(OIDAuthStateAuthorizationCallback)callback;
 
 /*! @internal

--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -106,12 +106,12 @@ static const NSUInteger kExpiryTimeTolerance = 60;
 
 + (id<OIDExternalUserAgentSession, OIDAuthorizationFlowSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
-                                UICoordinator:(id<OIDExternalUserAgent>)externalUserAgent
+                            externalUserAgent:(id<OIDExternalUserAgent>)externalUserAgent
                                      callback:(OIDAuthStateAuthorizationCallback)callback {
   // presents the authorization request
   id<OIDExternalUserAgentSession, OIDAuthorizationFlowSession> authFlowSession = [OIDAuthorizationService
       presentAuthorizationRequest:authorizationRequest
-                    UICoordinator:externalUserAgent
+                externalUserAgent:externalUserAgent
                          callback:^(OIDAuthorizationResponse *_Nullable authorizationResponse,
                                     NSError *_Nullable authorizationError) {
                            // inspects response and processes further if needed (e.g. authorization

--- a/Source/OIDAuthorizationService.h
+++ b/Source/OIDAuthorizationService.h
@@ -113,7 +113,7 @@ typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable reg
 
 /*! @brief Perform an authorization flow using a generic flow shim.
     @param request The authorization request.
-    @param UICoordinator Generic authorization UI coordinator that can present an authorization
+    @param externalUserAgent Generic external user-agent that can present an authorization
         request.
     @param callback The method called when the request has completed or failed.
     @return A @c OIDExternalUserAgentSession instance which will terminate when it
@@ -122,7 +122,7 @@ typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable reg
  */
 + (id<OIDExternalUserAgentSession, OIDAuthorizationFlowSession>)
     presentAuthorizationRequest:(OIDAuthorizationRequest *)request
-                  UICoordinator:(id<OIDExternalUserAgent>)externalUserAgent
+              externalUserAgent:(id<OIDExternalUserAgent>)externalUserAgent
                        callback:(OIDAuthorizationCallback)callback;
 
 /*! @brief Performs a token request.

--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OIDAuthorizationFlowSessionImplementation : NSObject<OIDExternalUserAgentSession, OIDAuthorizationFlowSession> {
   // private variables
   OIDAuthorizationRequest *_request;
-  id<OIDExternalUserAgent> _UICoordinator;
+  id<OIDExternalUserAgent> _externalUserAgent;
   OIDAuthorizationCallback _pendingauthorizationFlowCallback;
 }
 
@@ -66,12 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (void)presentAuthorizationWithCoordinator:(id<OIDExternalUserAgent>)UICoordinator
-                                   callback:(OIDAuthorizationCallback)authorizationFlowCallback {
-  _UICoordinator = UICoordinator;
+- (void)presentAuthorizationWithExternalUserAgent:(id<OIDExternalUserAgent>)externalUserAgent
+                                         callback:(OIDAuthorizationCallback)authorizationFlowCallback {
+  _externalUserAgent = externalUserAgent;
   _pendingauthorizationFlowCallback = authorizationFlowCallback;
   BOOL authorizationFlowStarted =
-      [_UICoordinator presentExternalUserAgentRequest:_request session:self];
+      [_externalUserAgent presentExternalUserAgentRequest:_request session:self];
   if (!authorizationFlowStarted) {
     NSError *safariError = [OIDErrorUtilities errorWithCode:OIDErrorCodeSafariOpenError
                                             underlyingError:nil
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)cancel {
-  [_UICoordinator dismissExternalUserAgentAnimated:YES completion:^{
+  [_externalUserAgent dismissExternalUserAgentAnimated:YES completion:^{
       NSError *error = [OIDErrorUtilities
                         errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
                         underlyingError:nil
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
       }
   }
 
-  [_UICoordinator dismissExternalUserAgentAnimated:YES completion:^{
+  [_externalUserAgent dismissExternalUserAgentAnimated:YES completion:^{
       [self didFinishWithResponse:response error:error];
   }];
 
@@ -165,7 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
                         error:(nullable NSError *)error {
   OIDAuthorizationCallback callback = _pendingauthorizationFlowCallback;
   _pendingauthorizationFlowCallback = nil;
-  _UICoordinator = nil;
+  _externalUserAgent = nil;
   if (callback) {
     callback(response, error);
   }
@@ -255,11 +255,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (id<OIDExternalUserAgentSession, OIDAuthorizationFlowSession>)
     presentAuthorizationRequest:(OIDAuthorizationRequest *)request
-                  UICoordinator:(id<OIDExternalUserAgent>)externalUserAgent
+              externalUserAgent:(id<OIDExternalUserAgent>)externalUserAgent
                        callback:(OIDAuthorizationCallback)callback {
   OIDAuthorizationFlowSessionImplementation *flowSession =
       [[OIDAuthorizationFlowSessionImplementation alloc] initWithRequest:request];
-  [flowSession presentAuthorizationWithCoordinator:externalUserAgent callback:callback];
+  [flowSession presentAuthorizationWithExternalUserAgent:externalUserAgent callback:callback];
   return flowSession;
 }
 

--- a/Source/OIDExternalUserAgent.h
+++ b/Source/OIDExternalUserAgent.h
@@ -24,9 +24,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*! @protocol OIDExternalUserAgent
-    @brief An external user-agent UI coordinator that presents a request. Clients may provide custom
-        implementations of an external UI coordinator to customize the way the requests are
-        presented to the end user.
+    @brief An external user-agent UI that presents displays the request to the user. Clients may
+        provide custom implementations of an external user-agent to customize the way the requests
+        are presented to the end user.
  */
 @protocol OIDExternalUserAgent<NSObject>
 

--- a/Source/iOS/OIDAuthState+IOS.m
+++ b/Source/iOS/OIDAuthState+IOS.m
@@ -30,7 +30,7 @@
         [[OIDExternalUserAgentIOS alloc]
             initWithPresentingViewController:presentingViewController];
   return [self authStateByPresentingAuthorizationRequest:authorizationRequest
-                                           UICoordinator:externalUserAgent
+                                       externalUserAgent:externalUserAgent
                                                 callback:callback];
 }
 

--- a/Source/iOS/OIDAuthorizationService+IOS.m
+++ b/Source/iOS/OIDAuthorizationService+IOS.m
@@ -28,9 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
     presentAuthorizationRequest:(OIDAuthorizationRequest *)request
        presentingViewController:(UIViewController *)presentingViewController
                        callback:(OIDAuthorizationCallback)callback {
-  OIDExternalUserAgentIOS *coordinator = [[OIDExternalUserAgentIOS alloc]
+  OIDExternalUserAgentIOS *externalUserAgent = [[OIDExternalUserAgentIOS alloc]
       initWithPresentingViewController:presentingViewController];
-  return [self presentAuthorizationRequest:request UICoordinator:coordinator callback:callback];
+  return [self presentAuthorizationRequest:request externalUserAgent:externalUserAgent callback:callback];
 }
 
 @end

--- a/Source/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/iOS/OIDExternalUserAgentIOS.h
@@ -36,8 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/*! @brief An iOS specific external user-agent UI Coordinator that uses a \SFSafariViewController to
-        present an user-agent request.
+/*! @brief An iOS specific external user-agent that uses the best possible user-agent available
+        depending on the version of iOS to present the request.
  */
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 

--- a/Source/iOS/OIDExternalUserAgentIOSCustomBrowser.m
+++ b/Source/iOS/OIDExternalUserAgentIOSCustomBrowser.m
@@ -72,9 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
   OIDCustomBrowserURLTransformation transformNOP = ^NSURL *(NSURL *requestURL) {
     return requestURL;
   };
-  OIDExternalUserAgentIOSCustomBrowser *coordinator =
+  OIDExternalUserAgentIOSCustomBrowser *transform =
       [[[self class] alloc] initWithURLTransformation:transformNOP];
-  return coordinator;
+  return transform;
 }
 
 + (OIDCustomBrowserURLTransformation)

--- a/Source/macOS/OIDAuthState+Mac.m
+++ b/Source/macOS/OIDAuthState+Mac.m
@@ -27,7 +27,7 @@
                                      callback:(OIDAuthStateAuthorizationCallback)callback {
   OIDExternalUserAgentMac *externalUserAgent = [[OIDExternalUserAgentMac alloc] init];
   return [self authStateByPresentingAuthorizationRequest:authorizationRequest
-                                           UICoordinator:externalUserAgent
+                                       externalUserAgent:externalUserAgent
                                                 callback:callback];
 }
 

--- a/Source/macOS/OIDAuthorizationService+Mac.m
+++ b/Source/macOS/OIDAuthorizationService+Mac.m
@@ -27,8 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (id<OIDExternalUserAgentSession, OIDAuthorizationFlowSession>)
     presentAuthorizationRequest:(OIDAuthorizationRequest *)request
                        callback:(OIDAuthorizationCallback)callback {
-  OIDExternalUserAgentMac *coordinator = [[OIDExternalUserAgentMac alloc] init];
-  return [self presentAuthorizationRequest:request UICoordinator:coordinator callback:callback];
+  OIDExternalUserAgentMac *externalUserAgent = [[OIDExternalUserAgentMac alloc] init];
+  return [self presentAuthorizationRequest:request externalUserAgent:externalUserAgent callback:callback];
 }
 
 @end


### PR DESCRIPTION
Follow up of previous class name refactor.
Cleaned up a few other instances of "coordinator".