### PR TITLE
Add support for an initial access token to registration endpoint

### DIFF
--- a/Source/OIDRegistrationRequest.h
+++ b/Source/OIDRegistrationRequest.h
@@ -34,6 +34,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) OIDServiceConfiguration *configuration;
 
+/*! @brief The initial access token to access the Client Registration Endpoint
+        (if required by the OpenID Provider).
+    @remarks OAuth 2.0 Access Token optionally issued by an Authorization Server granting
+        access to its Client Registration Endpoint. This token (if required) is
+        provisioned out of band.
+    @see Section 3 of OpenID Connect Dynamic Client Registration 1.0
+        https://openid.net/specs/openid-connect-registration-1_0.html#ClientRegistration
+ */
+@property(nonatomic, readonly) NSString *initialAccessToken;
+
 /*! @brief The application type to register, will always be 'native'.
     @remarks application_type
     @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
@@ -79,7 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)init NS_UNAVAILABLE;
 
-/*! @brief Designated initializer.
+/*! @brief Create a Client Registration Request to an OpenID Provider that supports open Dynamic
+        Registration.
     @param configuration The service's configuration.
     @param redirectURIs The redirect URIs to register for the client.
     @param responseTypes The response types to register for the client.
@@ -95,6 +106,28 @@ NS_ASSUME_NONNULL_BEGIN
                  grantTypes:(nullable NSArray<NSString *> *)grantTypes
                 subjectType:(nullable NSString *)subjectType
     tokenEndpointAuthMethod:(nullable NSString *)tokenEndpointAuthMethod
+       additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @brief Designated initializer.
+    @param configuration The service's configuration.
+    @param redirectURIs The redirect URIs to register for the client.
+    @param responseTypes The response types to register for the client.
+    @param grantTypes The grant types to register for the client.
+    @param subjectType The subject type to register for the client.
+    @param tokenEndpointAuthMethod The token endpoint authentication method to register for the
+        client.
+    @param initialAccessToken The initial access token to access the Client Registration Endpoint
+        (if required by the OpenID Provider).
+    @param additionalParameters The client's additional registration request parameters.
+    @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientRegistration
+ */
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+               redirectURIs:(NSArray<NSURL *> *)redirectURIs
+              responseTypes:(nullable NSArray<NSString *> *)responseTypes
+                 grantTypes:(nullable NSArray<NSString *> *)grantTypes
+                subjectType:(nullable NSString *)subjectType
+    tokenEndpointAuthMethod:(nullable NSString *)tokenEndpointAuthMethod
+         initialAccessToken:(nullable NSString *)initialAccessToken
        additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters
     NS_DESIGNATED_INITIALIZER;
 

--- a/Source/OIDRegistrationRequest.m
+++ b/Source/OIDRegistrationRequest.m
@@ -26,6 +26,10 @@
  */
 static NSString *const kConfigurationKey = @"configuration";
 
+/*! @brief The key for the @c initialAccessToken property for @c NSSecureCoding
+ */
+static NSString *const kInitialAccessToken  = @"initial_access_token";
+
 /*! @brief Key used to encode the @c redirectURIs property for @c NSSecureCoding
  */
 static NSString *const kRedirectURIsKey = @"redirect_uris";
@@ -69,9 +73,28 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
              subjectType:(nullable NSString *)subjectType
  tokenEndpointAuthMethod:(nullable NSString *)tokenEndpointAuthenticationMethod
     additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
+  return [self initWithConfiguration:configuration
+                        redirectURIs:redirectURIs
+                       responseTypes:responseTypes
+                          grantTypes:grantTypes
+                         subjectType:subjectType
+             tokenEndpointAuthMethod:tokenEndpointAuthenticationMethod
+                  initialAccessToken:nil
+                additionalParameters:additionalParameters];
+}
+
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+               redirectURIs:(NSArray<NSURL *> *)redirectURIs
+              responseTypes:(nullable NSArray<NSString *> *)responseTypes
+                 grantTypes:(nullable NSArray<NSString *> *)grantTypes
+                subjectType:(nullable NSString *)subjectType
+    tokenEndpointAuthMethod:(nullable NSString *)tokenEndpointAuthenticationMethod
+         initialAccessToken:(nullable NSString *)initialAccessToken
+       additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
   self = [super init];
   if (self) {
     _configuration = [configuration copy];
+    _initialAccessToken = [initialAccessToken copy];
     _redirectURIs = [redirectURIs copy];
     _responseTypes = [responseTypes copy];
     _grantTypes = [grantTypes copy];
@@ -105,6 +128,8 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
   OIDServiceConfiguration *configuration =
   [aDecoder decodeObjectOfClass:[OIDServiceConfiguration class]
                          forKey:kConfigurationKey];
+  NSString *initialAccessToken = [aDecoder decodeObjectOfClass:[NSString class]
+                                                        forKey:kInitialAccessToken];
   NSArray<NSURL *> *redirectURIs = [aDecoder decodeObjectOfClass:[NSArray<NSURL *> class]
                                                           forKey:kRedirectURIsKey];
   NSArray<NSString *> *responseTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
@@ -127,12 +152,14 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
                           grantTypes:grantTypes
                          subjectType:subjectType
              tokenEndpointAuthMethod:tokenEndpointAuthenticationMethod
+                  initialAccessToken:initialAccessToken
                 additionalParameters:additionalParameters];
   return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [aCoder encodeObject:_configuration forKey:kConfigurationKey];
