### PR TITLE
Remove the setSafariViewControllerFactory API

### DIFF
--- a/Source/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/iOS/OIDExternalUserAgentIOS.h
@@ -24,30 +24,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*! @brief Allows library consumers to bootstrap an @c SFSafariViewController as they see fit.
-    @remarks Useful for customizing tint colors and presentation styles.
- */
-@protocol OIDSafariViewControllerFactory
-
-/*! @brief Creates and returns a new @c SFSafariViewController.
-    @param URL The URL which the @c SFSafariViewController should load initially.
- */
-- (SFSafariViewController *)safariViewControllerWithURL:(NSURL *)URL;
-
-@end
-
 /*! @brief An iOS specific external user-agent that uses the best possible user-agent available
         depending on the version of iOS to present the request.
  */
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
-
-/*! @brief Allows library consumers to change the @c OIDSafariViewControllerFactory used to create
-        new instances of @c SFSafariViewController.
-    @remarks Useful for customizing tint colors and presentation styles.
-    @param factory The @c OIDSafariViewControllerFactory to use for creating new instances of
-        @c SFSafariViewController.
- */
-+ (void)setSafariViewControllerFactory:(id<OIDSafariViewControllerFactory>)factory;
 
 /*! @internal
     @brief Unavailable. Please use @c initWithPresentingViewController:

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -27,17 +27,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** @brief The global/shared Safari view controller factory. Responsible for creating all new
-        instances of @c SFSafariViewController.
- */
-static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactory;
-
-/** @brief The default @c OIDSafariViewControllerFactory which creates new instances of
-        @c SFSafariViewController using known best practices.
- */
-@interface OIDDefaultSafariViewControllerFactory : NSObject<OIDSafariViewControllerFactory>
-@end
-
 @interface OIDExternalUserAgentIOS ()<SFSafariViewControllerDelegate>
 @end
 
@@ -52,21 +41,6 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   SFAuthenticationSession *_authenticationVC;
   ASWebAuthenticationSession *_webAuthenticationVC;
 #pragma clang diagnostic pop
-}
-
-/** @brief Obtains the current @c OIDSafariViewControllerFactory; creating a new default instance if
-        required.
- */
-+ (id<OIDSafariViewControllerFactory>)safariViewControllerFactory {
-  if (!gSafariViewControllerFactory) {
-    gSafariViewControllerFactory = [[OIDDefaultSafariViewControllerFactory alloc] init];
-  }
-  return gSafariViewControllerFactory;
-}
-
-+ (void)setSafariViewControllerFactory:(id<OIDSafariViewControllerFactory>)factory {
-  NSAssert(factory, @"Parameter: |factory| must be non-nil.");
-  gSafariViewControllerFactory = factory;
 }
 
 - (nullable instancetype)initWithPresentingViewController:
@@ -145,7 +119,7 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
   // iOS 9 and 10, use SFSafariViewController
   } else if (@available(iOS 9.0, *)) {
     SFSafariViewController *safariVC =
-        [[[self class] safariViewControllerFactory] safariViewControllerWithURL:requestURL];
+        [[SFSafariViewController alloc] initWithURL:requestURL];
     safariVC.delegate = self;
     _safariVC = safariVC;
     [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
@@ -219,16 +193,6 @@ static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactor
                                     underlyingError:nil
                                         description:@"No external user agent flow in progress."];
   [session failExternalUserAgentFlowWithError:error];
-}
-
-@end
-
-@implementation OIDDefaultSafariViewControllerFactory
-
-- (SFSafariViewController *)safariViewControllerWithURL:(NSURL *)URL NS_AVAILABLE_IOS(9.0) {
-  SFSafariViewController *safariViewController =
-      [[SFSafariViewController alloc] initWithURL:URL entersReaderIfAvailable:NO];
-  return safariViewController;
 }
 
 @end


### PR DESCRIPTION
Simplifying OIDExternalUserAgentIOS by removing customization that is only
relevant in old versions of iOS that may confuse developers starting on
iOS 12+.

AppAuth's pluggable `OIDExternalUserAgent` system can be used by users
who need customizations, e.g. by copying OIDExternalUserAgentIOS and
modifying as needed (no fork required).