### PR TITLE
Introduce AppAuthCore podspec

### DIFF
--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		340DAE5A1D5821AB00EC285B /* OIDAuthorizationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B51C5D8243000EF209 /* OIDAuthorizationRequest.m */; };
 		340DAE5C1D5821AB00EC285B /* OIDAuthorizationService.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741B91C5D8243000EF209 /* OIDAuthorizationService.m */; };
 		340DAE5D1D5821AB00EC285B /* OIDAuthState.m in Sources */ = {isa = PBXBuildFile; fileRef = 341741BB1C5D8243000EF209 /* OIDAuthState.m */; };
-		340DAE741D58223A00EC285B /* AppAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = 341741AF1C5D8243000EF209 /* AppAuth.h */; };
+		340DAE741D58223A00EC285B /* AppAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 341741AF1C5D8243000EF209 /* AppAuthCore.h */; };
 		340DAEBC1D582AF100EC285B /* OIDRedirectHTTPHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 340DAEBA1D582AF100EC285B /* OIDRedirectHTTPHandler.m */; };
 		340DAECB1D582DE100EC285B /* OIDAuthorizationService+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */; };
 		340DAECC1D582DE100EC285B /* OIDAuthState+IOS.m in Sources */ = {isa = PBXBuildFile; fileRef = F6F60FB01D2BFEFE00325CB3 /* OIDAuthState+IOS.m */; };
@@ -508,7 +508,7 @@
 		340DAEB91D582AF100EC285B /* OIDRedirectHTTPHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDRedirectHTTPHandler.h; sourceTree = "<group>"; };
 		340DAEBA1D582AF100EC285B /* OIDRedirectHTTPHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDRedirectHTTPHandler.m; sourceTree = "<group>"; };
 		340E737C1C5D819B0076B1F6 /* libAppAuth-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libAppAuth-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		341741AF1C5D8243000EF209 /* AppAuth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppAuth.h; sourceTree = "<group>"; };
+		341741AF1C5D8243000EF209 /* AppAuthCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppAuthCore.h; sourceTree = "<group>"; };
 		341741B41C5D8243000EF209 /* OIDAuthorizationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDAuthorizationRequest.h; sourceTree = "<group>"; };
 		341741B51C5D8243000EF209 /* OIDAuthorizationRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OIDAuthorizationRequest.m; sourceTree = "<group>"; };
 		341741B61C5D8243000EF209 /* OIDAuthorizationResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDAuthorizationResponse.h; sourceTree = "<group>"; };
@@ -610,6 +610,8 @@
 		A6DEAB9A2018E4A20022AC32 /* OIDExternalUserAgentRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OIDExternalUserAgentRequest.h; sourceTree = "<group>"; };
 		A6DEABA82018E5B50022AC32 /* OIDExternalUserAgentIOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OIDExternalUserAgentIOS.m; path = iOS/OIDExternalUserAgentIOS.m; sourceTree = "<group>"; };
 		A6DEABA92018E5B50022AC32 /* OIDExternalUserAgentIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OIDExternalUserAgentIOS.h; path = iOS/OIDExternalUserAgentIOS.h; sourceTree = "<group>"; };
+		AEA601F32172017D00311864 /* AppAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppAuth.h; sourceTree = "<group>"; };
+		AEA601F4217201D400311864 /* AppAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppAuth.h; path = iOS/AppAuth.h; sourceTree = "<group>"; };
 		F6F60FB01D2BFEFE00325CB3 /* OIDAuthState+IOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthState+IOS.m"; path = "iOS/OIDAuthState+IOS.m"; sourceTree = "<group>"; };
 		F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "OIDAuthorizationService+IOS.m"; path = "iOS/OIDAuthorizationService+IOS.m"; sourceTree = "<group>"; };
 		F6F60FB31D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "OIDAuthorizationService+IOS.h"; path = "iOS/OIDAuthorizationService+IOS.h"; sourceTree = "<group>"; };
@@ -731,6 +733,7 @@
 			isa = PBXGroup;
 			children = (
 				34FEA6AB1DB6E083005C9212 /* LoopbackHTTPServer */,
+				AEA601F32172017D00311864 /* AppAuth.h */,
 				340DAEB91D582AF100EC285B /* OIDRedirectHTTPHandler.h */,
 				340DAEBA1D582AF100EC285B /* OIDRedirectHTTPHandler.m */,
 				340DAE251D581FE700EC285B /* OIDAuthorizationService+Mac.h */,
