### PR TITLE
Examples with extensions

### DIFF
--- a/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06462457205ED68000072191 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06462456205ED68000072191 /* NotificationCenter.framework */; };
+		0646245B205ED68000072191 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0646245A205ED68000072191 /* TodayViewController.m */; };
+		0646245E205ED68000072191 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0646245C205ED68000072191 /* MainInterface.storyboard */; };
+		06462463205ED68000072191 /* Example_Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 06462455205ED68000072191 /* Example_Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0646246A205EE25800072191 /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FEA25241E75C17E00C2D71B /* AppAuth.framework */; };
 		346E916E1C29D42800D3620B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 346E916D1C29D42800D3620B /* main.m */; };
 		346E91711C29D42800D3620B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 346E91701C29D42800D3620B /* AppDelegate.m */; };
 		346E91791C29D42800D3620B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346E91781C29D42800D3620B /* Assets.xcassets */; };
@@ -17,7 +22,39 @@
 		5FEA25251E75C17E00C2D71B /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FEA25241E75C17E00C2D71B /* AppAuth.framework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		06462460205ED68000072191 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 346E91611C29D42800D3620B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 06462454205ED68000072191;
+			remoteInfo = Example_Extension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		06462462205ED68000072191 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				06462463205ED68000072191 /* Example_Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		06462455205ED68000072191 /* Example_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Example_Extension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		06462456205ED68000072191 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		06462459205ED68000072191 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
+		0646245A205ED68000072191 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
+		0646245D205ED68000072191 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		0646245F205ED68000072191 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		06462467205EDB5400072191 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
+		06462468205EDB9900072191 /* Example_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_Extension.entitlements; sourceTree = "<group>"; };
 		346E91691C29D42800D3620B /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		346E916D1C29D42800D3620B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		346E916F1C29D42800D3620B /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -33,6 +70,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		06462452205ED68000072191 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				06462457205ED68000072191 /* NotificationCenter.framework in Frameworks */,
+				0646246A205EE25800072191 /* AppAuth.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		346E91661C29D42800D3620B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -45,11 +91,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		06462458205ED68000072191 /* Example_Extension */ = {
+			isa = PBXGroup;
+			children = (
+				06462459205ED68000072191 /* TodayViewController.h */,
+				0646245A205ED68000072191 /* TodayViewController.m */,
+				0646245C205ED68000072191 /* MainInterface.storyboard */,
+				0646245F205ED68000072191 /* Info.plist */,
+				06462468205EDB9900072191 /* Example_Extension.entitlements */,
+			);
+			path = Example_Extension;
+			sourceTree = "<group>";
+		};
 		341564001C487ABA00ECA3D9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				5FEA25241E75C17E00C2D71B /* AppAuth.framework */,
 				346E91981C2A245000D3620B /* SafariServices.framework */,
+				06462456205ED68000072191 /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -58,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				346E916B1C29D42800D3620B /* Source */,
+				06462458205ED68000072191 /* Example_Extension */,
 				341564001C487ABA00ECA3D9 /* Frameworks */,
 				346E916A1C29D42800D3620B /* Products */,
 			);
@@ -67,6 +127,7 @@
 			isa = PBXGroup;
 			children = (
 				346E91691C29D42800D3620B /* Example.app */,
+				06462455205ED68000072191 /* Example_Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -83,6 +144,7 @@
 				346E91781C29D42800D3620B /* Assets.xcassets */,
 				346E917A1C29D42800D3620B /* LaunchScreen.storyboard */,
 				346E917D1C29D42800D3620B /* Info.plist */,
+				06462467205EDB5400072191 /* Example.entitlements */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -90,6 +152,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		06462454205ED68000072191 /* Example_Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 06462466205ED68000072191 /* Build configuration list for PBXNativeTarget "Example_Extension" */;
+			buildPhases = (
+				06462451205ED68000072191 /* Sources */,
+				06462452205ED68000072191 /* Frameworks */,
+				06462453205ED68000072191 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Example_Extension;
+			productName = Example_Extension;
+			productReference = 06462455205ED68000072191 /* Example_Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		346E91681C29D42800D3620B /* Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 346E91801C29D42800D3620B /* Build configuration list for PBXNativeTarget "Example" */;
@@ -98,10 +177,12 @@
 				346E91661C29D42800D3620B /* Frameworks */,
 				346E91671C29D42800D3620B /* Resources */,
 				5FEA25261E75C1CF00C2D71B /* Carthage */,
+				06462462205ED68000072191 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				06462461205ED68000072191 /* PBXTargetDependency */,
 			);
 			name = Example;
 			productName = Example;
@@ -117,8 +198,22 @@
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "William Denniss";
 				TargetAttributes = {
+					06462454205ED68000072191 = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
+					};
 					346E91681C29D42800D3620B = {
 						CreatedOnToolsVersion = 7.2;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -136,11 +231,20 @@
 			projectRoot = "";
 			targets = (
 				346E91681C29D42800D3620B /* Example */,
+				06462454205ED68000072191 /* Example_Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		06462453205ED68000072191 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0646245E205ED68000072191 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		346E91671C29D42800D3620B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -172,6 +276,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		06462451205ED68000072191 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0646245B205ED68000072191 /* TodayViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		346E91651C29D42800D3620B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -184,7 +296,23 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		06462461205ED68000072191 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 06462454205ED68000072191 /* Example_Extension */;
+			targetProxy = 06462460205ED68000072191 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
+		0646245C205ED68000072191 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0646245D205ED68000072191 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		346E917A1C29D42800D3620B /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -196,6 +324,76 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		06462464205ED68000072191 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = Example_Extension/Example_Extension.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Example_Extension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		06462465205ED68000072191 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = Example_Extension/Example_Extension.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Example_Extension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		346E917E1C29D42800D3620B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -286,6 +484,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Source/Example.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -303,6 +504,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Source/Example.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -319,6 +523,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		06462466205ED68000072191 /* Build configuration list for PBXNativeTarget "Example_Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				06462464205ED68000072191 /* Debug */,
+				06462465205ED68000072191 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		346E91641C29D42800D3620B /* Build configuration list for PBXProject "Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06375C8521A4E46500338E3F /* AppAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06375C8421A4E46500338E3F /* AppAuthCore.framework */; };
 		06462457205ED68000072191 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06462456205ED68000072191 /* NotificationCenter.framework */; };
 		0646245B205ED68000072191 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0646245A205ED68000072191 /* TodayViewController.m */; };
 		0646245E205ED68000072191 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0646245C205ED68000072191 /* MainInterface.storyboard */; };
 		06462463205ED68000072191 /* Example_Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 06462455205ED68000072191 /* Example_Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		0646246A205EE25800072191 /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FEA25241E75C17E00C2D71B /* AppAuth.framework */; };
 		346E916E1C29D42800D3620B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 346E916D1C29D42800D3620B /* main.m */; };
 		346E91711C29D42800D3620B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 346E91701C29D42800D3620B /* AppDelegate.m */; };
 		346E91791C29D42800D3620B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346E91781C29D42800D3620B /* Assets.xcassets */; };
@@ -47,6 +47,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06375C8421A4E46500338E3F /* AppAuthCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppAuthCore.framework; path = Carthage/Build/iOS/AppAuthCore.framework; sourceTree = "<group>"; };
 		06462455205ED68000072191 /* Example_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Example_Extension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		06462456205ED68000072191 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		06462459205ED68000072191 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
@@ -74,8 +75,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06375C8521A4E46500338E3F /* AppAuthCore.framework in Frameworks */,
 				06462457205ED68000072191 /* NotificationCenter.framework in Frameworks */,
-				0646246A205EE25800072191 /* AppAuth.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +107,7 @@
 		341564001C487ABA00ECA3D9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				06375C8421A4E46500338E3F /* AppAuthCore.framework */,
 				5FEA25241E75C17E00C2D71B /* AppAuth.framework */,
 				346E91981C2A245000D3620B /* SafariServices.framework */,
 				06462456205ED68000072191 /* NotificationCenter.framework */,
@@ -159,6 +161,7 @@
 				06462451205ED68000072191 /* Sources */,
 				06462452205ED68000072191 /* Frameworks */,
 				06462453205ED68000072191 /* Resources */,
+				06375C8621A4E48800338E3F /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -258,6 +261,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		06375C8621A4E48800338E3F /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/AppAuth.framework",
+			);
+			name = Carthage;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
 		5FEA25261E75C1CF00C2D71B /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -271,7 +293,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Example_Extension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -385,7 +385,7 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Example_Extension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/xcshareddata/xcschemes/Example_Extension.xcscheme
+++ b/Examples/Example-iOS_ObjC-Carthage/Example.xcodeproj/xcshareddata/xcschemes/Example_Extension.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "06462454205ED68000072191"
+               BuildableName = "Example_Extension.appex"
+               BlueprintName = "Example_Extension"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "346E91681C29D42800D3620B"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06462454205ED68000072191"
+            BuildableName = "Example_Extension.appex"
+            BlueprintName = "Example_Extension"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06462454205ED68000072191"
+            BuildableName = "Example_Extension.appex"
+            BlueprintName = "Example_Extension"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06462454205ED68000072191"
+            BuildableName = "Example_Extension.appex"
+            BlueprintName = "Example_Extension"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "346E91681C29D42800D3620B"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wrl-gw-XJK">
+                                <rect key="frame" x="107" y="12" width="106" height="30"/>
+                                <state key="normal" title="Get user profile"/>
+                                <connections>
+                                    <action selector="getUserInfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="phE-gy-oaq"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="66l-TF-F1n">
+                                <rect key="frame" x="8" y="50" width="36" height="30"/>
+                                <state key="normal" title="Clear"/>
+                                <connections>
+                                    <action selector="clearLogTextView:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="iCp-J9-JX9"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ayH-z8-Pku">
+                                <rect key="frame" x="8" y="88" width="304" height="504"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="ayH-z8-Pku" secondAttribute="trailing" constant="8" id="IUF-8D-Y0o"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="ayH-z8-Pku" secondAttribute="bottom" constant="8" id="QZ2-rp-2Om"/>
+                            <constraint firstItem="66l-TF-F1n" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="bottom" constant="8" id="TPg-P8-h47"/>
+                            <constraint firstItem="ayH-z8-Pku" firstAttribute="top" secondItem="66l-TF-F1n" secondAttribute="bottom" constant="8" id="TRo-kO-AZz"/>
+                            <constraint firstItem="66l-TF-F1n" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="Wd5-Dp-LJF"/>
+                            <constraint firstItem="ayH-z8-Pku" firstAttribute="leading" secondItem="66l-TF-F1n" secondAttribute="leading" id="bq9-CH-Qvg"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="top" constant="8" id="lad-4e-RTz"/>
+                            <constraint firstItem="Wrl-gw-XJK" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="nHH-7M-rI5"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="600"/>
+                    <connections>
+                        <outlet property="logTextView" destination="ayH-z8-Pku" id="3bk-q8-qpQ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,43 +13,46 @@
         <scene sceneID="cwh-vc-ff4">
             <objects>
                 <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="gHE-Vj-kQx"/>
+                        <viewControllerLayoutGuide type="bottom" id="Pgi-ZC-hDV"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wrl-gw-XJK">
-                                <rect key="frame" x="107" y="12" width="106" height="30"/>
+                                <rect key="frame" x="8" y="28" width="106" height="30"/>
                                 <state key="normal" title="Get user profile"/>
                                 <connections>
                                     <action selector="getUserInfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="phE-gy-oaq"/>
                                 </connections>
                             </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ayH-z8-Pku">
+                                <rect key="frame" x="8" y="66" width="304" height="526"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="66l-TF-F1n">
-                                <rect key="frame" x="8" y="50" width="36" height="30"/>
+                                <rect key="frame" x="276" y="28" width="36" height="30"/>
                                 <state key="normal" title="Clear"/>
                                 <connections>
                                     <action selector="clearLogTextView:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="iCp-J9-JX9"/>
                                 </connections>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ayH-z8-Pku">
