### PR TITLE
Allow applications to use the "code id_token" response_type

### DIFF
--- a/Source/OIDAuthState.h
+++ b/Source/OIDAuthState.h
@@ -117,7 +117,11 @@ typedef void (^OIDAuthStateAuthorizationCallback)(OIDAuthState *_Nullable authSt
 @property(nonatomic, weak, nullable) id<OIDAuthStateErrorDelegate> errorDelegate;
 
 /*! @brief Convenience method to create a @c OIDAuthState by presenting an authorization request
-        and performing the authorization code exchange in the case of code flow requests.
+        and performing the authorization code exchange in the case of code flow requests. For
+        the hybrid flow, the caller should validate the id_token and c_hash, then perform the token
+        request (@c OIDAuthorizationService.performTokenRequest:callback:)
+        and update the OIDAuthState with the results (@c
+        OIDAuthState.updateWithTokenResponse:error:).
     @param authorizationRequest The authorization request to present.
     @param externalUserAgent A external user agent that can present an external user-agent request.
     @param callback The method called when the request has completed or failed.

--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -159,8 +159,13 @@ static const NSUInteger kExpiryTimeTolerance = 60;
                                                 callback(authState, tokenError);
                                }];
                              } else {
-                               // implicit or hybrid flow (hybrid flow assumes code is not for this
-                               // client)
+                               // hybrid flow (code id_token). Two possible cases:
+                               // 1. The code is not for this client, ie. will be sent to a
+                               //    webservice that performs the id token verification and token
+                               //    exchange
+                               // 2. The code is for this client and, for security reasons, the
+                               //    application developer must verify the id_token signature and
+                               //    c_hash before calling the token endpoint
                                OIDAuthState *authState = [[OIDAuthState alloc]
                                    initWithAuthorizationResponse:authorizationResponse];
                                callback(authState, authorizationError);

--- a/Source/OIDAuthorizationRequest.m
+++ b/Source/OIDAuthorizationRequest.m
@@ -87,7 +87,7 @@ static NSUInteger const kCodeVerifierBytes = 32;
 /*! @brief Assertion text for unsupported response types.
  */
 static NSString *const OIDOAuthUnsupportedResponseTypeMessage =
-    @"The response_type \"%@\" isn't supported. AppAuth only supports the \"code\" response_type.";
+    @"The response_type \"%@\" isn't supported. AppAuth only supports the \"code\" or \"code id_token\" response_type.";
 
 /*! @brief Code challenge request method.
  */
@@ -104,6 +104,23 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
                            responseType:
                    additionalParameters:)
     )
+
+/*! @brief Check if the response type is one AppAuth supports
+    @remarks AppAuth only supports the `code` and `code id_token` response types.
+    @see https://github.com/openid/AppAuth-iOS/issues/98
+    @see https://github.com/openid/AppAuth-iOS/issues/292
+ */
++ (BOOL)isSupportedResponseType:(NSString *)responseType
+{
+  NSString *codeIdToken = [@[OIDResponseTypeCode, OIDResponseTypeIDToken]
+                           componentsJoinedByString:@" "];
+  NSString *idTokenCode = [@[OIDResponseTypeIDToken, OIDResponseTypeCode]
+                           componentsJoinedByString:@" "];
+
+  return [responseType isEqualToString:OIDResponseTypeCode]
+         || [responseType isEqualToString:codeIdToken]
+         || [responseType isEqualToString:idTokenCode];
+}
 
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                 clientId:(NSString *)clientID
@@ -126,11 +143,7 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
     _scope = [scope copy];
     _redirectURL = [redirectURL copy];
     _responseType = [responseType copy];