@@ -782,7 +785,7 @@
 				343AAA4C1E8345B600F9D36E /* Framework */,
 				340DAE241D581FE700EC285B /* macOS */,
 				F6F60FAF1D2BFEF000325CB3 /* iOS */,
-				341741AF1C5D8243000EF209 /* AppAuth.h */,
+				341741AF1C5D8243000EF209 /* AppAuthCore.h */,
 				341741B41C5D8243000EF209 /* OIDAuthorizationRequest.h */,
 				341741B51C5D8243000EF209 /* OIDAuthorizationRequest.m */,
 				341741B61C5D8243000EF209 /* OIDAuthorizationResponse.h */,
@@ -906,6 +909,7 @@
 		F6F60FAF1D2BFEF000325CB3 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				AEA601F4217201D400311864 /* AppAuth.h */,
 				F6F60FB31D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.h */,
 				F6F60FB11D2BFEFE00325CB3 /* OIDAuthorizationService+IOS.m */,
 				345AE746202D526800738D22 /* OIDExternalUserAgentIOSCustomBrowser.h */,
@@ -925,7 +929,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				340DAE741D58223A00EC285B /* AppAuth.h in Headers */,
+				340DAE741D58223A00EC285B /* AppAuthCore.h in Headers */,
 				34FEA6AE1DB6E083005C9212 /* OIDLoopbackHTTPServer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AppAuthCore.podspec
+++ b/AppAuthCore.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = "AppAuthCore"
+  s.version      = "0.94.0"
+  s.summary      = "AppAuth for iOS and macOS is a client SDK for communicating with OAuth 2.0 and OpenID Connect providers."
+  s.description  = <<-DESC
+AppAuth for iOS and macOS is a client SDK for communicating with [OAuth 2.0]
+(https://tools.ietf.org/html/rfc6749) and [OpenID Connect]
+(http://openid.net/specs/openid-connect-core-1_0.html) providers. It strives to
+directly map the requests and responses of those specifications, while following
+the idiomatic style of the implementation language. In addition to mapping the
+raw protocol flows, convenience methods are available to assist with common
+tasks like performing an action with fresh tokens.
+It follows the OAuth 2.0 for Native Apps best current practice
+([RFC 8252](https://tools.ietf.org/html/rfc8252)).
+                   DESC
+  s.homepage     = "https://openid.github.io/AppAuth-iOS"
+  s.license      = "Apache License, Version 2.0"
+  s.authors      = { "William Denniss" => "wdenniss@google.com",
+                     "Steven E Wright" => "stevewright@google.com",
+                   }
+
+  s.platforms    = { :ios => "7.0", :osx => "10.9", :watchos => "2.0", :tvos => "9.0" }
+  s.source       = { :git => "https://github.com/openid/AppAuth-iOS.git", :tag => s.version }
+  s.source_files = "Source/*.{h,m}"
+  s.requires_arc = true
+end

--- a/Source/AppAuthCore.h
+++ b/Source/AppAuthCore.h
@@ -1,4 +1,4 @@
-/*! @file AppAuth.h
+/*! @file AppAuthCore.h
     @brief AppAuth iOS SDK
     @copyright
         Copyright 2015 Google Inc. All Rights Reserved.
@@ -40,22 +40,6 @@
 #import "OIDTokenResponse.h"
 #import "OIDTokenUtilities.h"
 #import "OIDURLSessionProvider.h"
-
-#if TARGET_OS_TV
-#elif TARGET_OS_WATCH
-#elif TARGET_OS_IOS
-#import "OIDAuthState+IOS.h"
-#import "OIDAuthorizationService+IOS.h"
-#import "OIDExternalUserAgentIOS.h"
-#import "OIDExternalUserAgentIOSCustomBrowser.h"
-#elif TARGET_OS_MAC
-#import "OIDAuthState+Mac.h"
-#import "OIDAuthorizationService+Mac.h"
-#import "OIDExternalUserAgentMac.h"
-#import "OIDRedirectHTTPHandler.h"
-#else
-#error "Platform Undefined"
-#endif
 
 
 /*! @mainpage AppAuth for iOS and macOS

--- a/Source/iOS/AppAuth.h
+++ b/Source/iOS/AppAuth.h
@@ -1,0 +1,63 @@
+/*! @file AppAuthCore.h
+ @brief AppAuth iOS SDK
+ @copyright
+ Copyright 2015 Google Inc. All Rights Reserved.
+ @copydetails
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef AppAuth_h
+#define AppAuth_h
+
+#import "AppAuthCore.h"
+
+#if TARGET_OS_IOS
+#import "OIDAuthState+IOS.h"
+#import "OIDAuthorizationService+IOS.h"
+#import "OIDExternalUserAgentIOS.h"
+#import "OIDExternalUserAgentIOSCustomBrowser.h"
+#endif
+
+#endif /* AppAuth_h */
+
+
+/*! @mainpage AppAuth for iOS and macOS
+ 
+ @section introduction Introduction
+ 
+ AppAuth for iOS and macOS is a client SDK for communicating with [OAuth 2.0]
+ (https://tools.ietf.org/html/rfc6749) and [OpenID Connect]
+ (http://openid.net/specs/openid-connect-core-1_0.html) providers. It strives to
+ directly map the requests and responses of those specifications, while following
+ the idiomatic style of the implementation language. In addition to mapping the
+ raw protocol flows, convenience methods are available to assist with common
+ tasks like performing an action with fresh tokens.
+ 
+ It follows the best practices set out in
+ [RFC 8252 - OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252)
+ including using `SFAuthenticationSession` and `SFSafariViewController` on iOS
+ for the auth request. `UIWebView` and `WKWebView` are explicitly *not*
+ supported due to the security and usability reasons explained in
+ [Section 8.12 of RFC 8252](https://tools.ietf.org/html/rfc8252#section-8.12).
+ 
+ It also supports the [PKCE](https://tools.ietf.org/html/rfc7636) extension to
+ OAuth which was created to secure authorization codes in public clients when
+ custom URI scheme redirects are used. The library is friendly to other
+ extensions (standard or otherwise) with the ability to handle additional params
+ in all protocol requests and responses.
+ 
+ <b>Homepage</b>: http://openid.github.io/AppAuth-iOS/ <br>
+ <b>API Documentation</b>: http://openid.github.io/AppAuth-iOS/docs/latest <br>
+ <b>Git Repository</b>: https://github.com/openid/AppAuth-iOS <br>
+ 
+ */

