### PR TITLE
Percent encode special characters from client ID and client secret in…

### DIFF
--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -286,9 +286,9 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
     
     // Percent encode all non-alphanumeric characters.
     NSString *encodedClientID =
-        [_clientID stringByAddingPercentEncodingWithAllowedCharacters: allowedCharacters];
+        [_clientID stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
     NSString *encodedClientSecret =
-        [_clientSecret stringByAddingPercentEncodingWithAllowedCharacters: allowedCharacters];
+        [_clientSecret stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 
     NSString *credentials =
         [NSString stringWithFormat:@"%@:%@", encodedClientID, encodedClientSecret];

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -22,6 +22,7 @@
 #import "OIDScopeUtilities.h"
 #import "OIDServiceConfiguration.h"
 #import "OIDURLQueryComponent.h"
+#import "OIDTokenUtilities.h"
 
 /*! @brief The key for the @c configuration property for @c NSSecureCoding
  */
@@ -274,22 +275,10 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   NSMutableDictionary *httpHeaders = [[NSMutableDictionary alloc] init];
 
   if (_clientSecret) {
-    // https://tools.ietf.org/html/rfc6749#appendix-B
-    // Note: Space character is percent encoded, rather than as "+" as it's a valid encoding,
-    // and less ambiguous (and we don't need the "+"-encoding for aesthetic reasons)
+    // https://tools.ietf.org/html/rfc6749#section-2.3.1
+    NSString *encodedClientID = [OIDTokenUtilities formUrlEncode:_clientID];
+    NSString *encodedClientSecret = [OIDTokenUtilities formUrlEncode:_clientSecret];
     
-    // Starts with the standard URL-allowed character set.
-    NSMutableCharacterSet *allowedCharacters =
-        [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
-    // Keep only alphanumeric characters.
-    [allowedCharacters formIntersectionWithCharacterSet:[NSCharacterSet alphanumericCharacterSet]];
-    
-    // Percent encode all non-alphanumeric characters.
-    NSString *encodedClientID =
-        [_clientID stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
-    NSString *encodedClientSecret =
-        [_clientSecret stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
-
     NSString *credentials =
         [NSString stringWithFormat:@"%@:%@", encodedClientID, encodedClientSecret];
     NSData *plainData = [credentials dataUsingEncoding:NSUTF8StringEncoding];

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -275,6 +275,8 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   NSMutableDictionary *httpHeaders = [[NSMutableDictionary alloc] init];
 
   if (_clientSecret) {
+    // The client id and secret are encoded using the "application/x-www-form-urlencoded" 
+    // encoding algorithm per RFC 6749 Section 2.3.1.
     // https://tools.ietf.org/html/rfc6749#section-2.3.1
     NSString *encodedClientID = [OIDTokenUtilities formUrlEncode:_clientID];
     NSString *encodedClientSecret = [OIDTokenUtilities formUrlEncode:_clientSecret];

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -274,7 +274,24 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   NSMutableDictionary *httpHeaders = [[NSMutableDictionary alloc] init];
 
   if (_clientSecret) {
-    NSString *credentials = [NSString stringWithFormat:@"%@:%@", _clientID, _clientSecret];
+    // https://tools.ietf.org/html/rfc6749#appendix-B
+    // Note: Space character is percent encoded, rather than as "+" as it's a valid encoding,
+    // and less ambiguous (and we don't need the "+"-encoding for aesthetic reasons)
+    
+    // Starts with the standard URL-allowed character set.
+    NSMutableCharacterSet *allowedCharacters =
+        [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    // Keep only alphanumeric characters.
+    [allowedCharacters formIntersectionWithCharacterSet:[NSCharacterSet alphanumericCharacterSet]];
+    
+    // Percent encode all non-alphanumeric characters.
+    NSString *encodedClientID =
+        [_clientID stringByAddingPercentEncodingWithAllowedCharacters: allowedCharacters];
+    NSString *encodedClientSecret =
+        [_clientSecret stringByAddingPercentEncodingWithAllowedCharacters: allowedCharacters];
+
+    NSString *credentials =
+        [NSString stringWithFormat:@"%@:%@", encodedClientID, encodedClientSecret];
     NSData *plainData = [credentials dataUsingEncoding:NSUTF8StringEncoding];
     NSString *basicAuth = [plainData base64EncodedStringWithOptions:kNilOptions];
 

--- a/Source/OIDTokenUtilities.h
+++ b/Source/OIDTokenUtilities.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSString *)redact:(nullable NSString *)inputString;
 
+/*! @brief Form url encode the input string by applying application/x-www-form-urlencoded algorithm
+    @param inputString The input string.
+    @return The encoded string.
+ */
++ (NSString*)formUrlEncode:(NSString*)inputString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/OIDTokenUtilities.m
+++ b/Source/OIDTokenUtilities.m
@@ -20,6 +20,12 @@
 
 #import <CommonCrypto/CommonDigest.h>
 
+/*! @brief String representing the set of characters that are allowed as is for the
+        application/x-www-form-urlencoded encoding algorithm.
+ */
+static NSString *const kFormUrlEncodedAllowedCharacters =
+    @" *-._0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
 @implementation OIDTokenUtilities
 
 + (NSString *)encodeBase64urlNoPadding:(NSData *)data {
@@ -61,6 +67,23 @@
     default:
       return [[inputString substringToIndex:6] stringByAppendingString:@"...[redacted]"];
   }
+}
+
++ (NSString*)formUrlEncode:(NSString*)inputString {
+  // https://www.w3.org/TR/html5/sec-forms.html#application-x-www-form-urlencoded-encoding-algorithm
+  // Following the spec from the above link, application/x-www-form-urlencoded percent encode all
+  // the characters except *-._A-Za-z0-9
+  // Space character is replaced by + in the resulting bytes sequence
+  if (inputString.length == 0) {
+    return inputString;
+  }
+  NSCharacterSet *allowedCharacters =
+      [NSCharacterSet characterSetWithCharactersInString:kFormUrlEncodedAllowedCharacters];
+  // Percent encode all characters not present in the provided set.
+  NSString *encodedString =
+      [inputString stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+  // Replace occurences of space by '+' character
+  return [encodedString stringByReplacingOccurrencesOfString:@" " withString:@"+"];
 }
 
 @end

--- a/UnitTests/OIDTokenUtilitiesTests.m
+++ b/UnitTests/OIDTokenUtilitiesTests.m
@@ -41,4 +41,13 @@
   XCTAssertEqualObjects([OIDTokenUtilities redact:@"01234"], @"[redacted]", @"");
 }
 
+- (void)testFormUrlEncode {
+  XCTAssertEqualObjects([OIDTokenUtilities formUrlEncode:@"t _9V-F*I+Z1Lk.u7:2/8L+w="],
+                        @"t+_9V-F*I%2BZ1Lk.u7%3A2%2F8L%2Bw%3D", @"");
+}
+
+- (void)testFormUrlEncodeEmptyString {
+  XCTAssertEqualObjects([OIDTokenUtilities formUrlEncode:@""], @"", @"");
+}
+
 @end


### PR DESCRIPTION
… Basic Authorization header

This pull request resolves issue #233.

I added code to percent encode all characters other than alphanumeric ones included in `URLQueryAllowedCharacterSet`. I also followed @WilliamDenniss's recommendation to percent encode space rather than replacing it by "+".