### PR TITLE
Support iOS 12 Beta

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -40,7 +40,7 @@ It follows the OAuth 2.0 for Native Apps best current practice
   # iOS
   s.ios.source_files      = "Source/iOS/**/*.{h,m}"
   s.ios.deployment_target = "7.0"
-  s.ios.framework         = "SafariServices"
+  s.ios.frameworks        = "SafariServices", "AuthenticationServices"
 
   # macOS
   s.osx.source_files = "Source/macOS/**/*.{h,m}"

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -19,6 +19,7 @@
 #import "OIDExternalUserAgentIOS.h"
 
 #import <SafariServices/SafariServices.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 
 #import "OIDErrorUtilities.h"
 #import "OIDExternalUserAgentSession.h"
@@ -49,6 +50,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
 #pragma clang diagnostic ignored "-Wpartial-availability"
   __weak SFSafariViewController *_safariVC;
   SFAuthenticationSession *_authenticationVC;
+  ASWebAuthenticationSession *_webAuthenticationVC;
 #pragma clang diagnostic pop
 }
 
@@ -88,7 +90,34 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   BOOL openedSafari = NO;
   NSURL *requestURL = [request externalUserAgentRequestURL];
 
-  if (@available(iOS 11.0, *)) {
+  // iOS 12 and later, use ASWebAuthenticationSession
+  if (@available(iOS 12.0, *)) {
+    __weak OIDExternalUserAgentIOS *weakSelf = self;
+    NSString *redirectScheme = request.redirectScheme;
+    ASWebAuthenticationSession *authenticationVC =
+        [[ASWebAuthenticationSession alloc] initWithURL:requestURL
+                                      callbackURLScheme:redirectScheme
+                                       completionHandler:^(NSURL * _Nullable callbackURL,
+                                                           NSError * _Nullable error) {
+      __strong OIDExternalUserAgentIOS *strongSelf = weakSelf;
+      if (!strongSelf) {
+          return;
+      }
+      strongSelf->_webAuthenticationVC = nil;
+      if (callbackURL) {
+        [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
+      } else {
+        NSError *safariError =
+            [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+                             underlyingError:error
+                                 description:nil];
+        [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
+      }
+    }];
+    _webAuthenticationVC = authenticationVC;
+    openedSafari = [authenticationVC start];
+  // iOS 11, use SFAuthenticationSession
+  } else if (@available(iOS 11.0, *)) {
     __weak OIDExternalUserAgentIOS *weakSelf = self;
     NSString *redirectScheme = request.redirectScheme;
     SFAuthenticationSession *authenticationVC =
@@ -97,8 +126,9 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
                                    completionHandler:^(NSURL * _Nullable callbackURL,
                                                        NSError * _Nullable error) {
       __strong OIDExternalUserAgentIOS *strongSelf = weakSelf;
-      if (!strongSelf)
+      if (!strongSelf) {
           return;
+      }
       strongSelf->_authenticationVC = nil;
       if (callbackURL) {
         [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
@@ -112,6 +142,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
     }];
     _authenticationVC = authenticationVC;
     openedSafari = [authenticationVC start];
+  // iOS 9 and 10, use SFAuthenticationSession
   } else if (@available(iOS 9.0, *)) {
     SFSafariViewController *safariVC =
         [[[self class] safariViewControllerFactory] safariViewControllerWithURL:requestURL];
@@ -119,6 +150,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
     _safariVC = safariVC;
     [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
     openedSafari = YES;
+  // iOS 8 and earlier, use mobile Safari
   } else {
     openedSafari = [[UIApplication sharedApplication] openURL:requestURL];
   }

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -50,7 +50,9 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
 #pragma clang diagnostic ignored "-Wpartial-availability"
   __weak SFSafariViewController *_safariVC;
   SFAuthenticationSession *_authenticationVC;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
   ASWebAuthenticationSession *_webAuthenticationVC;
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
 #pragma clang diagnostic pop
 }
 
@@ -91,6 +93,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   NSURL *requestURL = [request externalUserAgentRequestURL];
 
   // iOS 12 and later, use ASWebAuthenticationSession
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
   if (@available(iOS 12.0, *)) {
     __weak OIDExternalUserAgentIOS *weakSelf = self;
     NSString *redirectScheme = request.redirectScheme;
@@ -116,8 +119,10 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
     }];
     _webAuthenticationVC = authenticationVC;
     openedSafari = [authenticationVC start];
+  } else
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
   // iOS 11, use SFAuthenticationSession
-  } else if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, *)) {
     __weak OIDExternalUserAgentIOS *weakSelf = self;
     NSString *redirectScheme = request.redirectScheme;
     SFAuthenticationSession *authenticationVC =


### PR DESCRIPTION
SFAuthenticationSession is deprecated. Uses the replacement (and functionally equivalent) ASWebAuthenticationSession on iOS 12+.
AuthenticationServices framework is now required.

As with #129:

– CI will likely fail
– On Approval, PR will be merged in to a branch named `iOS12beta`, not `master`.
– When iOS 12 and Xcode 10 go GA, the `__IPHONE_OS_VERSION_MAX_ALLOWED` gating will be removed (as AppAuth only supports the latest Xcode), and the feature will be merged into `master`.

The platform beta version of AppAuth *should* work just fine in Xcode 9 (without the iOS 12 functionality), though production use is not recommended.