### PR TITLE
Perform case-insensitive comparison of scheme during callback validation

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -96,12 +96,20 @@ NS_ASSUME_NONNULL_BEGIN
   NSURL *standardizedURL = [URL standardizedURL];
   NSURL *standardizedRedirectURL = [_request.redirectURL standardizedURL];
 
-  return OIDIsEqualIncludingNil(standardizedURL.scheme, standardizedRedirectURL.scheme) &&
-      OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user) &&
-      OIDIsEqualIncludingNil(standardizedURL.password, standardizedRedirectURL.password) &&
-      OIDIsEqualIncludingNil(standardizedURL.host, standardizedRedirectURL.host) &&
-      OIDIsEqualIncludingNil(standardizedURL.port, standardizedRedirectURL.port) &&
-      OIDIsEqualIncludingNil(standardizedURL.path, standardizedRedirectURL.path);
+  BOOL schemeEqual = (standardizedURL.scheme == nil && standardizedRedirectURL.scheme == nil) 
+                      || [standardizedURL.scheme caseInsensitiveCompare:standardizedRedirectURL.scheme] == NSOrderedSame;
+  BOOL userEqual = OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user);
+  BOOL passwordEqual = OIDIsEqualIncludingNil(standardizedURL.password, standardizedRedirectURL.password);
+  BOOL hostEqual = OIDIsEqualIncludingNil(standardizedURL.host, standardizedRedirectURL.host);
+  BOOL portEqual = OIDIsEqualIncludingNil(standardizedURL.port, standardizedRedirectURL.port);
+  BOOL pathEqual = OIDIsEqualIncludingNil(standardizedURL.path, standardizedRedirectURL.path);
+    
+  return  schemeEqual &&
+    userEqual &&
+    passwordEqual &&
+    hostEqual &&
+    portEqual &&
+    pathEqual;
 }
 
 - (BOOL)resumeAuthorizationFlowWithURL:(NSURL *)URL {


### PR DESCRIPTION
When verifying that a callback url matches what's expected, the scheme is compared case-sensitively. 

As of iOS11, the SFAuthenticationSession process passes in the callback with an always all-lowercase scheme. If we've added a mixed-case scheme, this comparison will fail silently and the callback will not be handled; Causing the login process to hang.

[RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.1) calls for schemes to be case-insensitive. For that reason, performing a case-sensitive check on the scheme with `OIDIsEqualIncludingNil` is not necessary, and, in this case, incorrect.

I've also changed the structure of the check a bit for readability. However, this could easily be re-written as an all-in-one return the way it was before.
