### PR TITLE
Azure AD sends expires_in as string instead of number

### DIFF
--- a/Source/OIDFieldMapping.m
+++ b/Source/OIDFieldMapping.m
@@ -115,11 +115,20 @@
 
 + (OIDFieldMappingConversionFunction)dateSinceNowConversion {
   return ^id _Nullable(NSObject *_Nullable value) {
-    if (![value isKindOfClass:[NSNumber class]]) {
+    long long timeInterval = 0;
+    BOOL valueMapped = NO;
+    if ([value isKindOfClass:[NSNumber class]]) {
+      timeInterval = [(NSNumber *)value longLongValue];
+      valueMapped = YES;
+    } else if ([value isKindOfClass:[NSString class]]) {
+      timeInterval = [(NSString *)value longLongValue];
+      valueMapped = YES;
+    }
+    if (!valueMapped) {
       return value;
     }
-    NSNumber *valueAsNumber = (NSNumber *)value;
-    return [NSDate dateWithTimeIntervalSinceNow:[valueAsNumber longLongValue]];
+
+    return [NSDate dateWithTimeIntervalSinceNow:timeInterval];
   };
 }
 

--- a/Source/OIDFieldMapping.m
+++ b/Source/OIDFieldMapping.m
@@ -115,20 +115,19 @@
 
 + (OIDFieldMappingConversionFunction)dateSinceNowConversion {
   return ^id _Nullable(NSObject *_Nullable value) {
-    long long timeInterval = 0;
-    BOOL valueMapped = NO;
+    NSNumber *valueAsNumber = nil;
     if ([value isKindOfClass:[NSNumber class]]) {
-      timeInterval = [(NSNumber *)value longLongValue];
-      valueMapped = YES;
+      valueAsNumber = (NSNumber *)value;
     } else if ([value isKindOfClass:[NSString class]]) {
-      timeInterval = [(NSString *)value longLongValue];
-      valueMapped = YES;
+      NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
+      numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+      valueAsNumber = [numberFormatter numberFromString:(NSString *)value];
     }
-    if (!valueMapped) {
+    if (!valueAsNumber) {
       return value;
     }
 
-    return [NSDate dateWithTimeIntervalSinceNow:timeInterval];
+    return [NSDate dateWithTimeIntervalSinceNow:[valueAsNumber longLongValue]];
   };
 }
 

--- a/UnitTests/OIDTokenResponseTests.m
+++ b/UnitTests/OIDTokenResponseTests.m
@@ -189,16 +189,20 @@ static NSString *const kTestAdditionalParameterValue = @"example_value";
     OIDTokenResponse *response =
     [[OIDTokenResponse alloc] initWithRequest:request
                                    parameters:@{
-                                                kAccessTokenKey : kAccessTokenTestValue,
-                                                kExpiresInKey : [NSString stringWithFormat:@"%lld", kExpiresInTestValue],
-                                                kTokenTypeKey : kTokenTypeTestValue,
-                                                kIDTokenKey : kIDTokenTestValue,
-                                                kRefreshTokenKey : kRefreshTokenTestValue,
-                                                kScopesKey : kScopesTestValue,
-                                                kTestAdditionalParameterKey : kTestAdditionalParameterValue
+                                                kExpiresInKey : [NSString stringWithFormat:@"%lld", kExpiresInTestValue]
                                                 }];
     NSTimeInterval expiration = [response.accessTokenExpirationDate timeIntervalSinceNow];
     XCTAssert(expiration > kExpiresInTestValue - 5 && expiration <= kExpiresInTestValue);
+}
+
+- (void)testDecodingInvalidExpiresInString {
+    OIDTokenRequest *request = [OIDTokenRequestTests testInstance];
+    OIDTokenResponse *response =
+    [[OIDTokenResponse alloc] initWithRequest:request
+                                   parameters:@{
+                                                kExpiresInKey : @"invalid_value"
+                                                }];
+    XCTAssertNil(response.accessTokenExpirationDate);
 }
 
 @end

--- a/UnitTests/OIDTokenResponseTests.m
+++ b/UnitTests/OIDTokenResponseTests.m
@@ -184,4 +184,21 @@ static NSString *const kTestAdditionalParameterValue = @"example_value";
                         kTestAdditionalParameterValue);
 }
 
+- (void)testDecodingExpiresInAsString {
+    OIDTokenRequest *request = [OIDTokenRequestTests testInstance];
+    OIDTokenResponse *response =
+    [[OIDTokenResponse alloc] initWithRequest:request
+                                   parameters:@{
+                                                kAccessTokenKey : kAccessTokenTestValue,
+                                                kExpiresInKey : [NSString stringWithFormat:@"%lld", kExpiresInTestValue],
+                                                kTokenTypeKey : kTokenTypeTestValue,
+                                                kIDTokenKey : kIDTokenTestValue,
+                                                kRefreshTokenKey : kRefreshTokenTestValue,
+                                                kScopesKey : kScopesTestValue,
+                                                kTestAdditionalParameterKey : kTestAdditionalParameterValue
+                                                }];
+    NSTimeInterval expiration = [response.accessTokenExpirationDate timeIntervalSinceNow];
+    XCTAssert(expiration > kExpiresInTestValue - 5 && expiration <= kExpiresInTestValue);
+}
+
 @end


### PR DESCRIPTION
Hi,
I noticed I was getting errors from my apps after some time. Then I noted that token expiration dates were not set in my `OIDAuthState` and I had a look with Charles Proxy what is going on:
Microsoft is sending responses where `expires_in` is a string containing number of seconds. Because this was a string, it was not decoded properly. It will for sure be easier to add support in this library, than to make Microsoft change their API. (They are changing it anyway to v2, but it does not support yet what we need inside the company, so we need to stick with Azure AD)

So - simple `NSNumberFormatter` here was used.

Link to MS docs showing that they are returning `expires_in` as string: https://docs.microsoft.com/pl-pl/azure/active-directory/develop/active-directory-protocols-oauth-code#successful-response-1