-                                <rect key="frame" x="8" y="88" width="304" height="504"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="ayH-z8-Pku" secondAttribute="trailing" constant="8" id="IUF-8D-Y0o"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="ayH-z8-Pku" secondAttribute="bottom" constant="8" id="QZ2-rp-2Om"/>
-                            <constraint firstItem="66l-TF-F1n" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="bottom" constant="8" id="TPg-P8-h47"/>
-                            <constraint firstItem="ayH-z8-Pku" firstAttribute="top" secondItem="66l-TF-F1n" secondAttribute="bottom" constant="8" id="TRo-kO-AZz"/>
-                            <constraint firstItem="66l-TF-F1n" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="Wd5-Dp-LJF"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="66l-TF-F1n" secondAttribute="trailing" constant="8" id="Zcu-2V-lkR"/>
-                            <constraint firstItem="ayH-z8-Pku" firstAttribute="leading" secondItem="66l-TF-F1n" secondAttribute="leading" id="bq9-CH-Qvg"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="top" constant="8" id="lad-4e-RTz"/>
-                            <constraint firstItem="Wrl-gw-XJK" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="nHH-7M-rI5"/>
+                            <constraint firstAttribute="trailing" secondItem="66l-TF-F1n" secondAttribute="trailing" constant="8" id="0fk-Fm-60Y"/>
+                            <constraint firstItem="ayH-z8-Pku" firstAttribute="leading" secondItem="Wrl-gw-XJK" secondAttribute="leading" id="5Jg-pg-Fpl"/>
+                            <constraint firstItem="Wrl-gw-XJK" firstAttribute="top" secondItem="gHE-Vj-kQx" secondAttribute="bottom" constant="8" id="Bfk-5O-H7y"/>
+                            <constraint firstAttribute="trailing" secondItem="ayH-z8-Pku" secondAttribute="trailing" constant="8" id="IUF-8D-Y0o"/>
+                            <constraint firstItem="Pgi-ZC-hDV" firstAttribute="top" secondItem="ayH-z8-Pku" secondAttribute="bottom" constant="8" id="QZ2-rp-2Om"/>
+                            <constraint firstItem="66l-TF-F1n" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="top" id="Sa3-U9-n9N"/>
+                            <constraint firstItem="Wrl-gw-XJK" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="8" id="XiP-O8-m3O"/>
+                            <constraint firstItem="66l-TF-F1n" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Wrl-gw-XJK" secondAttribute="trailing" constant="8" id="hSr-b6-Ksj"/>
+                            <constraint firstItem="ayH-z8-Pku" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="bottom" constant="8" id="x8r-X9-nfG"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
@@ -45,6 +45,7 @@
                             <constraint firstItem="66l-TF-F1n" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="bottom" constant="8" id="TPg-P8-h47"/>
                             <constraint firstItem="ayH-z8-Pku" firstAttribute="top" secondItem="66l-TF-F1n" secondAttribute="bottom" constant="8" id="TRo-kO-AZz"/>
                             <constraint firstItem="66l-TF-F1n" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="Wd5-Dp-LJF"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="66l-TF-F1n" secondAttribute="trailing" constant="8" id="Zcu-2V-lkR"/>
                             <constraint firstItem="ayH-z8-Pku" firstAttribute="leading" secondItem="66l-TF-F1n" secondAttribute="leading" id="bq9-CH-Qvg"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="top" secondItem="Wrl-gw-XJK" secondAttribute="top" constant="8" id="lad-4e-RTz"/>
                             <constraint firstItem="Wrl-gw-XJK" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="nHH-7M-rI5"/>

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Example_Extension.entitlements
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Example_Extension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.net.openid.appauth.Example</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Info.plist
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Example_Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.h
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.h
@@ -1,0 +1,24 @@
+/*! @file TodayViewController.h
+    @brief AppAuth iOS SDK Example
+    @copyright
+        Copyright 2015 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface TodayViewController : UIViewController
+
+@end
+

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
@@ -1,0 +1,223 @@
+/*! @file TodayViewController.m
+    @brief AppAuth iOS SDK Example
+    @copyright
+        Copyright 2015 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "TodayViewController.h"
+#import <NotificationCenter/NotificationCenter.h>
+#import <AppAuth/AppAuth.h>
+
+static NSString *const kAppAuthExampleAuthStateKey = @"authState";
+
+@interface TodayViewController () <NCWidgetProviding, OIDAuthStateChangeDelegate>
+
+@property(nonatomic, readonly, nullable) OIDAuthState *authState;
+@property (weak, nonatomic) IBOutlet UITextView *logTextView;
+
+@end
+
+@implementation TodayViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    if ([self.extensionContext respondsToSelector:@selector(setWidgetLargestAvailableDisplayMode:)]) { // iOS 10+
+        [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
+    } else {
+        self.preferredContentSize = CGSizeMake(0, 600.0); // iOS 10-
+    }
+    
+    [self loadState];
+}
+
+- (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
+                         withMaximumSize:(CGSize)maxSize {
+    
+    if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
+        self.preferredContentSize = CGSizeMake(maxSize.width, 600.0);
+    } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
+        self.preferredContentSize = maxSize;
+    }
+}
+
+- (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
+    // Perform any setup necessary in order to update the view.
+    
+    // If an error is encountered, use NCUpdateResultFailed
+    // If there's no update required, use NCUpdateResultNoData
+    // If there's an update, use NCUpdateResultNewData
+    
+    completionHandler(NCUpdateResultNewData);
+}
+
+/*! @brief Loads the @c OIDAuthState from @c NSUSerDefaults.
+ */
+- (void)loadState {
+    // loads OIDAuthState from NSUSerDefaults
+    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+    NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
+    OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
+    [self setAuthState:authState];
+}
+
+/*! @brief Saves the @c OIDAuthState to @c NSUSerDefaults.
+ */
+- (void)saveState {
+    // for production usage consider using the OS Keychain instead
+    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+    NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
+    [userDefaults setObject:archivedAuthState
+                     forKey:kAppAuthExampleAuthStateKey];
+    [userDefaults synchronize];
+}
+
+- (void)setAuthState:(nullable OIDAuthState *)authState {
+    if (_authState == authState) {
+        return;
+    }
+    _authState = authState;
+    _authState.stateChangeDelegate = self;
+    [self stateChanged];
+}
+
+- (void)stateChanged {
+    [self saveState];
+}
+
+- (void)didChangeState:(OIDAuthState *)state {
+    [self stateChanged];
+}
+
+- (IBAction)getUserInfo:(UIButton *)sender {
+    NSURL *userinfoEndpoint =
+    _authState.lastAuthorizationResponse.request.configuration.discoveryDocument.userinfoEndpoint;
+    if (!userinfoEndpoint) {
+        [self logMessage:@"Userinfo endpoint not declared in discovery document"];
+        return;
+    }
+    NSString *currentAccessToken = _authState.lastTokenResponse.accessToken;
+    
+    [self logMessage:@"Performing userinfo request"];
+    
+    [_authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
+                                               NSString *_Nonnull idToken,
+                                               NSError *_Nullable error) {
+        if (error) {
+            [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];
+            return;
+        }
+        
+        // log whether a token refresh occurred
+        if (![currentAccessToken isEqual:accessToken]) {
+            [self logMessage:@"Access token was refreshed automatically (%@ to %@)",
+             currentAccessToken,
+             accessToken];
+        } else {
+            [self logMessage:@"Access token was fresh and not updated [%@]", accessToken];
+        }
+        
+        // creates request to the userinfo endpoint, with access token in the Authorization header
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:userinfoEndpoint];
+        NSString *authorizationHeaderValue = [NSString stringWithFormat:@"Bearer %@", accessToken];
+        [request addValue:authorizationHeaderValue forHTTPHeaderField:@"Authorization"];
+        
+        NSURLSessionConfiguration *configuration =
+        [NSURLSessionConfiguration defaultSessionConfiguration];
+        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
+                                                              delegate:nil
+                                                         delegateQueue:nil];
+        
+        // performs HTTP request
+        NSURLSessionDataTask *postDataTask =
+        [session dataTaskWithRequest:request
+                   completionHandler:^(NSData *_Nullable data,
+                                       NSURLResponse *_Nullable response,
+                                       NSError *_Nullable error) {
+                       dispatch_async(dispatch_get_main_queue(), ^() {
+                           if (error) {
+                               [self logMessage:@"HTTP request failed %@", error];
+                               return;
+                           }
+                           if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+                               [self logMessage:@"Non-HTTP response"];
+                               return;
+                           }
+                           
+                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                           id jsonDictionaryOrArray =
+                           [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+                           
+                           if (httpResponse.statusCode != 200) {
+                               // server replied with an error
+                               NSString *responseText = [[NSString alloc] initWithData:data
+                                                                              encoding:NSUTF8StringEncoding];
+                               if (httpResponse.statusCode == 401) {
+                                   // "401 Unauthorized" generally indicates there is an issue with the authorization
+                                   // grant. Puts OIDAuthState into an error state.
+                                   NSError *oauthError =
+                                   [OIDErrorUtilities resourceServerAuthorizationErrorWithCode:0
+                                                                                 errorResponse:jsonDictionaryOrArray
+                                                                               underlyingError:error];
+                                   [_authState updateWithAuthorizationError:oauthError];
+                                   // log error
+                                   [self logMessage:@"Authorization Error (%@). Response: %@", oauthError, responseText];
+                               } else {
+                                   [self logMessage:@"HTTP: %d. Response: %@",
+                                    (int)httpResponse.statusCode,
+                                    responseText];
+                               }
+                               return;
+                           }
+                           
+                           // success response
+                           [self logMessage:@"Success: %@", jsonDictionaryOrArray];
+                       });
+                   }];
+        
+        [postDataTask resume];
+    }];
+}
+
+/*! @brief Logs a message to stdout and the textfield.
+ @param format The format string and arguments.
+ */
+- (void)logMessage:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2) {
+    // gets message as string
+    va_list argp;
+    va_start(argp, format);
+    NSString *log = [[NSString alloc] initWithFormat:format arguments:argp];
+    va_end(argp);
+    
+    // outputs to stdout
+    NSLog(@"%@", log);
+    
+    // appends to output log
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.dateFormat = @"hh:mm:ss";
+    NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
+    _logTextView.text = [NSString stringWithFormat:@"%@%@%@: %@",
+                         _logTextView.text,
+                         ([_logTextView.text length] > 0) ? @"\n" : @"",
+                         dateString,
+                         log];
+}
+
+- (IBAction)clearLogTextView:(UIButton *)sender {
+    _logTextView.text = @"";
+}
+
+@end
+

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
@@ -32,191 +32,191 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 @implementation TodayViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-    
-    if (@available(iOS 10.0, *)) {
-        [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
-    } else {
-        self.preferredContentSize = CGSizeMake(0, 400.0);
-    }
-    
-    [self loadState];
+  [super viewDidLoad];
+  
+  if (@available(iOS 10.0, *)) {
+    [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
+  } else {
+    self.preferredContentSize = CGSizeMake(0, 400.0);
+  }
+  
+  [self loadState];
 }
 
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
                          withMaximumSize:(CGSize)maxSize NS_AVAILABLE_IOS(10.0) {
-    
-    if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
-        self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
-    } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
-        self.preferredContentSize = maxSize;
-    }
+  
+  if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
+    self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
+  } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
+    self.preferredContentSize = maxSize;
+  }
 }
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
-    // Perform any setup necessary in order to update the view.
-    
-    // If an error is encountered, use NCUpdateResultFailed
-    // If there's no update required, use NCUpdateResultNoData
-    // If there's an update, use NCUpdateResultNewData
-    
-    completionHandler(NCUpdateResultNewData);
+  // Perform any setup necessary in order to update the view.
+  
+  // If an error is encountered, use NCUpdateResultFailed
+  // If there's no update required, use NCUpdateResultNoData
+  // If there's an update, use NCUpdateResultNewData
+  
+  completionHandler(NCUpdateResultNewData);
 }
 
 /*! @brief Loads the @c OIDAuthState from @c NSUSerDefaults.
  */
 - (void)loadState {
-    // loads OIDAuthState from NSUSerDefaults
-    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
-    NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
-    OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
-    [self setAuthState:authState];
+  // loads OIDAuthState from NSUSerDefaults
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
+  OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
+  [self setAuthState:authState];
 }
 
 /*! @brief Saves the @c OIDAuthState to @c NSUSerDefaults.
  */
 - (void)saveState {
-    // for production usage consider using the OS Keychain instead
-    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
-    NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
-    [userDefaults setObject:archivedAuthState
-                     forKey:kAppAuthExampleAuthStateKey];
-    [userDefaults synchronize];
+  // for production usage consider using the OS Keychain instead
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
+  [userDefaults setObject:archivedAuthState
+                   forKey:kAppAuthExampleAuthStateKey];
+  [userDefaults synchronize];
 }
 
 - (void)setAuthState:(nullable OIDAuthState *)authState {
-    if (_authState == authState) {
-        return;
-    }
-    _authState = authState;
-    _authState.stateChangeDelegate = self;
-    [self stateChanged];
+  if (_authState == authState) {
+    return;
+  }
+  _authState = authState;
+  _authState.stateChangeDelegate = self;
+  [self stateChanged];
 }
 
 - (void)stateChanged {
-    [self saveState];
+  [self saveState];
 }
 
 - (void)didChangeState:(OIDAuthState *)state {
-    [self stateChanged];
+  [self stateChanged];
 }
 
 - (IBAction)getUserInfo:(UIButton *)sender {
-    NSURL *userinfoEndpoint =
-    _authState.lastAuthorizationResponse.request.configuration.discoveryDocument.userinfoEndpoint;
-    if (!userinfoEndpoint) {
-        [self logMessage:@"Userinfo endpoint not declared in discovery document"];
-        return;
+  NSURL *userinfoEndpoint =
+  _authState.lastAuthorizationResponse.request.configuration.discoveryDocument.userinfoEndpoint;
+  if (!userinfoEndpoint) {
+    [self logMessage:@"Userinfo endpoint not declared in discovery document"];
+    return;
+  }
+  NSString *currentAccessToken = _authState.lastTokenResponse.accessToken;
+  
+  [self logMessage:@"Performing userinfo request"];
+  
+  [_authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
+                                             NSString *_Nonnull idToken,
+                                             NSError *_Nullable error) {
+    if (error) {
+      [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];
+      return;
     }
-    NSString *currentAccessToken = _authState.lastTokenResponse.accessToken;
     
-    [self logMessage:@"Performing userinfo request"];
+    // log whether a token refresh occurred
+    if (![currentAccessToken isEqual:accessToken]) {
+      [self logMessage:@"Access token was refreshed automatically (%@ to %@)",
+       currentAccessToken,
+       accessToken];
+    } else {
+      [self logMessage:@"Access token was fresh and not updated [%@]", accessToken];
+    }
     
-    [_authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
-                                               NSString *_Nonnull idToken,
-                                               NSError *_Nullable error) {
-        if (error) {
-            [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];
-            return;
-        }
-        
-        // log whether a token refresh occurred
-        if (![currentAccessToken isEqual:accessToken]) {
-            [self logMessage:@"Access token was refreshed automatically (%@ to %@)",
-             currentAccessToken,
-             accessToken];
-        } else {
-            [self logMessage:@"Access token was fresh and not updated [%@]", accessToken];
-        }
-        
-        // creates request to the userinfo endpoint, with access token in the Authorization header
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:userinfoEndpoint];
-        NSString *authorizationHeaderValue = [NSString stringWithFormat:@"Bearer %@", accessToken];
-        [request addValue:authorizationHeaderValue forHTTPHeaderField:@"Authorization"];
-        
-        NSURLSessionConfiguration *configuration =
-        [NSURLSessionConfiguration defaultSessionConfiguration];
-        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
-                                                              delegate:nil
-                                                         delegateQueue:nil];
-        
-        // performs HTTP request
-        NSURLSessionDataTask *postDataTask =
-        [session dataTaskWithRequest:request
-                   completionHandler:^(NSData *_Nullable data,
-                                       NSURLResponse *_Nullable response,
-                                       NSError *_Nullable error) {
-                       dispatch_async(dispatch_get_main_queue(), ^() {
-                           if (error) {
-                               [self logMessage:@"HTTP request failed %@", error];
-                               return;
-                           }
-                           if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-                               [self logMessage:@"Non-HTTP response"];
-                               return;
-                           }
-                           
-                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-                           id jsonDictionaryOrArray =
-                           [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
-                           
-                           if (httpResponse.statusCode != 200) {
-                               // server replied with an error
-                               NSString *responseText = [[NSString alloc] initWithData:data
-                                                                              encoding:NSUTF8StringEncoding];
-                               if (httpResponse.statusCode == 401) {
-                                   // "401 Unauthorized" generally indicates there is an issue with the authorization
-                                   // grant. Puts OIDAuthState into an error state.
-                                   NSError *oauthError =
-                                   [OIDErrorUtilities resourceServerAuthorizationErrorWithCode:0
-                                                                                 errorResponse:jsonDictionaryOrArray
-                                                                               underlyingError:error];
-                                   [_authState updateWithAuthorizationError:oauthError];
-                                   // log error
-                                   [self logMessage:@"Authorization Error (%@). Response: %@", oauthError, responseText];
-                               } else {
-                                   [self logMessage:@"HTTP: %d. Response: %@",
-                                    (int)httpResponse.statusCode,
-                                    responseText];
-                               }
-                               return;
-                           }
-                           
-                           // success response
-                           [self logMessage:@"Success: %@", jsonDictionaryOrArray];
-                       });
-                   }];
-        
-        [postDataTask resume];
-    }];
+    // creates request to the userinfo endpoint, with access token in the Authorization header
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:userinfoEndpoint];
+    NSString *authorizationHeaderValue = [NSString stringWithFormat:@"Bearer %@", accessToken];
+    [request addValue:authorizationHeaderValue forHTTPHeaderField:@"Authorization"];
+    
+    NSURLSessionConfiguration *configuration =
+    [NSURLSessionConfiguration defaultSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
+                                                          delegate:nil
+                                                     delegateQueue:nil];
+    
+    // performs HTTP request
+    NSURLSessionDataTask *postDataTask =
+    [session dataTaskWithRequest:request
+               completionHandler:^(NSData *_Nullable data,
+                                   NSURLResponse *_Nullable response,
+                                   NSError *_Nullable error) {
+                 dispatch_async(dispatch_get_main_queue(), ^() {
+                   if (error) {
+                     [self logMessage:@"HTTP request failed %@", error];
+                     return;
+                   }
+                   if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+                     [self logMessage:@"Non-HTTP response"];
+                     return;
+                   }
+                   
+                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                   id jsonDictionaryOrArray =
+                       [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+                   
+                   if (httpResponse.statusCode != 200) {
+                     // server replied with an error
+                     NSString *responseText = [[NSString alloc] initWithData:data
+                                                                    encoding:NSUTF8StringEncoding];
+                     if (httpResponse.statusCode == 401) {
+                       // "401 Unauthorized" generally indicates there is an issue with the authorization
+                       // grant. Puts OIDAuthState into an error state.
+                       NSError *oauthError =
+                           [OIDErrorUtilities resourceServerAuthorizationErrorWithCode:0
+                                                                         errorResponse:jsonDictionaryOrArray
+                                                                       underlyingError:error];
+                       [_authState updateWithAuthorizationError:oauthError];
+                       // log error
+                       [self logMessage:@"Authorization Error (%@). Response: %@", oauthError, responseText];
+                     } else {
+                       [self logMessage:@"HTTP: %d. Response: %@",
+                                        (int)httpResponse.statusCode,
+                                        responseText];
+                     }
+                     return;
+                   }
+                   
+                   // success response
+                   [self logMessage:@"Success: %@", jsonDictionaryOrArray];
+                 });
+               }];
+    
+    [postDataTask resume];
+  }];
 }
 
 /*! @brief Logs a message to stdout and the textfield.
  @param format The format string and arguments.
  */
 - (void)logMessage:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2) {
-    // gets message as string
-    va_list argp;
-    va_start(argp, format);
-    NSString *log = [[NSString alloc] initWithFormat:format arguments:argp];
-    va_end(argp);
-    
-    // outputs to stdout
-    NSLog(@"%@", log);
-    
-    // appends to output log
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    dateFormatter.dateFormat = @"hh:mm:ss";
-    NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
-    _logTextView.text = [NSString stringWithFormat:@"%@%@%@: %@",
-                         _logTextView.text,
-                         ([_logTextView.text length] > 0) ? @"\n" : @"",
-                         dateString,
-                         log];
+  // gets message as string
+  va_list argp;
+  va_start(argp, format);
+  NSString *log = [[NSString alloc] initWithFormat:format arguments:argp];
+  va_end(argp);
+  
+  // outputs to stdout
+  NSLog(@"%@", log);
+  
+  // appends to output log
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  dateFormatter.dateFormat = @"hh:mm:ss";
+  NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
+  _logTextView.text = [NSString stringWithFormat:@"%@%@%@: %@",
+                                                 _logTextView.text,
+                                                 ([_logTextView.text length] > 0) ? @"\n" : @"",
+                                                 dateString,
+                                                 log];
 }
 
 - (IBAction)clearLogTextView:(UIButton *)sender {
-    _logTextView.text = @"";
+  _logTextView.text = @"";
 }
 
 @end

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
@@ -34,24 +34,27 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    if ([self.extensionContext respondsToSelector:@selector(setWidgetLargestAvailableDisplayMode:)]) { // iOS 10+
+    if (@available(iOS 10.0, *)) {
         [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
     } else {
-        self.preferredContentSize = CGSizeMake(0, 600.0); // iOS 10-
+        self.preferredContentSize = CGSizeMake(0, 400.0);
     }
     
     [self loadState];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
                          withMaximumSize:(CGSize)maxSize {
     
     if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
-        self.preferredContentSize = CGSizeMake(maxSize.width, 600.0);
+        self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
     } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
         self.preferredContentSize = maxSize;
     }
 }
