### PR TITLE
Remove `scope` from the token refresh request as it is redundant

### DIFF
--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -414,7 +414,7 @@ static const NSUInteger kExpiryTimeTolerance = 60;
                 redirectURL:nil
                    clientID:_lastAuthorizationResponse.request.clientID
                clientSecret:_lastAuthorizationResponse.request.clientSecret
-                      scope:_lastAuthorizationResponse.request.scope
+                      scope:nil
                refreshToken:_refreshToken
                codeVerifier:nil
        additionalParameters:additionalParameters];


### PR DESCRIPTION
Scope is a valid parameter for the Refresh Token request (Sectiom 6 of RFC
6749), however it's optional and when ommitted is treated as equal to the scope
originally granted by the resource owner. Since the indented behavior of this
convenience method is to create a token refresh with the full scope, it's
redundant to include.

Related to b5870c0bc6f65cb4004d697722612cd4a1019ab8 but slightly different
reason.