### PR TITLE
Fixes NSSecureCoding (breaks backward compatibly)

### DIFF
--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -23,6 +23,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! @brief Key used to encode the @c discoveryDictionary property for @c NSSecureCoding
+ */
+static NSString *const kDiscoveryDictionaryKey = @"discovery_dictionary";
+
 /*! Field keys associated with an OpenID Connect Discovery Document. */
 static NSString *const kIssuerKey = @"issuer";
 static NSString *const kAuthorizationEndpointKey = @"authorization_endpoint";
@@ -183,7 +187,8 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   NSError *error;
-  NSDictionary *dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
+  NSDictionary *dictionary = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSDictionary class], nil] forKey:kDiscoveryDictionaryKey];
+
   self = [self initWithDictionary:dictionary error:&error];
   if (error) {
     return nil;
@@ -192,7 +197,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  [_discoveryDictionary encodeWithCoder:aCoder];
+  [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
 }
 
 #pragma mark - Properties


### PR DESCRIPTION
I found quite interesting bug in `OIDServiceDiscovery` `NSSecureCoding` implementation:
if `discoveryDictionary` contains `NSArray`s as values, secure unarchive fails with exception: ```value for key 'NS.objects' was of unexpected class NSArray. Allowed classes are {(
    OIDServiceDiscovery
)}```.

I found a way to fix this, **but** this breaks all current users archives. 

The question is what can we do about this? I can think of the following variants:
- Keep code as is. But this breaks contract, it says that `NSSecureCoding` is supported, while it is not. 
- Ask all users to migrate archives. Not an option in my opinion.
- Modify `initWithCoder:` in a way that will be able to decode old archives, but the new ones will be created with new secure coding implementation. 

Below is possible variant of 3rd option:

```ObjC
- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
  NSError *error;
  __block NSDictionary *dictionary;
  void (^oldImpl)(void) = ^{
    dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
  };

  @try {
    dictionary = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NSDictionary class], nil] forKey:kDiscoveryDictionaryKey];
    if (!dictionary) {
      oldImpl();
    }
  }
  @catch (NSException *exception) {
    oldImpl();
  }

  self = [self initWithDictionary:dictionary error:&error];
  if (error) {
    return nil;
  }
  return self;
}
```