+#pragma clang diagnostic pop
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
     // Perform any setup necessary in order to update the view.

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
@@ -43,10 +43,8 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
     [self loadState];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
-                         withMaximumSize:(CGSize)maxSize {
+                         withMaximumSize:(CGSize)maxSize NS_AVAILABLE_IOS(10.0) {
     
     if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
         self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
@@ -54,7 +52,6 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
         self.preferredContentSize = maxSize;
     }
 }
-#pragma clang diagnostic pop
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
     // Perform any setup necessary in order to update the view.

--- a/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC-Carthage/Example_Extension/TodayViewController.m
@@ -18,7 +18,7 @@
 
 #import "TodayViewController.h"
 #import <NotificationCenter/NotificationCenter.h>
-#import <AppAuth/AppAuth.h>
+#import <AppAuthCore/AppAuthCore.h>
 
 static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 

--- a/Examples/Example-iOS_ObjC-Carthage/Source/AppAuthExampleViewController.m
+++ b/Examples/Example-iOS_ObjC-Carthage/Source/AppAuthExampleViewController.m
@@ -102,18 +102,19 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
  */
 - (void)saveState {
   // for production usage consider using the OS Keychain instead
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
   NSData *archivedAuthState = [ NSKeyedArchiver archivedDataWithRootObject:_authState];
-  [[NSUserDefaults standardUserDefaults] setObject:archivedAuthState
-                                            forKey:kAppAuthExampleAuthStateKey];
-  [[NSUserDefaults standardUserDefaults] synchronize];
+  [userDefaults setObject:archivedAuthState
+                   forKey:kAppAuthExampleAuthStateKey];
+  [userDefaults synchronize];
 }
 
 /*! @brief Loads the @c OIDAuthState from @c NSUSerDefaults.
  */
 - (void)loadState {
   // loads OIDAuthState from NSUSerDefaults
-  NSData *archivedAuthState =
-      [[NSUserDefaults standardUserDefaults] objectForKey:kAppAuthExampleAuthStateKey];
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
   OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
   [self setAuthState:authState];
 }

--- a/Examples/Example-iOS_ObjC-Carthage/Source/Example.entitlements
+++ b/Examples/Example-iOS_ObjC-Carthage/Source/Example.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.net.openid.appauth.Example</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
@@ -215,7 +215,6 @@
 				06D481292055C3D400D9DC32 /* Sources */,
 				06D4812A2055C3D400D9DC32 /* Frameworks */,
 				06D4812B2055C3D400D9DC32 /* Resources */,
-				F998F170E4D14F53FCAA2B07 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -252,8 +251,6 @@
 				346E91651C29D42800D3620B /* Sources */,
 				346E91661C29D42800D3620B /* Frameworks */,
 				346E91671C29D42800D3620B /* Resources */,
-				0B0B46F67786AB6E322D5F2B /* [CP] Embed Pods Frameworks */,
-				3CB1FD4B438DD277394F39A7 /* [CP] Copy Pods Resources */,
 				06D4813E2055C3D400D9DC32 /* Embed App Extensions */,
 			);
 			buildRules = (
@@ -348,36 +345,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0B0B46F67786AB6E322D5F2B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-iOS_ObjC/Pods-Example-iOS_ObjC-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		3CB1FD4B438DD277394F39A7 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-iOS_ObjC/Pods-Example-iOS_ObjC-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		836219F293F319703A16E68D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -412,21 +379,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F998F170E4D14F53FCAA2B07 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-iOS_ObjC_Extension/Pods-Example-iOS_ObjC_Extension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06D4812F2055C3D400D9DC32 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06D4812E2055C3D400D9DC32 /* NotificationCenter.framework */; };
+		06D481332055C3D400D9DC32 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 06D481322055C3D400D9DC32 /* TodayViewController.m */; };
+		06D481362055C3D400D9DC32 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 06D481342055C3D400D9DC32 /* MainInterface.storyboard */; };
+		06D4813A2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 06D4812D2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		341310AA1E6DEF7000D5DEE5 /* AppAuthExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 341310A91E6DEF7000D5DEE5 /* AppAuthExampleTests.m */; };
 		346E916E1C29D42800D3620B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 346E916D1C29D42800D3620B /* main.m */; };
 		346E91711C29D42800D3620B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 346E91701C29D42800D3620B /* AppDelegate.m */; };
@@ -15,10 +19,18 @@
 		346E91991C2A245000D3620B /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 346E91981C2A245000D3620B /* SafariServices.framework */; };
 		34CB09BD1C42007600A54261 /* AppAuthExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 34CB09BB1C42007600A54261 /* AppAuthExampleViewController.m */; };
 		34CB09BE1C42007600A54261 /* AppAuthExampleViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 34CB09BC1C42007600A54261 /* AppAuthExampleViewController.xib */; };
+		D0B5FA33D74A6F7924A47471 /* libPods-Example-iOS_ObjC_Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 715EDB7EC4271193E47615ED /* libPods-Example-iOS_ObjC_Extension.a */; };
 		E46F8589CE9E5DDFA69D835B /* libPods-Example-iOS_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B61A918CBE7B8142CD7D8B3 /* libPods-Example-iOS_ObjC.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		06D481382055C3D400D9DC32 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 346E91611C29D42800D3620B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 06D4812C2055C3D400D9DC32;
+			remoteInfo = "Example-iOS_ObjC_Extension";
+		};
 		341310AC1E6DEF7000D5DEE5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 346E91611C29D42800D3620B /* Project object */;
@@ -28,7 +40,27 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		06D4813E2055C3D400D9DC32 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				06D4813A2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		06D4812D2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Example-iOS_ObjC_Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		06D4812E2055C3D400D9DC32 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		06D481312055C3D400D9DC32 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
+		06D481322055C3D400D9DC32 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
+		06D481352055C3D400D9DC32 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		06D481372055C3D400D9DC32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		09795EAF079B07A1781675D9 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D29B2A58C931A5D41332144 /* Pods-Example-iOS_ObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-iOS_ObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example-iOS_ObjC/Pods-Example-iOS_ObjC.debug.xcconfig"; sourceTree = "<group>"; };
 		341310A71E6DEF7000D5DEE5 /* AppAuthExample-iOS_ObjCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AppAuthExample-iOS_ObjCTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -46,6 +78,9 @@
 		34CB09BA1C42007600A54261 /* AppAuthExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppAuthExampleViewController.h; sourceTree = "<group>"; };
 		34CB09BB1C42007600A54261 /* AppAuthExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppAuthExampleViewController.m; sourceTree = "<group>"; };
 		34CB09BC1C42007600A54261 /* AppAuthExampleViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AppAuthExampleViewController.xib; sourceTree = "<group>"; };
+		3A18DF082AC2FA0980C9DE57 /* Pods-Example-iOS_ObjC_Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-iOS_ObjC_Extension.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example-iOS_ObjC_Extension/Pods-Example-iOS_ObjC_Extension.release.xcconfig"; sourceTree = "<group>"; };
+		715EDB7EC4271193E47615ED /* libPods-Example-iOS_ObjC_Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example-iOS_ObjC_Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		86C7660572AE6FF7A4D1592A /* Pods-Example-iOS_ObjC_Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-iOS_ObjC_Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example-iOS_ObjC_Extension/Pods-Example-iOS_ObjC_Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		8B61A918CBE7B8142CD7D8B3 /* libPods-Example-iOS_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example-iOS_ObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4C31DB4A4928F246AA03805 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		D9867DC6FA9089CD613D4728 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -53,6 +88,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		06D4812A2055C3D400D9DC32 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				06D4812F2055C3D400D9DC32 /* NotificationCenter.framework in Frameworks */,
+				D0B5FA33D74A6F7924A47471 /* libPods-Example-iOS_ObjC_Extension.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		341310A41E6DEF7000D5DEE5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -72,6 +116,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		06D481302055C3D400D9DC32 /* Example-iOS_ObjC_Extension */ = {
+			isa = PBXGroup;
+			children = (
+				06D481312055C3D400D9DC32 /* TodayViewController.h */,
+				06D481322055C3D400D9DC32 /* TodayViewController.m */,
+				06D481342055C3D400D9DC32 /* MainInterface.storyboard */,
+				06D481372055C3D400D9DC32 /* Info.plist */,
+			);
+			path = "Example-iOS_ObjC_Extension";
+			sourceTree = "<group>";
+		};
 		341310A81E6DEF7000D5DEE5 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -88,6 +143,8 @@
 				346E91981C2A245000D3620B /* SafariServices.framework */,
 				09795EAF079B07A1781675D9 /* libPods-Example.a */,
 				8B61A918CBE7B8142CD7D8B3 /* libPods-Example-iOS_ObjC.a */,
+				06D4812E2055C3D400D9DC32 /* NotificationCenter.framework */,
+				715EDB7EC4271193E47615ED /* libPods-Example-iOS_ObjC_Extension.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -97,6 +154,7 @@
 			children = (
 				346E916B1C29D42800D3620B /* Source */,
 				341310A81E6DEF7000D5DEE5 /* Tests */,