+  [aCoder encodeObject:_initialAccessToken forKey:kInitialAccessToken];
   [aCoder encodeObject:_redirectURIs forKey:kRedirectURIsKey];
   [aCoder encodeObject:_responseTypes forKey:kResponseTypesKey];
   [aCoder encodeObject:_grantTypes forKey:kGrantTypesKey];
@@ -157,8 +184,10 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 
 - (NSURLRequest *)URLRequest {
   static NSString *const kHTTPPost = @"POST";
+  static NSString *const kBearer = @"Bearer";
   static NSString *const kHTTPContentTypeHeaderKey = @"Content-Type";
   static NSString *const kHTTPContentTypeHeaderValue = @"application/json";
+  static NSString *const kHTTPAuthorizationHeaderKey = @"Authorization";
 
   NSData *postBody = [self JSONString];
   if (!postBody) {
@@ -170,6 +199,10 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
       [[NSURLRequest requestWithURL:registrationRequestURL] mutableCopy];
   URLRequest.HTTPMethod = kHTTPPost;
   [URLRequest setValue:kHTTPContentTypeHeaderValue forHTTPHeaderField:kHTTPContentTypeHeaderKey];
+  if (_initialAccessToken) {
+    NSString *value = [NSString stringWithFormat:@"%@ %@", kBearer, _initialAccessToken];
+    [URLRequest setValue:value forHTTPHeaderField:kHTTPAuthorizationHeaderKey];
+  }
   URLRequest.HTTPBody = postBody;
   return URLRequest;
 }

--- a/UnitTests/OIDRegistrationRequestTests.m
+++ b/UnitTests/OIDRegistrationRequestTests.m
@@ -31,6 +31,10 @@ static NSString *const kTestAdditionalParameterKey = @"A";
  */
 static NSString *const kTestAdditionalParameterValue = @"1";
 
+/*! @brief Test value for the @c initialAccessToken property.
+ */
+static NSString *const kInitialAccessTokenTestValue = @"test";
+
 /*! @brief Test value for the @c redirectURL property.
  */
 static NSString *kRedirectURLTestValue = @"https://client.example.com/redirect";
@@ -66,6 +70,7 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
                                  grantTypes:@[ kGrantTypeTestValue ]
                                 subjectType:kSubjectTypeTestValue
                     tokenEndpointAuthMethod:kTokenEndpointAuthMethodTestValue
+                         initialAccessToken:kInitialAccessTokenTestValue
                        additionalParameters:additionalParameters];
 
   return request;
@@ -84,6 +89,7 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
 
   XCTAssertNotNil(request.configuration);
   XCTAssertEqualObjects(request.applicationType, OIDApplicationTypeNative);
+  XCTAssertEqualObjects(request.initialAccessToken, kInitialAccessTokenTestValue);
   XCTAssertEqualObjects(request.redirectURIs, @[ [NSURL URLWithString:kRedirectURLTestValue] ]);
   XCTAssertEqualObjects(request.responseTypes, @[ kResponseTypeTestValue ]);
   XCTAssertEqualObjects(request.grantTypes, @[ kGrantTypeTestValue ]);
@@ -101,6 +107,7 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
   XCTAssertEqualObjects(requestCopy.configuration, request.configuration);
 
   XCTAssertEqualObjects(requestCopy.applicationType, request.applicationType);
+  XCTAssertEqualObjects(requestCopy.initialAccessToken, kInitialAccessTokenTestValue);
   XCTAssertEqualObjects(requestCopy.redirectURIs, request.redirectURIs);
   XCTAssertEqualObjects(requestCopy.responseTypes, request.responseTypes);
   XCTAssertEqualObjects(requestCopy.grantTypes, request.grantTypes);
@@ -120,6 +127,7 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
 
   XCTAssertNotNil(request.configuration);
   XCTAssertEqualObjects(request.applicationType, OIDApplicationTypeNative);
+  XCTAssertEqualObjects(request.initialAccessToken, kInitialAccessTokenTestValue);
   XCTAssertEqualObjects(request.redirectURIs, @[ [NSURL URLWithString:kRedirectURLTestValue] ]);
   XCTAssertEqualObjects(request.responseTypes, @[ kResponseTypeTestValue ]);
   XCTAssertEqualObjects(request.grantTypes, @[ kGrantTypeTestValue ]);
@@ -139,6 +147,7 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
   XCTAssertNotNil(requestCopy.configuration);
 
   XCTAssertEqualObjects(requestCopy.applicationType, request.applicationType);
+  XCTAssertEqualObjects(requestCopy.initialAccessToken, kInitialAccessTokenTestValue);
   XCTAssertEqualObjects(requestCopy.redirectURIs, request.redirectURIs);
   XCTAssertEqualObjects(requestCopy.responseTypes, request.responseTypes);
   XCTAssertEqualObjects(requestCopy.grantTypes, request.grantTypes);
@@ -162,6 +171,8 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
   XCTAssertEqualObjects(httpRequest.HTTPMethod, @"POST");
   XCTAssertEqualObjects([httpRequest valueForHTTPHeaderField:@"Content-Type"],
                         @"application/json");
+  XCTAssertEqualObjects([httpRequest valueForHTTPHeaderField:@"Authorization"],
+                        @"Bearer test");
   XCTAssertEqualObjects(httpRequest.URL, request.configuration.registrationEndpoint);
   XCTAssertEqualObjects(parsedJSON[OIDApplicationTypeParam], request.applicationType);
   XCTAssertEqualObjects(parsedJSON[OIDRedirectURIsParam][0],


### PR DESCRIPTION
As per the dynamic client registration specification, the AS may require an access token for access to the registration endpoint - allow the app to specify this.

(I've tried my best to follow the coding standard doc but it's quite long so very possible I missed something, let me know if so.)