### PR TITLE
Show id_token in log

### DIFF
--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -109,12 +109,12 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
     _authenticationVC = authenticationVC;
     openedSafari = [authenticationVC start];
   } else if (@available(iOS 9.0, *)) {
-      SFSafariViewController *safariVC =
-          [[[self class] safariViewControllerFactory] safariViewControllerWithURL:requestURL];
-      safariVC.delegate = self;
-      _safariVC = safariVC;
-      [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
-      openedSafari = YES;
+    SFSafariViewController *safariVC =
+        [[[self class] safariViewControllerFactory] safariViewControllerWithURL:requestURL];
+    safariVC.delegate = self;
+    _safariVC = safariVC;
+    [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
+    openedSafari = YES;
   } else {
     openedSafari = [[UIApplication sharedApplication] openURL:requestURL];
   }
@@ -179,7 +179,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   }
   id<OIDExternalUserAgentSession> session = _session;
   [self cleanUp];
-  NSError *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeProgramCanceledAuthorizationFlow
+  NSError *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
                                     underlyingError:nil
                                         description:nil];
   [session failExternalUserAgentFlowWithError:error];


### PR DESCRIPTION
I noticed when I was following the example, I was watching for the id_token to appear in the log, as this is what is most important in the OIDC protocol, but only saw the access token. This patch shows the id_token for both manual code exchange and auto.