+				06D481302055C3D400D9DC32 /* Example-iOS_ObjC_Extension */,
 				341564001C487ABA00ECA3D9 /* Frameworks */,
 				346E916A1C29D42800D3620B /* Products */,
 				6DB0B0125441549B9E4A3E6C /* Pods */,
@@ -108,6 +166,7 @@
 			children = (
 				346E91691C29D42800D3620B /* Example-iOS_ObjC.app */,
 				341310A71E6DEF7000D5DEE5 /* AppAuthExample-iOS_ObjCTests.xctest */,
+				06D4812D2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -135,6 +194,8 @@
 				C4C31DB4A4928F246AA03805 /* Pods-Example.release.xcconfig */,
 				0D29B2A58C931A5D41332144 /* Pods-Example-iOS_ObjC.debug.xcconfig */,
 				ECBCCC4A1A779C83C72044F2 /* Pods-Example-iOS_ObjC.release.xcconfig */,
+				86C7660572AE6FF7A4D1592A /* Pods-Example-iOS_ObjC_Extension.debug.xcconfig */,
+				3A18DF082AC2FA0980C9DE57 /* Pods-Example-iOS_ObjC_Extension.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -142,6 +203,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		06D4812C2055C3D400D9DC32 /* Example-iOS_ObjC_Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 06D4813D2055C3D400D9DC32 /* Build configuration list for PBXNativeTarget "Example-iOS_ObjC_Extension" */;
+			buildPhases = (
+				836219F293F319703A16E68D /* [CP] Check Pods Manifest.lock */,
+				06D481292055C3D400D9DC32 /* Sources */,
+				06D4812A2055C3D400D9DC32 /* Frameworks */,
+				06D4812B2055C3D400D9DC32 /* Resources */,
+				F998F170E4D14F53FCAA2B07 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Example-iOS_ObjC_Extension";
+			productName = "Example-iOS_ObjC_Extension";
+			productReference = 06D4812D2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		341310A61E6DEF7000D5DEE5 /* AppAuthExample-iOS_ObjCTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 341310AE1E6DEF7000D5DEE5 /* Build configuration list for PBXNativeTarget "AppAuthExample-iOS_ObjCTests" */;
@@ -170,10 +250,12 @@
 				346E91671C29D42800D3620B /* Resources */,
 				0B0B46F67786AB6E322D5F2B /* [CP] Embed Pods Frameworks */,
 				3CB1FD4B438DD277394F39A7 /* [CP] Copy Pods Resources */,
+				06D4813E2055C3D400D9DC32 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				06D481392055C3D400D9DC32 /* PBXTargetDependency */,
 			);
 			name = "Example-iOS_ObjC";
 			productName = Example;
@@ -189,6 +271,10 @@
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "William Denniss";
 				TargetAttributes = {
+					06D4812C2055C3D400D9DC32 = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+					};
 					341310A61E6DEF7000D5DEE5 = {
 						CreatedOnToolsVersion = 8.2.1;
 						ProvisioningStyle = Automatic;
@@ -214,11 +300,20 @@
 			targets = (
 				346E91681C29D42800D3620B /* Example-iOS_ObjC */,
 				341310A61E6DEF7000D5DEE5 /* AppAuthExample-iOS_ObjCTests */,
+				06D4812C2055C3D400D9DC32 /* Example-iOS_ObjC_Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		06D4812B2055C3D400D9DC32 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				06D481362055C3D400D9DC32 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		341310A51E6DEF7000D5DEE5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,24 +364,68 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-iOS_ObjC/Pods-Example-iOS_ObjC-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		836219F293F319703A16E68D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-iOS_ObjC_Extension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		C4DC5E3A0D4C7419380FA8C2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-iOS_ObjC-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F998F170E4D14F53FCAA2B07 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example-iOS_ObjC_Extension/Pods-Example-iOS_ObjC_Extension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		06D481292055C3D400D9DC32 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				06D481332055C3D400D9DC32 /* TodayViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		341310A31E6DEF7000D5DEE5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -308,6 +447,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		06D481392055C3D400D9DC32 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 06D4812C2055C3D400D9DC32 /* Example-iOS_ObjC_Extension */;
+			targetProxy = 06D481382055C3D400D9DC32 /* PBXContainerItemProxy */;
+		};
 		341310AD1E6DEF7000D5DEE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 346E91681C29D42800D3620B /* Example-iOS_ObjC */;
@@ -316,6 +460,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		06D481342055C3D400D9DC32 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				06D481352055C3D400D9DC32 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		346E917A1C29D42800D3620B /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -327,6 +479,66 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		06D4813B2055C3D400D9DC32 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 86C7660572AE6FF7A4D1592A /* Pods-Example-iOS_ObjC_Extension.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Example-iOS_ObjC_Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-iOS-ObjC-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		06D4813C2055C3D400D9DC32 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3A18DF082AC2FA0980C9DE57 /* Pods-Example-iOS_ObjC_Extension.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Example-iOS_ObjC_Extension/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-iOS-ObjC-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		341310AF1E6DEF7000D5DEE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -456,6 +668,7 @@
 			baseConfigurationReference = 0D29B2A58C931A5D41332144 /* Pods-Example-iOS_ObjC.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Source/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -469,6 +682,7 @@
 			baseConfigurationReference = ECBCCC4A1A779C83C72044F2 /* Pods-Example-iOS_ObjC.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Source/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -480,6 +694,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		06D4813D2055C3D400D9DC32 /* Build configuration list for PBXNativeTarget "Example-iOS_ObjC_Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				06D4813B2055C3D400D9DC32 /* Debug */,
+				06D4813C2055C3D400D9DC32 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		341310AE1E6DEF7000D5DEE5 /* Build configuration list for PBXNativeTarget "AppAuthExample-iOS_ObjCTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06462428205EB35400072191 /* Example-iOS_ObjC.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Example-iOS_ObjC.entitlements"; sourceTree = "<group>"; };
+		06462429205EB37A00072191 /* Example-iOS_ObjC_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Example-iOS_ObjC_Extension.entitlements"; sourceTree = "<group>"; };
 		06D4812D2055C3D400D9DC32 /* Example-iOS_ObjC_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Example-iOS_ObjC_Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		06D4812E2055C3D400D9DC32 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		06D481312055C3D400D9DC32 /* TodayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayViewController.h; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				06D481322055C3D400D9DC32 /* TodayViewController.m */,
 				06D481342055C3D400D9DC32 /* MainInterface.storyboard */,
 				06D481372055C3D400D9DC32 /* Info.plist */,
+				06462429205EB37A00072191 /* Example-iOS_ObjC_Extension.entitlements */,
 			);
 			path = "Example-iOS_ObjC_Extension";
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				346E91781C29D42800D3620B /* Assets.xcassets */,
 				346E917A1C29D42800D3620B /* LaunchScreen.storyboard */,
 				346E917D1C29D42800D3620B /* Info.plist */,
+				06462428205EB35400072191 /* Example-iOS_ObjC.entitlements */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -274,6 +278,11 @@
 					06D4812C2055C3D400D9DC32 = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 					341310A61E6DEF7000D5DEE5 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -282,6 +291,11 @@
 					};
 					346E91681C29D42800D3620B = {
 						CreatedOnToolsVersion = 7.2;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -496,8 +510,10 @@
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Example-iOS_ObjC_Extension/Example-iOS_ObjC_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Example-iOS_ObjC_Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
@@ -526,8 +542,10 @@
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Example-iOS_ObjC_Extension/Example-iOS_ObjC_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Example-iOS_ObjC_Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
@@ -668,7 +686,9 @@
 			baseConfigurationReference = 0D29B2A58C931A5D41332144 /* Pods-Example-iOS_ObjC.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "Source/Example-iOS_ObjC.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Source/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -682,7 +702,9 @@
 			baseConfigurationReference = ECBCCC4A1A779C83C72044F2 /* Pods-Example-iOS_ObjC.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "Source/Example-iOS_ObjC.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Source/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Example-iOS_ObjC_Extension/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-iOS-ObjC-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -548,7 +548,7 @@
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Example-iOS_ObjC_Extension/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-iOS-ObjC-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/xcshareddata/xcschemes/Example-iOS_ObjC_Extension.xcscheme
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC.xcodeproj/xcshareddata/xcschemes/Example-iOS_ObjC_Extension.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "06D4812C2055C3D400D9DC32"
+               BuildableName = "Example-iOS_ObjC_Extension.appex"
+               BlueprintName = "Example-iOS_ObjC_Extension"
+               ReferencedContainer = "container:Example-iOS_ObjC.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "346E91681C29D42800D3620B"
+               BuildableName = "Example-iOS_ObjC.app"
+               BlueprintName = "Example-iOS_ObjC"
+               ReferencedContainer = "container:Example-iOS_ObjC.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06D4812C2055C3D400D9DC32"
+            BuildableName = "Example-iOS_ObjC_Extension.appex"
+            BlueprintName = "Example-iOS_ObjC_Extension"
+            ReferencedContainer = "container:Example-iOS_ObjC.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06D4812C2055C3D400D9DC32"
+            BuildableName = "Example-iOS_ObjC_Extension.appex"
+            BlueprintName = "Example-iOS_ObjC_Extension"
+            ReferencedContainer = "container:Example-iOS_ObjC.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06D4812C2055C3D400D9DC32"
+            BuildableName = "Example-iOS_ObjC_Extension.appex"
+            BlueprintName = "Example-iOS_ObjC_Extension"
+            ReferencedContainer = "container:Example-iOS_ObjC.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "346E91681C29D42800D3620B"
+            BuildableName = "Example-iOS_ObjC.app"
+            BlueprintName = "Example-iOS_ObjC"
+            ReferencedContainer = "container:Example-iOS_ObjC.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,43 +13,46 @@
         <scene sceneID="cwh-vc-ff4">
             <objects>
                 <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="h1m-gk-Ifv"/>
+                        <viewControllerLayoutGuide type="bottom" id="6wY-PY-xe7"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ueb-rd-oaa">
-                                <rect key="frame" x="107" y="28" width="106" height="30"/>
-                                <state key="normal" title="Get user profile"/>
-                                <connections>
-                                    <action selector="getUserInfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="eq5-4v-GO2"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YY6-lX-cn2">
-                                <rect key="frame" x="8" y="66" width="36" height="30"/>
+                                <rect key="frame" x="276" y="28" width="36" height="30"/>
                                 <state key="normal" title="Clear"/>
                                 <connections>
                                     <action selector="clearLogTextView:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="jx1-VM-nJq"/>
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="AiD-Q7-M0I">
-                                <rect key="frame" x="8" y="104" width="304" height="488"/>
+                                <rect key="frame" x="8" y="66" width="304" height="526"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ueb-rd-oaa">
+                                <rect key="frame" x="8" y="28" width="106" height="30"/>
+                                <state key="normal" title="Get user profile"/>
+                                <connections>
+                                    <action selector="getUserInfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="eq5-4v-GO2"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="AiD-Q7-M0I" firstAttribute="top" secondItem="YY6-lX-cn2" secondAttribute="bottom" constant="8" id="0Yb-JH-FMU"/>
-                            <constraint firstItem="YY6-lX-cn2" firstAttribute="top" secondItem="Ueb-rd-oaa" secondAttribute="bottom" constant="8" id="5mU-tH-hP1"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="AiD-Q7-M0I" secondAttribute="bottom" constant="8" id="6DA-bw-L9M"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YY6-lX-cn2" secondAttribute="trailing" constant="8" id="PKo-Pm-HC1"/>
-                            <constraint firstItem="AiD-Q7-M0I" firstAttribute="leading" secondItem="YY6-lX-cn2" secondAttribute="leading" id="UHN-Bw-uZJ"/>
-                            <constraint firstItem="YY6-lX-cn2" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="ZHD-EG-EQB"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="AiD-Q7-M0I" secondAttribute="trailing" constant="8" id="bWH-bb-nBT"/>
-                            <constraint firstItem="Ueb-rd-oaa" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="l1C-eg-Yiu"/>
-                            <constraint firstItem="Ueb-rd-oaa" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="sea-0h-aBQ"/>
+                            <constraint firstItem="6wY-PY-xe7" firstAttribute="top" secondItem="AiD-Q7-M0I" secondAttribute="bottom" constant="8" id="6DA-bw-L9M"/>
+                            <constraint firstItem="Ueb-rd-oaa" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="8" id="8Vc-pz-xik"/>
+                            <constraint firstItem="AiD-Q7-M0I" firstAttribute="leading" secondItem="Ueb-rd-oaa" secondAttribute="leading" id="UDH-TZ-YRi"/>
+                            <constraint firstItem="YY6-lX-cn2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ueb-rd-oaa" secondAttribute="trailing" constant="8" id="YIs-89-CnX"/>
+                            <constraint firstItem="Ueb-rd-oaa" firstAttribute="top" secondItem="h1m-gk-Ifv" secondAttribute="bottom" constant="8" id="Yqa-IX-kle"/>
+                            <constraint firstItem="AiD-Q7-M0I" firstAttribute="top" secondItem="Ueb-rd-oaa" secondAttribute="bottom" constant="8" id="aD8-cd-d2y"/>
+                            <constraint firstAttribute="trailing" secondItem="AiD-Q7-M0I" secondAttribute="trailing" constant="8" id="bWH-bb-nBT"/>
+                            <constraint firstItem="YY6-lX-cn2" firstAttribute="top" secondItem="Ueb-rd-oaa" secondAttribute="top" id="bcH-7Z-WbJ"/>
+                            <constraint firstAttribute="trailing" secondItem="YY6-lX-cn2" secondAttribute="trailing" constant="8" id="lmT-M5-mge"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <rect key="frame" x="0.0" y="20" width="320" height="580"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ueb-rd-oaa">
+                                <rect key="frame" x="107" y="28" width="106" height="30"/>
+                                <state key="normal" title="Get user profile"/>
+                                <connections>
+                                    <action selector="getUserInfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="eq5-4v-GO2"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YY6-lX-cn2">
+                                <rect key="frame" x="8" y="66" width="36" height="30"/>
+                                <state key="normal" title="Clear"/>
+                                <connections>
+                                    <action selector="clearLogTextView:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="jx1-VM-nJq"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="AiD-Q7-M0I">
+                                <rect key="frame" x="8" y="104" width="304" height="488"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="GcN-lo-r42" secondAttribute="bottom" symbolic="YES" id="0Q0-KW-PJ6"/>
+                            <constraint firstItem="AiD-Q7-M0I" firstAttribute="top" secondItem="YY6-lX-cn2" secondAttribute="bottom" constant="8" id="0Yb-JH-FMU"/>
+                            <constraint firstItem="YY6-lX-cn2" firstAttribute="top" secondItem="Ueb-rd-oaa" secondAttribute="bottom" constant="8" id="5mU-tH-hP1"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="AiD-Q7-M0I" secondAttribute="bottom" constant="8" id="6DA-bw-L9M"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" symbolic="YES" id="6Vq-gs-PHe"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="AiD-Q7-M0I" firstAttribute="leading" secondItem="YY6-lX-cn2" secondAttribute="leading" id="UHN-Bw-uZJ"/>
+                            <constraint firstItem="YY6-lX-cn2" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="ZHD-EG-EQB"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="AiD-Q7-M0I" secondAttribute="trailing" constant="8" id="bWH-bb-nBT"/>
+                            <constraint firstItem="Ueb-rd-oaa" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="l1C-eg-Yiu"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" symbolic="YES" id="mYS-Cv-VNx"/>
+                            <constraint firstItem="Ueb-rd-oaa" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="sea-0h-aBQ"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="600"/>
+                    <connections>
+                        <outlet property="logTextView" destination="AiD-Q7-M0I" id="g85-OL-vdU"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
@@ -18,12 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
-                                <rect key="frame" x="0.0" y="20" width="320" height="580"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ueb-rd-oaa">
                                 <rect key="frame" x="107" y="28" width="106" height="30"/>
                                 <state key="normal" title="Get user profile"/>
@@ -46,17 +40,13 @@
                             </textView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="GcN-lo-r42" secondAttribute="bottom" symbolic="YES" id="0Q0-KW-PJ6"/>
                             <constraint firstItem="AiD-Q7-M0I" firstAttribute="top" secondItem="YY6-lX-cn2" secondAttribute="bottom" constant="8" id="0Yb-JH-FMU"/>
                             <constraint firstItem="YY6-lX-cn2" firstAttribute="top" secondItem="Ueb-rd-oaa" secondAttribute="bottom" constant="8" id="5mU-tH-hP1"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="AiD-Q7-M0I" secondAttribute="bottom" constant="8" id="6DA-bw-L9M"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" symbolic="YES" id="6Vq-gs-PHe"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" symbolic="YES" id="L8K-9R-egU"/>
                             <constraint firstItem="AiD-Q7-M0I" firstAttribute="leading" secondItem="YY6-lX-cn2" secondAttribute="leading" id="UHN-Bw-uZJ"/>
                             <constraint firstItem="YY6-lX-cn2" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="ZHD-EG-EQB"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="AiD-Q7-M0I" secondAttribute="trailing" constant="8" id="bWH-bb-nBT"/>
                             <constraint firstItem="Ueb-rd-oaa" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="l1C-eg-Yiu"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" symbolic="YES" id="mYS-Cv-VNx"/>
                             <constraint firstItem="Ueb-rd-oaa" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="sea-0h-aBQ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Base.lproj/MainInterface.storyboard
@@ -43,6 +43,7 @@
                             <constraint firstItem="AiD-Q7-M0I" firstAttribute="top" secondItem="YY6-lX-cn2" secondAttribute="bottom" constant="8" id="0Yb-JH-FMU"/>
                             <constraint firstItem="YY6-lX-cn2" firstAttribute="top" secondItem="Ueb-rd-oaa" secondAttribute="bottom" constant="8" id="5mU-tH-hP1"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="AiD-Q7-M0I" secondAttribute="bottom" constant="8" id="6DA-bw-L9M"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YY6-lX-cn2" secondAttribute="trailing" constant="8" id="PKo-Pm-HC1"/>
                             <constraint firstItem="AiD-Q7-M0I" firstAttribute="leading" secondItem="YY6-lX-cn2" secondAttribute="leading" id="UHN-Bw-uZJ"/>
                             <constraint firstItem="YY6-lX-cn2" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="ZHD-EG-EQB"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="AiD-Q7-M0I" secondAttribute="trailing" constant="8" id="bWH-bb-nBT"/>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Example-iOS_ObjC_Extension.entitlements
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Example-iOS_ObjC_Extension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.net.openid.appauth.Example</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Info.plist
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Example-iOS_ObjC_Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.h
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.h
@@ -1,19 +1,19 @@
 /*! @file TodayViewController.h
- @brief AppAuth iOS SDK Example
- @copyright
- Copyright 2015 Google Inc. All Rights Reserved.
- @copydetails
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+    @brief AppAuth iOS SDK Example
+    @copyright
+        Copyright 2015 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
  
- http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
  
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
  */
 
 #import <UIKit/UIKit.h>

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.h
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.h
@@ -1,10 +1,20 @@
-//
-//  TodayViewController.h
-//  Example-iOS_ObjC_Extension
-//
-//  Created by Julien Bodet on 2018-03-11.
-//  Copyright © 2018 William Denniss. All rights reserved.
-//
+/*! @file TodayViewController.h
+ @brief AppAuth iOS SDK Example
+ @copyright
+ Copyright 2015 Google Inc. All Rights Reserved.
+ @copydetails
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.h
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.h
@@ -1,0 +1,13 @@
+//
+//  TodayViewController.h
+//  Example-iOS_ObjC_Extension
+//
+//  Created by Julien Bodet on 2018-03-11.
+//  Copyright © 2018 William Denniss. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface TodayViewController : UIViewController
+
+@end

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -1,10 +1,20 @@
-//
-//  TodayViewController.m
-//  Example-iOS_ObjC_Extension
-//
-//  Created by Julien Bodet on 2018-03-11.
-//  Copyright © 2018 William Denniss. All rights reserved.
-//
+/*! @file TodayViewController.m
+ @brief AppAuth iOS SDK Example
+ @copyright
+ Copyright 2015 Google Inc. All Rights Reserved.
+ @copydetails
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 
 #import "TodayViewController.h"
 #import <NotificationCenter/NotificationCenter.h>
@@ -31,10 +41,6 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
     }
     
     [self loadState];
-}
-
-- (void) viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
 }
 
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
@@ -207,6 +213,7 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
                          dateString,
                          log];
 }
+
 - (IBAction)clearLogTextView:(UIButton *)sender {
     _logTextView.text = @"";
 }

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -18,7 +18,7 @@
 
 #import "TodayViewController.h"
 #import <NotificationCenter/NotificationCenter.h>
-#import <AppAuth.h>
+#import <AppAuthCore.h>
 
 static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -32,191 +32,191 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 @implementation TodayViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-    
-    if (@available(iOS 10, *)) {
-        [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
-    } else {
-        self.preferredContentSize = CGSizeMake(0, 400.0);
-    }
-    
-    [self loadState];
+  [super viewDidLoad];
+  
+  if (@available(iOS 10, *)) {
+    [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
+  } else {
+    self.preferredContentSize = CGSizeMake(0, 400.0);
+  }
+  
+  [self loadState];
 }
 
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
                          withMaximumSize:(CGSize)maxSize NS_AVAILABLE_IOS(10.0) {
-    
-    if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
-        self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
-    } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
-        self.preferredContentSize = maxSize;
-    }
+  
+  if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
+    self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
+  } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
+    self.preferredContentSize = maxSize;
+  }
 }
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
-    // Perform any setup necessary in order to update the view.
-    
-    // If an error is encountered, use NCUpdateResultFailed
-    // If there's no update required, use NCUpdateResultNoData
-    // If there's an update, use NCUpdateResultNewData
-    
-    completionHandler(NCUpdateResultNewData);
+  // Perform any setup necessary in order to update the view.
+  
+  // If an error is encountered, use NCUpdateResultFailed
+  // If there's no update required, use NCUpdateResultNoData
+  // If there's an update, use NCUpdateResultNewData
+  
+  completionHandler(NCUpdateResultNewData);
 }
 
 /*! @brief Loads the @c OIDAuthState from @c NSUSerDefaults.
  */
 - (void)loadState {
-    // loads OIDAuthState from NSUSerDefaults
-    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
-    NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
-    OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
-    [self setAuthState:authState];
+  // loads OIDAuthState from NSUSerDefaults
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
+  OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
+  [self setAuthState:authState];
 }
 
 /*! @brief Saves the @c OIDAuthState to @c NSUSerDefaults.
  */
 - (void)saveState {
-    // for production usage consider using the OS Keychain instead
-    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
-    NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
-    [userDefaults setObject:archivedAuthState
-                     forKey:kAppAuthExampleAuthStateKey];
-    [userDefaults synchronize];
+  // for production usage consider using the OS Keychain instead
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
+  [userDefaults setObject:archivedAuthState
+                   forKey:kAppAuthExampleAuthStateKey];
+  [userDefaults synchronize];
 }
 
 - (void)setAuthState:(nullable OIDAuthState *)authState {
-    if (_authState == authState) {
-        return;
-    }
-    _authState = authState;
-    _authState.stateChangeDelegate = self;
-    [self stateChanged];
+  if (_authState == authState) {
+    return;
+  }
+  _authState = authState;
+  _authState.stateChangeDelegate = self;
+  [self stateChanged];
 }
 
 - (void)stateChanged {
-    [self saveState];
+  [self saveState];
 }
 
 - (void)didChangeState:(OIDAuthState *)state {
-    [self stateChanged];
+  [self stateChanged];
 }
 
 - (IBAction)getUserInfo:(UIButton *)sender {
-    NSURL *userinfoEndpoint =
-    _authState.lastAuthorizationResponse.request.configuration.discoveryDocument.userinfoEndpoint;
-    if (!userinfoEndpoint) {
-        [self logMessage:@"Userinfo endpoint not declared in discovery document"];
-        return;
+  NSURL *userinfoEndpoint =
+  _authState.lastAuthorizationResponse.request.configuration.discoveryDocument.userinfoEndpoint;
+  if (!userinfoEndpoint) {
+    [self logMessage:@"Userinfo endpoint not declared in discovery document"];
+    return;
+  }
+  NSString *currentAccessToken = _authState.lastTokenResponse.accessToken;
+  
+  [self logMessage:@"Performing userinfo request"];
+  
+  [_authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
+                                             NSString *_Nonnull idToken,
+                                             NSError *_Nullable error) {
+    if (error) {
+      [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];
+      return;
     }
-    NSString *currentAccessToken = _authState.lastTokenResponse.accessToken;
     
-    [self logMessage:@"Performing userinfo request"];
+    // log whether a token refresh occurred
+    if (![currentAccessToken isEqual:accessToken]) {
+      [self logMessage:@"Access token was refreshed automatically (%@ to %@)",
+       currentAccessToken,
+       accessToken];
+    } else {
+      [self logMessage:@"Access token was fresh and not updated [%@]", accessToken];
+    }
     
-    [_authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
-                                               NSString *_Nonnull idToken,
-                                               NSError *_Nullable error) {
-        if (error) {
-            [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];
-            return;
-        }
-        
-        // log whether a token refresh occurred
-        if (![currentAccessToken isEqual:accessToken]) {
-            [self logMessage:@"Access token was refreshed automatically (%@ to %@)",
-             currentAccessToken,
-             accessToken];
-        } else {
-            [self logMessage:@"Access token was fresh and not updated [%@]", accessToken];
-        }
-        
-        // creates request to the userinfo endpoint, with access token in the Authorization header
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:userinfoEndpoint];
-        NSString *authorizationHeaderValue = [NSString stringWithFormat:@"Bearer %@", accessToken];
-        [request addValue:authorizationHeaderValue forHTTPHeaderField:@"Authorization"];
-        
-        NSURLSessionConfiguration *configuration =
-        [NSURLSessionConfiguration defaultSessionConfiguration];
-        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
-                                                              delegate:nil
-                                                         delegateQueue:nil];
-        
-        // performs HTTP request
-        NSURLSessionDataTask *postDataTask =
-        [session dataTaskWithRequest:request
-                   completionHandler:^(NSData *_Nullable data,
-                                       NSURLResponse *_Nullable response,
-                                       NSError *_Nullable error) {
-                       dispatch_async(dispatch_get_main_queue(), ^() {
-                           if (error) {
-                               [self logMessage:@"HTTP request failed %@", error];
-                               return;
-                           }
-                           if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-                               [self logMessage:@"Non-HTTP response"];
-                               return;
-                           }
-                           
-                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-                           id jsonDictionaryOrArray =
-                           [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
-                           
-                           if (httpResponse.statusCode != 200) {
-                               // server replied with an error
-                               NSString *responseText = [[NSString alloc] initWithData:data
-                                                                              encoding:NSUTF8StringEncoding];
-                               if (httpResponse.statusCode == 401) {
-                                   // "401 Unauthorized" generally indicates there is an issue with the authorization
-                                   // grant. Puts OIDAuthState into an error state.
-                                   NSError *oauthError =
-                                   [OIDErrorUtilities resourceServerAuthorizationErrorWithCode:0
-                                                                                 errorResponse:jsonDictionaryOrArray
-                                                                               underlyingError:error];
-                                   [_authState updateWithAuthorizationError:oauthError];
-                                   // log error
-                                   [self logMessage:@"Authorization Error (%@). Response: %@", oauthError, responseText];
-                               } else {
-                                   [self logMessage:@"HTTP: %d. Response: %@",
-                                    (int)httpResponse.statusCode,
-                                    responseText];
-                               }
-                               return;
-                           }
-                           
-                           // success response
-                           [self logMessage:@"Success: %@", jsonDictionaryOrArray];
-                       });
-                   }];
-        
-        [postDataTask resume];
-    }];
+    // creates request to the userinfo endpoint, with access token in the Authorization header
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:userinfoEndpoint];
+    NSString *authorizationHeaderValue = [NSString stringWithFormat:@"Bearer %@", accessToken];
+    [request addValue:authorizationHeaderValue forHTTPHeaderField:@"Authorization"];
+    
+    NSURLSessionConfiguration *configuration =
+    [NSURLSessionConfiguration defaultSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
+                                                          delegate:nil
+                                                     delegateQueue:nil];
+    
+    // performs HTTP request
+    NSURLSessionDataTask *postDataTask =
+    [session dataTaskWithRequest:request
+               completionHandler:^(NSData *_Nullable data,
+                                   NSURLResponse *_Nullable response,
+                                   NSError *_Nullable error) {
+                 dispatch_async(dispatch_get_main_queue(), ^() {
+                   if (error) {
+                     [self logMessage:@"HTTP request failed %@", error];
+                     return;
+                   }
+                   if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+                     [self logMessage:@"Non-HTTP response"];
+                     return;
+                   }
+                   
+                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                   id jsonDictionaryOrArray =
+                       [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+                   
+                   if (httpResponse.statusCode != 200) {
+                     // server replied with an error
+                     NSString *responseText = [[NSString alloc] initWithData:data
+                                                                    encoding:NSUTF8StringEncoding];
+                     if (httpResponse.statusCode == 401) {
+                       // "401 Unauthorized" generally indicates there is an issue with the authorization
+                       // grant. Puts OIDAuthState into an error state.
+                       NSError *oauthError =
+                           [OIDErrorUtilities resourceServerAuthorizationErrorWithCode:0
+                                                                         errorResponse:jsonDictionaryOrArray
+                                                                       underlyingError:error];
+                       [_authState updateWithAuthorizationError:oauthError];
+                       // log error
+                       [self logMessage:@"Authorization Error (%@). Response: %@", oauthError, responseText];
+                     } else {
+                       [self logMessage:@"HTTP: %d. Response: %@",
+                                        (int)httpResponse.statusCode,
+                                        responseText];
+                     }
+                     return;
+                   }
+                   
+                   // success response
+                   [self logMessage:@"Success: %@", jsonDictionaryOrArray];
+                 });
+               }];
+    
+    [postDataTask resume];
+  }];
 }
 
 /*! @brief Logs a message to stdout and the textfield.
  @param format The format string and arguments.
  */
 - (void)logMessage:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2) {
-    // gets message as string
-    va_list argp;
-    va_start(argp, format);
-    NSString *log = [[NSString alloc] initWithFormat:format arguments:argp];
-    va_end(argp);
-    
-    // outputs to stdout
-    NSLog(@"%@", log);
-    
-    // appends to output log
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    dateFormatter.dateFormat = @"hh:mm:ss";
-    NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
-    _logTextView.text = [NSString stringWithFormat:@"%@%@%@: %@",
-                         _logTextView.text,
-                         ([_logTextView.text length] > 0) ? @"\n" : @"",
-                         dateString,
-                         log];
+  // gets message as string
+  va_list argp;
+  va_start(argp, format);
+  NSString *log = [[NSString alloc] initWithFormat:format arguments:argp];
+  va_end(argp);
+  
+  // outputs to stdout
+  NSLog(@"%@", log);
+  
+  // appends to output log
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  dateFormatter.dateFormat = @"hh:mm:ss";
+  NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
+  _logTextView.text = [NSString stringWithFormat:@"%@%@%@: %@",
+                                                 _logTextView.text,
+                                                 ([_logTextView.text length] > 0) ? @"\n" : @"",
+                                                 dateString,
+                                                 log];
 }
 
 - (IBAction)clearLogTextView:(UIButton *)sender {
-    _logTextView.text = @"";
+  _logTextView.text = @"";
 }
 
 @end

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -67,8 +67,8 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
  */
 - (void)loadState {
     // loads OIDAuthState from NSUSerDefaults
-    NSData *archivedAuthState =
-    [[NSUserDefaults standardUserDefaults] objectForKey:kAppAuthExampleAuthStateKey];
+    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+    NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
     OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
     [self setAuthState:authState];
 }