--- a/Source/macOS/AppAuth.h
+++ b/Source/macOS/AppAuth.h
@@ -1,0 +1,63 @@
+/*! @file AppAuthCore.h
+ @brief AppAuth iOS SDK
+ @copyright
+ Copyright 2015 Google Inc. All Rights Reserved.
+ @copydetails
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef AppAuth_h
+#define AppAuth_h
+
+#import "AppAuthCore.h"
+
+#if TARGET_OS_MAC
+#import "OIDAuthState+Mac.h"
+#import "OIDAuthorizationService+Mac.h"
+#import "OIDExternalUserAgentMac.h"
+#import "OIDRedirectHTTPHandler.h"
+#endif
+
+#endif /* AppAuth_h */
+
+
+/*! @mainpage AppAuth for iOS and macOS
+ 
+ @section introduction Introduction
+ 
+ AppAuth for iOS and macOS is a client SDK for communicating with [OAuth 2.0]
+ (https://tools.ietf.org/html/rfc6749) and [OpenID Connect]
+ (http://openid.net/specs/openid-connect-core-1_0.html) providers. It strives to
+ directly map the requests and responses of those specifications, while following
+ the idiomatic style of the implementation language. In addition to mapping the
+ raw protocol flows, convenience methods are available to assist with common
+ tasks like performing an action with fresh tokens.
+ 
+ It follows the best practices set out in
+ [RFC 8252 - OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252)
+ including using `SFAuthenticationSession` and `SFSafariViewController` on iOS
+ for the auth request. `UIWebView` and `WKWebView` are explicitly *not*
+ supported due to the security and usability reasons explained in
+ [Section 8.12 of RFC 8252](https://tools.ietf.org/html/rfc8252#section-8.12).
+ 
+ It also supports the [PKCE](https://tools.ietf.org/html/rfc7636) extension to
+ OAuth which was created to secure authorization codes in public clients when
+ custom URI scheme redirects are used. The library is friendly to other
+ extensions (standard or otherwise) with the ability to handle additional params
+ in all protocol requests and responses.
+ 
+ <b>Homepage</b>: http://openid.github.io/AppAuth-iOS/ <br>
+ <b>API Documentation</b>: http://openid.github.io/AppAuth-iOS/docs/latest <br>
+ <b>Git Repository</b>: https://github.com/openid/AppAuth-iOS <br>
+ 
+ */


### PR DESCRIPTION
Fix bug #198 by implementing a dedicated `AppAuthCore.podspec` which includes only core AppAuth classes but no platform specific user agent code. Cocoapods users can depend on:

- `AppAuth` pod if they need the fully blown AppAuth.framework (including platform specific APIs)
- `AppAuthCore` pod if they cannot use platform specific APIs (like when running in an iOS App Extension)