### PR TITLE
Correct supported macOS version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ confidentiality of the client secrets may not work well.
 
 #### Supported Versions
 
-AppAuth supports macOS (OS X) 10.8 and above.
+AppAuth supports macOS (OS X) 10.9 and above.
 
 #### Authorization Server Requirements
 


### PR DESCRIPTION
The minimum versions used in the Xcodeproj and the podspec are 10.9,
but README.md was stating 10.8 - updated it to 10.9 to match the other
references.