@@ -77,10 +77,11 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
  */
 - (void)saveState {
     // for production usage consider using the OS Keychain instead
-    NSData *archivedAuthState = [ NSKeyedArchiver archivedDataWithRootObject:_authState];
-    [[NSUserDefaults standardUserDefaults] setObject:archivedAuthState
-                                              forKey:kAppAuthExampleAuthStateKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+    NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
+    [userDefaults setObject:archivedAuthState
+                     forKey:kAppAuthExampleAuthStateKey];
+    [userDefaults synchronize];
 }
 
 - (void)setAuthState:(nullable OIDAuthState *)authState {

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -34,24 +34,27 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    if ([self.extensionContext respondsToSelector:@selector(setWidgetLargestAvailableDisplayMode:)]) { // iOS 10+
+    if (@available(iOS 10, *)) {
         [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
     } else {
-        self.preferredContentSize = CGSizeMake(0, 600.0); // iOS 10-
+        self.preferredContentSize = CGSizeMake(0, 400.0);
     }
     
     [self loadState];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
                          withMaximumSize:(CGSize)maxSize {
     
     if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
-        self.preferredContentSize = CGSizeMake(maxSize.width, 600.0);
+        self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
     } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
         self.preferredContentSize = maxSize;
     }
 }
+#pragma clang diagnostic pop
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
     // Perform any setup necessary in order to update the view.

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -1,0 +1,214 @@
+//
+//  TodayViewController.m
+//  Example-iOS_ObjC_Extension
+//
+//  Created by Julien Bodet on 2018-03-11.
+//  Copyright © 2018 William Denniss. All rights reserved.
+//
+
+#import "TodayViewController.h"
+#import <NotificationCenter/NotificationCenter.h>
+#import <AppAuth.h>
+
+static NSString *const kAppAuthExampleAuthStateKey = @"authState";
+
+@interface TodayViewController () <NCWidgetProviding, OIDAuthStateChangeDelegate>
+
+@property(nonatomic, readonly, nullable) OIDAuthState *authState;
+@property (weak, nonatomic) IBOutlet UITextView *logTextView;
+
+@end
+
+@implementation TodayViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    if ([self.extensionContext respondsToSelector:@selector(setWidgetLargestAvailableDisplayMode:)]) { // iOS 10+
+        [self.extensionContext setWidgetLargestAvailableDisplayMode:NCWidgetDisplayModeExpanded];
+    } else {
+        self.preferredContentSize = CGSizeMake(0, 600.0); // iOS 10-
+    }
+    
+    [self loadState];
+}
+
+- (void) viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+}
+
+- (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
+                         withMaximumSize:(CGSize)maxSize {
+    
+    if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
+        self.preferredContentSize = CGSizeMake(maxSize.width, 600.0);
+    } else if (activeDisplayMode == NCWidgetDisplayModeCompact) {
+        self.preferredContentSize = maxSize;
+    }
+}
+
+- (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
+    // Perform any setup necessary in order to update the view.
+    
+    // If an error is encountered, use NCUpdateResultFailed
+    // If there's no update required, use NCUpdateResultNoData
+    // If there's an update, use NCUpdateResultNewData
+    
+    completionHandler(NCUpdateResultNewData);
+}
+
+/*! @brief Loads the @c OIDAuthState from @c NSUSerDefaults.
+ */
+- (void)loadState {
+    // loads OIDAuthState from NSUSerDefaults
+    NSData *archivedAuthState =
+    [[NSUserDefaults standardUserDefaults] objectForKey:kAppAuthExampleAuthStateKey];
+    OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
+    [self setAuthState:authState];
+}
+
+/*! @brief Saves the @c OIDAuthState to @c NSUSerDefaults.
+ */
+- (void)saveState {
+    // for production usage consider using the OS Keychain instead
+    NSData *archivedAuthState = [ NSKeyedArchiver archivedDataWithRootObject:_authState];
+    [[NSUserDefaults standardUserDefaults] setObject:archivedAuthState
+                                              forKey:kAppAuthExampleAuthStateKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)setAuthState:(nullable OIDAuthState *)authState {
+    if (_authState == authState) {
+        return;
+    }
+    _authState = authState;
+    _authState.stateChangeDelegate = self;
+    [self stateChanged];
+}
+
+- (void)stateChanged {
+    [self saveState];
+}
+
+- (void)didChangeState:(OIDAuthState *)state {
+    [self stateChanged];
+}
+
+- (IBAction)getUserInfo:(UIButton *)sender {
+    NSURL *userinfoEndpoint =
+    _authState.lastAuthorizationResponse.request.configuration.discoveryDocument.userinfoEndpoint;
+    if (!userinfoEndpoint) {
+        [self logMessage:@"Userinfo endpoint not declared in discovery document"];
+        return;
+    }
+    NSString *currentAccessToken = _authState.lastTokenResponse.accessToken;
+    
+    [self logMessage:@"Performing userinfo request"];
+    
+    [_authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
+                                               NSString *_Nonnull idToken,
+                                               NSError *_Nullable error) {
+        if (error) {
+            [self logMessage:@"Error fetching fresh tokens: %@", [error localizedDescription]];
+            return;
+        }
+        
+        // log whether a token refresh occurred
+        if (![currentAccessToken isEqual:accessToken]) {
+            [self logMessage:@"Access token was refreshed automatically (%@ to %@)",
+             currentAccessToken,
+             accessToken];
+        } else {
+            [self logMessage:@"Access token was fresh and not updated [%@]", accessToken];
+        }
+        
+        // creates request to the userinfo endpoint, with access token in the Authorization header
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:userinfoEndpoint];
+        NSString *authorizationHeaderValue = [NSString stringWithFormat:@"Bearer %@", accessToken];
+        [request addValue:authorizationHeaderValue forHTTPHeaderField:@"Authorization"];
+        
+        NSURLSessionConfiguration *configuration =
+        [NSURLSessionConfiguration defaultSessionConfiguration];
+        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
+                                                              delegate:nil
+                                                         delegateQueue:nil];
+        
+        // performs HTTP request
+        NSURLSessionDataTask *postDataTask =
+        [session dataTaskWithRequest:request
+                   completionHandler:^(NSData *_Nullable data,
+                                       NSURLResponse *_Nullable response,
+                                       NSError *_Nullable error) {
+                       dispatch_async(dispatch_get_main_queue(), ^() {
+                           if (error) {
+                               [self logMessage:@"HTTP request failed %@", error];
+                               return;
+                           }
+                           if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+                               [self logMessage:@"Non-HTTP response"];
+                               return;
+                           }
+                           
+                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                           id jsonDictionaryOrArray =
+                           [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+                           
+                           if (httpResponse.statusCode != 200) {
+                               // server replied with an error
+                               NSString *responseText = [[NSString alloc] initWithData:data
+                                                                              encoding:NSUTF8StringEncoding];
+                               if (httpResponse.statusCode == 401) {
+                                   // "401 Unauthorized" generally indicates there is an issue with the authorization
+                                   // grant. Puts OIDAuthState into an error state.
+                                   NSError *oauthError =
+                                   [OIDErrorUtilities resourceServerAuthorizationErrorWithCode:0
+                                                                                 errorResponse:jsonDictionaryOrArray
+                                                                               underlyingError:error];
+                                   [_authState updateWithAuthorizationError:oauthError];
+                                   // log error
+                                   [self logMessage:@"Authorization Error (%@). Response: %@", oauthError, responseText];
+                               } else {
+                                   [self logMessage:@"HTTP: %d. Response: %@",
+                                    (int)httpResponse.statusCode,
+                                    responseText];
+                               }
+                               return;
+                           }
+                           
+                           // success response
+                           [self logMessage:@"Success: %@", jsonDictionaryOrArray];
+                       });
+                   }];
+        
+        [postDataTask resume];
+    }];
+}
+
+/*! @brief Logs a message to stdout and the textfield.
+ @param format The format string and arguments.
+ */
+- (void)logMessage:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2) {
+    // gets message as string
+    va_list argp;
+    va_start(argp, format);
+    NSString *log = [[NSString alloc] initWithFormat:format arguments:argp];
+    va_end(argp);
+    
+    // outputs to stdout
+    NSLog(@"%@", log);
+    
+    // appends to output log
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.dateFormat = @"hh:mm:ss";
+    NSString *dateString = [dateFormatter stringFromDate:[NSDate date]];
+    _logTextView.text = [NSString stringWithFormat:@"%@%@%@: %@",
+                         _logTextView.text,
+                         ([_logTextView.text length] > 0) ? @"\n" : @"",
+                         dateString,
+                         log];
+}
+- (IBAction)clearLogTextView:(UIButton *)sender {
+    _logTextView.text = @"";
+}
+
+@end

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -43,10 +43,8 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
     [self loadState];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
 - (void)widgetActiveDisplayModeDidChange:(NCWidgetDisplayMode)activeDisplayMode