-    // Attention: Please refer to https://github.com/openid/AppAuth-iOS/issues/105
-    // If you change the restriction on response type here, you must also update initWithCoder:
-    if (![_responseType isEqualToString:OIDResponseTypeCode]) {
-      // AppAuth only supports the `code` response type.
-      // Discussion: https://github.com/openid/AppAuth-iOS/issues/98
+    if (![[self class] isSupportedResponseType:_responseType]) {
       NSAssert(NO, OIDOAuthUnsupportedResponseTypeMessage, _responseType);
       return nil;
     }
@@ -209,12 +222,7 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
   OIDServiceConfiguration *configuration =
       [aDecoder decodeObjectOfClass:[OIDServiceConfiguration class]
                              forKey:kConfigurationKey];
-  // Attention: Please refer to https://github.com/openid/AppAuth-iOS/issues/105
-  // If the initializer relaxes it's restriction on the response type field, this code must also
-  // be updated to re-enable use of the serialized responseType value. The value of 'code' here
-  // is only a valid assumption for that reason.
-  // [aDecoder decodeObjectOfClass:[NSString class] forKey:kResponseTypeKey];
-  NSString *responseType = OIDResponseTypeCode;
+  NSString *responseType = [aDecoder decodeObjectOfClass:[NSString class] forKey:kResponseTypeKey];
   NSString *clientID = [aDecoder decodeObjectOfClass:[NSString class] forKey:kClientIDKey];
   NSString *clientSecret = [aDecoder decodeObjectOfClass:[NSString class] forKey:kClientSecretKey];
   NSString *scope = [aDecoder decodeObjectOfClass:[NSString class] forKey:kScopeKey];

--- a/Source/iOS/OIDAuthState+IOS.h
+++ b/Source/iOS/OIDAuthState+IOS.h
@@ -27,7 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OIDAuthState (IOS)
 
 /*! @brief Convenience method to create a @c OIDAuthState by presenting an authorization request
-        and performing the authorization code exchange in the case of code flow requests.
+        and performing the authorization code exchange in the case of code flow requests. For
+        the hybrid flow, the caller should validate the id_token and c_hash, then perform the token
+        request (@c OIDAuthorizationService.performTokenRequest:callback:)
+        and update the OIDAuthState with the results (@c
+        OIDAuthState.updateWithTokenResponse:error:).
     @param authorizationRequest The authorization request to present.
     @param presentingViewController The view controller from which to present the
         @c SFSafariViewController.

--- a/Source/macOS/OIDAuthState+Mac.h
+++ b/Source/macOS/OIDAuthState+Mac.h
@@ -25,7 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OIDAuthState (Mac)
 
 /*! @brief Convenience method to create a @c OIDAuthState by presenting an authorization request
-        and performing the authorization code exchange in the case of code flow requests.
+        and performing the authorization code exchange in the case of code flow requests. For
+        the hybrid flow, the caller should validate the id_token and c_hash, then perform the token
+        request (@c OIDAuthorizationService.performTokenRequest:callback:)
+        and update the OIDAuthState with the results (@c
+        OIDAuthState.updateWithTokenResponse:error:).
     @param authorizationRequest The authorization request to present.
     @param callback The method called when the request has completed or failed.
     @return A @c OIDExternalUserAgentSession instance which will terminate when it

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -440,13 +440,29 @@ static int const kCodeVerifierRecommendedLength = 43;
 
   NSString *scope = [OIDScopeUtilities scopesWithArray:@[ kTestScope, kTestScopeA ]];
 
-  XCTAssertThrows(
+  XCTAssertNoThrow(
       [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
                       clientId:kTestClientID
                   clientSecret:kTestClientSecret
                         scope:scope
                   redirectURL:[NSURL URLWithString:kTestRedirectURL]
                   responseType:@"code id_token"
+                         state:kTestState
+                         nonce:kTestNonce
+                  codeVerifier:kTestCodeVerifier
+                 codeChallenge:[[self class] codeChallenge]
+           codeChallengeMethod:[[self class] codeChallengeMethod]
+          additionalParameters:additionalParameters]
+  );
+
+  // https://tools.ietf.org/html/rfc6749#section-3.1.1 says the order of values does not matter
+  XCTAssertNoThrow(
+      [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
+                      clientId:kTestClientID
+                  clientSecret:kTestClientSecret
+                        scope:scope
+                  redirectURL:[NSURL URLWithString:kTestRedirectURL]
+                  responseType:@"id_token code"
                          state:kTestState
                          nonce:kTestNonce
                   codeVerifier:kTestCodeVerifier
@@ -462,6 +478,21 @@ static int const kCodeVerifierRecommendedLength = 43;
                         scope:scope
                   redirectURL:[NSURL URLWithString:kTestRedirectURL]
                   responseType:@"code token id_token"
+                         state:kTestState
+                         nonce:kTestNonce
+                  codeVerifier:kTestCodeVerifier
+                 codeChallenge:[[self class] codeChallenge]
+           codeChallengeMethod:[[self class] codeChallengeMethod]
+          additionalParameters:additionalParameters]
+  );
+
+  XCTAssertThrows(
+      [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
+                      clientId:kTestClientID
+                  clientSecret:kTestClientSecret
+                        scope:scope
+                  redirectURL:[NSURL URLWithString:kTestRedirectURL]
+                  responseType:@"token"
                          state:kTestState
                          nonce:kTestNonce
                   codeVerifier:kTestCodeVerifier


### PR DESCRIPTION
This response type is required to build a FAPI compliant client, and as
the application can verify the id_token signature and c_hash before
calling the token endpoint there is no reason to block applications from
using code id_token.

Other response types are still blocked as they don't appear to make sense
in the context of a native app.

closes #292