### PR TITLE
Add a description to errors, even if they have an underlyingError with a description

### DIFF
--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -88,7 +88,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
   if (!json || jsonError) {
     *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeJSONDeserializationError
                               underlyingError:jsonError
-                                  description:nil];
+                                  description:jsonError.localizedDescription];
     return nil;
   }
   return [self initWithDictionary:json error:error];

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -106,7 +106,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
         NSError *safariError =
             [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
                              underlyingError:error
-                                 description:nil];
+                                 description:@"User cancelled."];
         [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
       }
     }];
@@ -185,7 +185,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   [self cleanUp];
   NSError *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
                                     underlyingError:nil
-                                        description:nil];
+                                        description:@"No external user agent flow in progress."];
   [session failExternalUserAgentFlowWithError:error];
 }
 


### PR DESCRIPTION
Fixes #261