-                         withMaximumSize:(CGSize)maxSize {
+                         withMaximumSize:(CGSize)maxSize NS_AVAILABLE_IOS(10.0) {
     
     if (activeDisplayMode == NCWidgetDisplayModeExpanded) {
         self.preferredContentSize = CGSizeMake(maxSize.width, 400.0);
@@ -54,7 +52,6 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
         self.preferredContentSize = maxSize;
     }
 }
-#pragma clang diagnostic pop
 
 - (void)widgetPerformUpdateWithCompletionHandler:(void (^)(NCUpdateResult))completionHandler {
     // Perform any setup necessary in order to update the view.

--- a/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
+++ b/Examples/Example-iOS_ObjC/Example-iOS_ObjC_Extension/TodayViewController.m
@@ -1,19 +1,19 @@
 /*! @file TodayViewController.m
- @brief AppAuth iOS SDK Example
- @copyright
- Copyright 2015 Google Inc. All Rights Reserved.
- @copydetails
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+    @brief AppAuth iOS SDK Example
+    @copyright
+        Copyright 2015 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
  
- http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
  
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
  */
 
 #import "TodayViewController.h"

--- a/Examples/Example-iOS_ObjC/Podfile
+++ b/Examples/Example-iOS_ObjC/Podfile
@@ -1,7 +1,13 @@
-target 'Example-iOS_ObjC' do
-  platform :ios, '9.0'
+platform :ios, '9.0'
 
+target 'Example-iOS_ObjC' do
   # AppAuth Pod
   # In production, just use `pod 'AppAuth'` without the path reference.
   pod 'AppAuth', :path => '../../'
+end
+
+target 'Example-iOS_ObjC_Extension' do    
+    # AppAuth Pod
+    # In production, just use `pod 'AppAuth'` without the path reference.
+    pod 'AppAuth', :path => '../../'
 end

--- a/Examples/Example-iOS_ObjC/Podfile
+++ b/Examples/Example-iOS_ObjC/Podfile
@@ -7,7 +7,7 @@ target 'Example-iOS_ObjC' do
 end
 
 target 'Example-iOS_ObjC_Extension' do    
-    # AppAuth Pod
-    # In production, just use `pod 'AppAuth'` without the path reference.
-    pod 'AppAuth', :path => '../../'
+    # AppAuth/Core Pod
+    # In production, just use `pod 'AppAuth/Core'` without the path reference.
+    pod 'AppAuth/Core', :path => '../../'
 end

--- a/Examples/Example-iOS_ObjC/Source/AppAuthExampleViewController.m
+++ b/Examples/Example-iOS_ObjC/Source/AppAuthExampleViewController.m
@@ -104,18 +104,19 @@ static NSString *const kAppAuthExampleAuthStateKey = @"authState";
  */
 - (void)saveState {
   // for production usage consider using the OS Keychain instead
-  NSData *archivedAuthState = [ NSKeyedArchiver archivedDataWithRootObject:_authState];
-  [[NSUserDefaults standardUserDefaults] setObject:archivedAuthState
-                                            forKey:kAppAuthExampleAuthStateKey];
-  [[NSUserDefaults standardUserDefaults] synchronize];
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [NSKeyedArchiver archivedDataWithRootObject:_authState];
+  [userDefaults setObject:archivedAuthState
+                   forKey:kAppAuthExampleAuthStateKey];
+  [userDefaults synchronize];
 }
 
 /*! @brief Loads the @c OIDAuthState from @c NSUSerDefaults.
  */
 - (void)loadState {
   // loads OIDAuthState from NSUSerDefaults
-  NSData *archivedAuthState =
-      [[NSUserDefaults standardUserDefaults] objectForKey:kAppAuthExampleAuthStateKey];
+  NSUserDefaults* userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"group.net.openid.appauth.Example"];
+  NSData *archivedAuthState = [userDefaults objectForKey:kAppAuthExampleAuthStateKey];
   OIDAuthState *authState = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAuthState];
   [self setAuthState:authState];
 }

