### PR TITLE
Specify indent width in .xcodeproj

### DIFF
--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -748,7 +748,9 @@
 				341741AE1C5D8243000EF209 /* Source */,
 				340E737D1C5D819B0076B1F6 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		340E737D1C5D819B0076B1F6 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This project seems to use an indent width of 2; it makes life easier
for people that have to work on other projects with other indent widths
if that is specified in the xcodeproj.