### PR TITLE
Add the ability to dictate ports

### DIFF
--- a/Source/macOS/OIDRedirectHTTPHandler.h
+++ b/Source/macOS/OIDRedirectHTTPHandler.h
@@ -45,17 +45,30 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithSuccessURL:(nullable NSURL *)successURL;
 
+/*! @brief Starts listening on the loopback interface on a specified port, and returns a URL
+        with the base address. Use the returned redirect URI to build a @c OIDExternalUserAgentRequest,
+        and once you initiate the request, set the resulting @c OIDExternalUserAgentSession to
+        @c currentAuthorizationFlow so the response can be handled.
+    @param returnError The error if an error occurred while starting the local HTTP server.
+    @param port The manually specified port, or 0 for a random available port.
+    @return The URL containing the address of the server with the specified port, or nil if there was an error.
+    @discussion Each instance of @c OIDRedirectHTTPHandler can only listen for a single response.
+        Calling this more than once will result in the previous listener being cancelled (equivalent
+        of @c cancelHTTPListener being called).
+ */
+- (NSURL *)startHTTPListener:(NSError **)returnError withPort:(uint16_t)port;
+
 /*! @brief Starts listening on the loopback interface on a random available port, and returns a URL
         with the base address. Use the returned redirect URI to build a @c OIDExternalUserAgentRequest,
         and once you initiate the request, set the resulting @c OIDExternalUserAgentSession to
         @c currentAuthorizationFlow so the response can be handled.
-    @param error The error if an error occurred while starting the local HTTP server.
+    @param returnError The error if an error occurred while starting the local HTTP server.
     @return The URL containing the address of the server with the randomly assigned available port.
     @discussion Each instance of @c OIDRedirectHTTPHandler can only listen for a single response.
         Calling this more than once will result in the previous listener being cancelled (equivalent
         of @c cancelHTTPListener being called).
  */
-- (NSURL *)startHTTPListener:(NSError **)error;
+- (NSURL *)startHTTPListener:(NSError **)returnError;
 
 /*! @brief Stops listening the loopback interface and sends an cancellation error (in the domain
         ::OIDGeneralErrorDomain, with the code ::OIDErrorCodeProgramCanceledAuthorizationFlow) to

--- a/Source/macOS/OIDRedirectHTTPHandler.m
+++ b/Source/macOS/OIDRedirectHTTPHandler.m
@@ -64,13 +64,14 @@ static NSString *const kHTMLErrorRedirectNotValid =
   return self;
 }
 
-- (NSURL *)startHTTPListener:(NSError **)returnError {
+- (NSURL *)startHTTPListener:(NSError **)returnError withPort:(uint16_t)port {
   // Cancels any pending requests.
   [self cancelHTTPListener];
 
   // Starts a HTTP server on the loopback interface.
   // By not specifying a port, a random available one will be assigned.
   _httpServ = [[HTTPServer alloc] init];
+  [_httpServ setPort:port];
   [_httpServ setDelegate:self];
   NSError *error = nil;
   if (![_httpServ start:&error]) {
@@ -89,6 +90,11 @@ static NSString *const kHTMLErrorRedirectNotValid =
   }
 
   return nil;
+}
+
+- (NSURL *)startHTTPListener:(NSError **)returnError {
+  // A port of 0 requests a random available port
+  return [self startHTTPListener:returnError withPort:0];
 }
 
 - (void)cancelHTTPListener {


### PR DESCRIPTION
Some OAuth applications such as Reddit require that a redirect URI be specified at app setup time. This URI does not always support wildcard characters. The dynamic port binding in `- (NSURL *)startHTTPListener:(NSError **)returnError` then prevents the OAuth from completing successfully. 

This pull request adds an optional port parameter to this method which forces the port to whatever the developer wants while maintaining compatibility with the existing method.