--- a/Examples/Example-iOS_ObjC/Source/Example-iOS_ObjC.entitlements
+++ b/Examples/Example-iOS_ObjC/Source/Example-iOS_ObjC.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.net.openid.appauth.Example</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0646249B205F026300072191 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0646249A205F026300072191 /* NotificationCenter.framework */; };
+		0646249E205F026300072191 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0646249D205F026300072191 /* TodayViewController.swift */; };
+		064624A1205F026300072191 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0646249F205F026300072191 /* MainInterface.storyboard */; };
+		064624A5205F026300072191 /* Example_Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 06462499205F026300072191 /* Example_Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		064624AC205F02FA00072191 /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F265BD91F9AE50400DC14BF /* AppAuth.framework */; };
 		9F265BD11F9AC69300DC14BF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BC91F9AC69300DC14BF /* Assets.xcassets */; };
 		9F265BD31F9AC69300DC14BF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BCB1F9AC69300DC14BF /* LaunchScreen.storyboard */; };
 		9F265BD41F9AC69300DC14BF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BCD1F9AC69300DC14BF /* Main.storyboard */; };
@@ -15,7 +20,38 @@
 		9FD378231FB7C6F800436204 /* AppAuthExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD378221FB7C6F800436204 /* AppAuthExampleViewController.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		064624A3205F026300072191 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9F265B8F1F9AC5D600DC14BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 06462498205F026300072191;
+			remoteInfo = Example_Extension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		064624A9205F026300072191 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				064624A5205F026300072191 /* Example_Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		06462499205F026300072191 /* Example_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Example_Extension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		0646249A205F026300072191 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		0646249D205F026300072191 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
+		064624A0205F026300072191 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		064624A2205F026300072191 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		064624AD205F034A00072191 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
+		064624AE205F035D00072191 /* Example_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_Extension.entitlements; sourceTree = "<group>"; };
 		9F265B971F9AC5D600DC14BF /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F265BC91F9AC69300DC14BF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9F265BCC1F9AC69300DC14BF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -27,6 +63,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		06462496205F026300072191 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				064624AC205F02FA00072191 /* AppAuth.framework in Frameworks */,
+				0646249B205F026300072191 /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F265B941F9AC5D600DC14BF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -38,10 +83,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0646249C205F026300072191 /* Example_Extension */ = {
+			isa = PBXGroup;
+			children = (
+				0646249D205F026300072191 /* TodayViewController.swift */,
+				0646249F205F026300072191 /* MainInterface.storyboard */,
+				064624A2205F026300072191 /* Info.plist */,
+				064624AE205F035D00072191 /* Example_Extension.entitlements */,
+			);
+			path = Example_Extension;
+			sourceTree = "<group>";
+		};
 		9F265B8E1F9AC5D600DC14BF = {
 			isa = PBXGroup;
 			children = (
 				9F265BC81F9AC69300DC14BF /* Source */,
+				0646249C205F026300072191 /* Example_Extension */,
 				9F265BD81F9AE4CA00DC14BF /* Frameworks */,
 				9F265B981F9AC5D600DC14BF /* Products */,
 			);
@@ -51,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				9F265B971F9AC5D600DC14BF /* Example.app */,
+				06462499205F026300072191 /* Example_Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -64,6 +122,7 @@
 				9F265BCD1F9AC69300DC14BF /* Main.storyboard */,
 				9F265BC91F9AC69300DC14BF /* Assets.xcassets */,
 				9F265BD01F9AC69300DC14BF /* Info.plist */,
+				064624AD205F034A00072191 /* Example.entitlements */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -72,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				9F265BD91F9AE50400DC14BF /* AppAuth.framework */,
+				0646249A205F026300072191 /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -79,6 +139,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		06462498205F026300072191 /* Example_Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 064624A8205F026300072191 /* Build configuration list for PBXNativeTarget "Example_Extension" */;
+			buildPhases = (
+				06462495205F026300072191 /* Sources */,
+				06462496205F026300072191 /* Frameworks */,
+				06462497205F026300072191 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Example_Extension;
+			productName = Example_Extension;
+			productReference = 06462499205F026300072191 /* Example_Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		9F265B961F9AC5D600DC14BF /* Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9F265BBF1F9AC5D600DC14BF /* Build configuration list for PBXNativeTarget "Example" */;
@@ -87,10 +164,12 @@
 				9F265B941F9AC5D600DC14BF /* Frameworks */,
 				9F265B951F9AC5D600DC14BF /* Resources */,
 				9F265BDB1F9AE52C00DC14BF /* ShellScript */,
+				064624A9205F026300072191 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				064624A4205F026300072191 /* PBXTargetDependency */,
 			);
 			name = Example;
 			productName = Example;
@@ -103,13 +182,27 @@
 		9F265B8F1F9AC5D600DC14BF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0900;
+				LastSwiftUpdateCheck = 0920;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Google Inc.";
 				TargetAttributes = {
+					06462498205F026300072191 = {
+						CreatedOnToolsVersion = 9.2;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
+					};
 					9F265B961F9AC5D600DC14BF = {
 						CreatedOnToolsVersion = 9.0.1;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -127,11 +220,20 @@
 			projectRoot = "";
 			targets = (
 				9F265B961F9AC5D600DC14BF /* Example */,
+				06462498205F026300072191 /* Example_Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		06462497205F026300072191 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				064624A1205F026300072191 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F265B951F9AC5D600DC14BF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -162,6 +264,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		06462495205F026300072191 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0646249E205F026300072191 /* TodayViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9F265B931F9AC5D600DC14BF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -173,7 +283,23 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		064624A4205F026300072191 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 06462498205F026300072191 /* Example_Extension */;
+			targetProxy = 064624A3205F026300072191 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
+		0646249F205F026300072191 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				064624A0205F026300072191 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
 		9F265BCB1F9AC69300DC14BF /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -193,6 +319,48 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		064624A6205F026300072191 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Example_Extension/Example_Extension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Example_Extension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		064624A7205F026300072191 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Example_Extension/Example_Extension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Example_Extension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		9F265BBD1F9AC5D600DC14BF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -303,8 +471,11 @@
 		9F265BC01F9AC5D600DC14BF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Source/Example.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -322,8 +493,11 @@
 		9F265BC11F9AC5D600DC14BF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Source/Example.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -341,6 +515,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		064624A8205F026300072191 /* Build configuration list for PBXNativeTarget "Example_Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				064624A6205F026300072191 /* Debug */,
+				064624A7205F026300072191 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		9F265B921F9AC5D600DC14BF /* Build configuration list for PBXProject "Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06375C8821A4E50E00338E3F /* AppAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06375C8721A4E50E00338E3F /* AppAuthCore.framework */; };
 		0646249B205F026300072191 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0646249A205F026300072191 /* NotificationCenter.framework */; };
 		0646249E205F026300072191 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0646249D205F026300072191 /* TodayViewController.swift */; };
 		064624A1205F026300072191 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0646249F205F026300072191 /* MainInterface.storyboard */; };
 		064624A5205F026300072191 /* Example_Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 06462499205F026300072191 /* Example_Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		064624AC205F02FA00072191 /* AppAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F265BD91F9AE50400DC14BF /* AppAuth.framework */; };
 		9F265BD11F9AC69300DC14BF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BC91F9AC69300DC14BF /* Assets.xcassets */; };
 		9F265BD31F9AC69300DC14BF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BCB1F9AC69300DC14BF /* LaunchScreen.storyboard */; };
 		9F265BD41F9AC69300DC14BF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F265BCD1F9AC69300DC14BF /* Main.storyboard */; };
@@ -45,6 +45,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06375C8721A4E50E00338E3F /* AppAuthCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppAuthCore.framework; path = Carthage/Build/iOS/AppAuthCore.framework; sourceTree = "<group>"; };
 		06462499205F026300072191 /* Example_Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Example_Extension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		0646249A205F026300072191 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		0646249D205F026300072191 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
@@ -67,7 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				064624AC205F02FA00072191 /* AppAuth.framework in Frameworks */,
+				06375C8821A4E50E00338E3F /* AppAuthCore.framework in Frameworks */,
 				0646249B205F026300072191 /* NotificationCenter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -130,6 +131,7 @@
 		9F265BD81F9AE4CA00DC14BF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				06375C8721A4E50E00338E3F /* AppAuthCore.framework */,
 				9F265BD91F9AE50400DC14BF /* AppAuth.framework */,
 				0646249A205F026300072191 /* NotificationCenter.framework */,
 			);
@@ -146,6 +148,7 @@
 				06462495205F026300072191 /* Sources */,
 				06462496205F026300072191 /* Frameworks */,
 				06462497205F026300072191 /* Resources */,
+				06375C8921A4E56B00338E3F /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -163,7 +166,7 @@
 				9F265B931F9AC5D600DC14BF /* Sources */,
 				9F265B941F9AC5D600DC14BF /* Frameworks */,
 				9F265B951F9AC5D600DC14BF /* Resources */,
-				9F265BDB1F9AE52C00DC14BF /* ShellScript */,
+				9F265BDB1F9AE52C00DC14BF /* Carthage */,
 				064624A9205F026300072191 /* Embed App Extensions */,
 			);
 			buildRules = (
@@ -247,7 +250,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		9F265BDB1F9AE52C00DC14BF /* ShellScript */ = {
+		06375C8921A4E56B00338E3F /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/AppAuth.framework",
+			);
+			name = Carthage;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+		9F265BDB1F9AE52C00DC14BF /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -255,11 +277,12 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/AppAuth.framework",
 			);
+			name = Carthage;
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/project.pbxproj
@@ -330,7 +330,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Example_Extension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -351,7 +351,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Example_Extension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.appauth.Example.Example-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F265B961F9AC5D600DC14BF"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F265B961F9AC5D600DC14BF"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F265B961F9AC5D600DC14BF"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F265B961F9AC5D600DC14BF"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/xcshareddata/xcschemes/Example_Extension.xcscheme
+++ b/Examples/Example-iOS_Swift-Carthage/Example.xcodeproj/xcshareddata/xcschemes/Example_Extension.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0920"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "06462498205F026300072191"
+               BuildableName = "Example_Extension.appex"
+               BlueprintName = "Example_Extension"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F265B961F9AC5D600DC14BF"
+               BuildableName = "Example.app"
+               BlueprintName = "Example"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06462498205F026300072191"
+            BuildableName = "Example_Extension.appex"
+            BlueprintName = "Example_Extension"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06462498205F026300072191"
+            BuildableName = "Example_Extension.appex"
+            BlueprintName = "Example_Extension"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "06462498205F026300072191"
+            BuildableName = "Example_Extension.appex"
+            BlueprintName = "Example_Extension"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9F265B961F9AC5D600DC14BF"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
@@ -43,6 +43,7 @@
                             <constraint firstItem="6YF-3j-aPa" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="3Au-Gy-34g"/>
                             <constraint firstItem="sEP-NR-Ej5" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="7DG-gr-aTC"/>
                             <constraint firstItem="sEP-NR-Ej5" firstAttribute="top" secondItem="6YF-3j-aPa" secondAttribute="bottom" constant="8" id="MYM-Qp-fDV"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="sEP-NR-Ej5" secondAttribute="trailing" constant="8" id="Urq-Tf-326"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="tja-ia-dT6" secondAttribute="bottom" constant="8" id="X4C-ds-cXn"/>
                             <constraint firstItem="tja-ia-dT6" firstAttribute="top" secondItem="sEP-NR-Ej5" secondAttribute="bottom" constant="8" id="dKM-iB-4u0"/>
                             <constraint firstItem="tja-ia-dT6" firstAttribute="leading" secondItem="sEP-NR-Ej5" secondAttribute="leading" id="ddn-cr-EWQ"/>

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
@@ -18,37 +18,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6YF-3j-aPa">
-                                <rect key="frame" x="107" y="28" width="106" height="30"/>
-                                <state key="normal" title="Get user profile"/>
-                                <connections>
-                                    <action selector="userinfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="5Cq-a5-Ow5"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sEP-NR-Ej5">
-                                <rect key="frame" x="8" y="66" width="36" height="30"/>
+                                <rect key="frame" x="276" y="28" width="36" height="30"/>
                                 <state key="normal" title="Clear"/>
                                 <connections>
                                     <action selector="clearLogTextView:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="hJK-8X-ICY"/>
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="tja-ia-dT6">
-                                <rect key="frame" x="8" y="104" width="304" height="488"/>
+                                <rect key="frame" x="8" y="66" width="304" height="526"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6YF-3j-aPa">
+                                <rect key="frame" x="8" y="28" width="106" height="30"/>
+                                <state key="normal" title="Get user profile"/>
+                                <connections>
+                                    <action selector="userinfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="5Cq-a5-Ow5"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="6YF-3j-aPa" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="3Au-Gy-34g"/>
-                            <constraint firstItem="sEP-NR-Ej5" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="7DG-gr-aTC"/>
-                            <constraint firstItem="sEP-NR-Ej5" firstAttribute="top" secondItem="6YF-3j-aPa" secondAttribute="bottom" constant="8" id="MYM-Qp-fDV"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="sEP-NR-Ej5" secondAttribute="trailing" constant="8" id="Urq-Tf-326"/>
+                            <constraint firstItem="tja-ia-dT6" firstAttribute="top" secondItem="6YF-3j-aPa" secondAttribute="bottom" constant="8" id="9dp-AI-CeV"/>
+                            <constraint firstItem="6YF-3j-aPa" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="DqD-AE-dQ1"/>
+                            <constraint firstItem="sEP-NR-Ej5" firstAttribute="top" secondItem="6YF-3j-aPa" secondAttribute="top" id="Pe1-RQ-eU6"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="sEP-NR-Ej5" secondAttribute="trailing" constant="8" id="UeB-Kc-ZfJ"/>
+                            <constraint firstItem="sEP-NR-Ej5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6YF-3j-aPa" secondAttribute="trailing" constant="8" id="VsV-bV-DQd"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="tja-ia-dT6" secondAttribute="bottom" constant="8" id="X4C-ds-cXn"/>
-                            <constraint firstItem="tja-ia-dT6" firstAttribute="top" secondItem="sEP-NR-Ej5" secondAttribute="bottom" constant="8" id="dKM-iB-4u0"/>
-                            <constraint firstItem="tja-ia-dT6" firstAttribute="leading" secondItem="sEP-NR-Ej5" secondAttribute="leading" id="ddn-cr-EWQ"/>
+                            <constraint firstItem="tja-ia-dT6" firstAttribute="leading" secondItem="6YF-3j-aPa" secondAttribute="leading" id="dEN-Dt-khR"/>
+                            <constraint firstItem="6YF-3j-aPa" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="dLc-Tx-tPW"/>
                             <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="tja-ia-dT6" secondAttribute="trailing" constant="8" id="iPW-19-ayh"/>
