### PR TITLE
Add option to prefer Safari View Controller

### DIFF
--- a/Source/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/iOS/OIDExternalUserAgentIOS.h
@@ -41,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 
+/*! @brief Set whether to prefer using @c SFSafariViewController even if newer user agents are available. False by default.
+    @remarks Useful if you rely on customization via @c setSafariViewControllerFactory:
+        or need to share the browser session (e.g., cookies) with other Safari View
+        Controllers.
+ */
++ (void)setPreferSafariViewController:
+    (BOOL)preferSafariViewController;
+
 /*! @brief Allows library consumers to change the @c OIDSafariViewControllerFactory used to create
         new instances of @c SFSafariViewController.
     @remarks Useful for customizing tint colors and presentation styles.


### PR DESCRIPTION
### What

This PR adds a static `setPreferSafariViewController:` method to `OIDExternalUserAgentIOS`. If set to `YES`, the Safari View Controller is used even iOS 11 and 12 where `SFAuthenticationSession` and `ASWebAuthenticationSession` are normally used.

This should fix  #209.

### Why

We need to implement identity provider logout in an app. This requires us to open a special logout URL in a browser that shared the session (cookies) with the login browser's session. This is trivially possible with Safari View Controller, but not `SFAuthenticationSession` (see #209).