-                            <constraint firstItem="6YF-3j-aPa" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="oEp-sU-iJ8"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
                     </view>

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModule="Example_Extension" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6YF-3j-aPa">
+                                <rect key="frame" x="107" y="28" width="106" height="30"/>
+                                <state key="normal" title="Get user profile"/>
+                                <connections>
+                                    <action selector="userinfo:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="5Cq-a5-Ow5"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sEP-NR-Ej5">
+                                <rect key="frame" x="8" y="66" width="36" height="30"/>
+                                <state key="normal" title="Clear"/>
+                                <connections>
+                                    <action selector="clearLogTextView:" destination="M4Y-Lb-cyx" eventType="touchUpInside" id="hJK-8X-ICY"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="tja-ia-dT6">
+                                <rect key="frame" x="8" y="104" width="304" height="488"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="6YF-3j-aPa" firstAttribute="centerX" secondItem="S3S-Oj-5AN" secondAttribute="centerX" id="3Au-Gy-34g"/>
+                            <constraint firstItem="sEP-NR-Ej5" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="8" id="7DG-gr-aTC"/>
+                            <constraint firstItem="sEP-NR-Ej5" firstAttribute="top" secondItem="6YF-3j-aPa" secondAttribute="bottom" constant="8" id="MYM-Qp-fDV"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="tja-ia-dT6" secondAttribute="bottom" constant="8" id="X4C-ds-cXn"/>
+                            <constraint firstItem="tja-ia-dT6" firstAttribute="top" secondItem="sEP-NR-Ej5" secondAttribute="bottom" constant="8" id="dKM-iB-4u0"/>
+                            <constraint firstItem="tja-ia-dT6" firstAttribute="leading" secondItem="sEP-NR-Ej5" secondAttribute="leading" id="ddn-cr-EWQ"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="tja-ia-dT6" secondAttribute="trailing" constant="8" id="iPW-19-ayh"/>
+                            <constraint firstItem="6YF-3j-aPa" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="8" id="oEp-sU-iJ8"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="600"/>
+                    <connections>
+                        <outlet property="logTextView" destination="tja-ia-dT6" id="WPv-Qh-Bqm"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/Example_Extension.entitlements
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/Example_Extension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.net.openid.appauth.Example</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/Info.plist
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Example_Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
@@ -37,15 +37,16 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         if #available(iOS 10.0, *) {
             self.extensionContext?.widgetLargestAvailableDisplayMode = .expanded
         } else {
-            self.preferredContentSize = CGSize(width: 0, height: 600.0)
+            self.preferredContentSize = CGSize(width: 0, height: 400.0)
         }
         
         self.loadState()
     }
     
+    @available(iOSApplicationExtension 10.0, *)
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
         if activeDisplayMode == .expanded {
-            preferredContentSize = CGSize(width: maxSize.width, height: 600.0)
+            preferredContentSize = CGSize(width: maxSize.width, height: 400.0)
         } else if activeDisplayMode == .compact {
             preferredContentSize = maxSize
         }

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 import NotificationCenter
-import AppAuth
+import AppAuthCore
 
 /**
  NSCoding key for the authState property.

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
@@ -1,0 +1,223 @@
+//
+//  TodayViewController.swift
+//
+//  Copyright (c) 2017 The AppAuth Authors.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import NotificationCenter
+import AppAuth
+
+/**
+ NSCoding key for the authState property.
+ */
+let kAppAuthExampleAuthStateKey: String = "authState";
+
+class TodayViewController: UIViewController, NCWidgetProviding {
+    
+    @IBOutlet private weak var logTextView: UITextView!
+    
+    private var authState: OIDAuthState?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if let extensionContext = self.extensionContext, extensionContext.responds(to: #selector(setter: NSExtensionContext.widgetLargestAvailableDisplayMode)) { // iOS 10+
+            extensionContext.widgetLargestAvailableDisplayMode = .expanded
+        } else {
+            preferredContentSize = CGSize(width: 0, height: 600.0) // iOS 10-
+        }
+        
+        self.loadState()
+    }
+    
+    func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
+        if activeDisplayMode == .expanded {
+            preferredContentSize = CGSize(width: maxSize.width, height: 600.0)
+        } else if activeDisplayMode == .compact {
+            preferredContentSize = maxSize
+        }
+    }
+    
+    func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
+        // Perform any setup necessary in order to update the view.
+        
+        // If an error is encountered, use NCUpdateResult.Failed
+        // If there's no update required, use NCUpdateResult.NoData
+        // If there's an update, use NCUpdateResult.NewData
+        
+        completionHandler(NCUpdateResult.newData)
+    }
+    
+    @IBAction func userinfo(_ sender: UIButton) {
+        
+        guard let userinfoEndpoint = self.authState?.lastAuthorizationResponse.request.configuration.discoveryDocument?.userinfoEndpoint else {
+            self.logMessage("Userinfo endpoint not declared in discovery document")
+            return
+        }
+        
+        self.logMessage("Performing userinfo request")
+        
+        let currentAccessToken: String? = self.authState?.lastTokenResponse?.accessToken
+        
+        self.authState?.performAction() { (accessToken, idTOken, error) in
+            
+            if error != nil  {
+                self.logMessage("Error fetching fresh tokens: \(error?.localizedDescription ?? "ERROR")")
+                return
+            }
+            
+            guard let accessToken = accessToken else {
+                self.logMessage("Error getting accessToken")
+                return
+            }
+            
+            if currentAccessToken != accessToken {
+                self.logMessage("Access token was refreshed automatically (\(currentAccessToken ?? "CURRENT_ACCESS_TOKEN") to \(accessToken))")
+            } else {
+                self.logMessage("Access token was fresh and not updated \(accessToken)")
+            }
+            
+            var urlRequest = URLRequest(url: userinfoEndpoint)
+            urlRequest.allHTTPHeaderFields = ["Authorization":"Bearer \(accessToken)"]
+            
+            let task = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+                
+                DispatchQueue.main.async {
+                    
+                    guard error == nil else {
+                        self.logMessage("HTTP request failed \(error?.localizedDescription ?? "ERROR")")
+                        return
+                    }
+                    
+                    guard let response = response as? HTTPURLResponse else {
+                        self.logMessage("Non-HTTP response")
+                        return
+                    }
+                    
+                    guard let data = data else {
+                        self.logMessage("HTTP response data is empty")
+                        return
+                    }
+                    
+                    var json: [AnyHashable: Any]?
+                    
+                    do {
+                        json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                    } catch {
+                        self.logMessage("JSON Serialization Error")
+                    }
+                    
+                    if response.statusCode != 200 {
+                        // server replied with an error
+                        let responseText: String? = String(data: data, encoding: String.Encoding.utf8)
+                        
+                        if response.statusCode == 401 {
+                            // "401 Unauthorized" generally indicates there is an issue with the authorization
+                            // grant. Puts OIDAuthState into an error state.
+                            let oauthError = OIDErrorUtilities.resourceServerAuthorizationError(withCode: 0,
+                                                                                                errorResponse: json,
+                                                                                                underlyingError: error)
+                            self.authState?.update(withAuthorizationError: oauthError)
+                            self.logMessage("Authorization Error (\(oauthError)). Response: \(responseText ?? "RESPONSE_TEXT")")
+                        } else {
+                            self.logMessage("HTTP: \(response.statusCode), Response: \(responseText ?? "RESPONSE_TEXT")")
+                        }
+                        
+                        return
+                    }
+                    
+                    if let json = json {
+                        self.logMessage("Success: \(json)")
+                    }
+                }
+            }
+            
+            task.resume()
+        }
+    }
+    
+    @IBAction func clearLogTextView(_ sender: UIButton) {
+        self.logTextView.text = ""
+    }
+}
+
+//MARK: OIDAuthState Delegate
+extension TodayViewController: OIDAuthStateChangeDelegate {
+    
+    func didChange(_ state: OIDAuthState) {
+        self.stateChanged()
+    }
+}
+
+//MARK: Helper Methods
+extension TodayViewController {
+    
+    func saveState() {
+        
+        var data: Data? = nil
+        
+        if let authState = self.authState {
+            data = NSKeyedArchiver.archivedData(withRootObject: authState)
+        }
+        
+        if let userDefaults = UserDefaults(suiteName: "group.net.openid.appauth.Example") {
+            userDefaults.set(data, forKey: kAppAuthExampleAuthStateKey)
+            userDefaults.synchronize()
+        }
+    }
+    
+    func loadState() {
+        guard let data = UserDefaults(suiteName: "group.net.openid.appauth.Example")?.object(forKey: kAppAuthExampleAuthStateKey) as? Data else {
+            return
+        }
+        
+        if let authState = NSKeyedUnarchiver.unarchiveObject(with: data) as? OIDAuthState {
+            self.setAuthState(authState)
+        }
+    }
+    
+    func setAuthState(_ authState: OIDAuthState?) {
+        if (self.authState == authState) {
+            return;
+        }
+        self.authState = authState;
+        self.authState?.stateChangeDelegate = self;
+        self.stateChanged()
+    }
+    
+    func stateChanged() {
+        self.saveState()
+    }
+    
+    func logMessage(_ message: String?) {
+        
+        guard let message = message else {
+            return
+        }
+        
+        print(message);
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "hh:mm:ss";
+        let dateString = dateFormatter.string(from: Date())
+        
+        // appends to output log
+        DispatchQueue.main.async {
+            let logText = "\(self.logTextView.text ?? "")\n\(dateString): \(message)"
+            self.logTextView.text = logText
+        }
+    }
+}

--- a/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Example_Extension/TodayViewController.swift
@@ -34,10 +34,10 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        if let extensionContext = self.extensionContext, extensionContext.responds(to: #selector(setter: NSExtensionContext.widgetLargestAvailableDisplayMode)) { // iOS 10+
-            extensionContext.widgetLargestAvailableDisplayMode = .expanded
+        if #available(iOS 10.0, *) {
+            self.extensionContext?.widgetLargestAvailableDisplayMode = .expanded
         } else {
-            preferredContentSize = CGSize(width: 0, height: 600.0) // iOS 10-
+            self.preferredContentSize = CGSize(width: 0, height: 600.0)
         }
         
         self.loadState()

--- a/Examples/Example-iOS_Swift-Carthage/Source/AppAuthExampleViewController.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Source/AppAuthExampleViewController.swift
@@ -463,13 +463,15 @@ extension AppAuthExampleViewController {
         if let authState = self.authState {
             data = NSKeyedArchiver.archivedData(withRootObject: authState)
         }
-
-        UserDefaults.standard.set(data, forKey: kAppAuthExampleAuthStateKey)
-        UserDefaults.standard.synchronize()
+        
+        if let userDefaults = UserDefaults(suiteName: "group.net.openid.appauth.Example") {
+            userDefaults.set(data, forKey: kAppAuthExampleAuthStateKey)
+            userDefaults.synchronize()
+        }
     }
 
     func loadState() {
-        guard let data = UserDefaults.standard.object(forKey: kAppAuthExampleAuthStateKey) as? Data else {
+        guard let data = UserDefaults(suiteName: "group.net.openid.appauth.Example")?.object(forKey: kAppAuthExampleAuthStateKey) as? Data else {
             return
         }
 

--- a/Examples/Example-iOS_Swift-Carthage/Source/Example.entitlements
+++ b/Examples/Example-iOS_Swift-Carthage/Source/Example.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.net.openid.appauth.Example</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This pull request adds extensions to all iOS examples by using the Core subspec (cocoapods) or Core framework (Carthage).

The extension is a simple UI with a logging view just like the app and allows to get the user profile.

I also discovered that the carthage example's extension is, surprisingly, able to build by importing the `AppAuth.framework` in contrary to the cocoapods example that is not building (it's the reason why the Core subspec exists). But importing `AppAuthCore.framework` instead fixes a linking warning.