### PR TITLE
Present ExternalUserAgent without passing UIViewController for iOS 11+

### DIFF
--- a/Source/iOS/OIDAuthState+IOS.h
+++ b/Source/iOS/OIDAuthState+IOS.h
@@ -45,7 +45,12 @@ NS_ASSUME_NONNULL_BEGIN
                      presentingViewController:(UIViewController *)presentingViewController
                                      callback:(OIDAuthStateAuthorizationCallback)callback;
 
-/*! @brief Convenience method for iOS 11+ devices to create a @c OIDAuthState by presenting an    authorization request and performing the authorization code exchange in the case of code flow requests. For the hybrid flow, the caller should validate the id_token and c_hash, then perform the token request (@c OIDAuthorizationService.performTokenRequest:callback:) and update the OIDAuthState with the results (@c OIDAuthState.updateWithTokenResponse:error:).
+/*! @brief Convenience method for iOS 11+ devices to create a @c OIDAuthState
+        by presenting an authorization request and performing the authorization code exchange
+        in the case of code flow requests. For the hybrid flow, the caller should validate
+        the id_token and c_hash, then perform the token request
+        (@c OIDAuthorizationService.performTokenRequest:callback:) and update the OIDAuthState
+        with the results (@c OIDAuthState.updateWithTokenResponse:error:).
     @param authorizationRequest The authorization request to present.
     @param callback The method called when the request has completed or failed.
     @return A @c OIDExternalUserAgentSession instance which will terminate when it

--- a/Source/iOS/OIDAuthState+IOS.h
+++ b/Source/iOS/OIDAuthState+IOS.h
@@ -45,6 +45,17 @@ NS_ASSUME_NONNULL_BEGIN
                      presentingViewController:(UIViewController *)presentingViewController
                                      callback:(OIDAuthStateAuthorizationCallback)callback;
 
+/*! @brief Convenience method for iOS 11+ devices to create a @c OIDAuthState by presenting an    authorization request and performing the authorization code exchange in the case of code flow requests. For the hybrid flow, the caller should validate the id_token and c_hash, then perform the token request (@c OIDAuthorizationService.performTokenRequest:callback:) and update the OIDAuthState with the results (@c OIDAuthState.updateWithTokenResponse:error:).
+    @param authorizationRequest The authorization request to present.
+    @param callback The method called when the request has completed or failed.
+    @return A @c OIDExternalUserAgentSession instance which will terminate when it
+        receives a @c OIDExternalUserAgentSession.cancel message, or after processing a
+        @c OIDExternalUserAgentSession.resumeExternalUserAgentFlowWithURL: message.
+ */
++ (id<OIDExternalUserAgentSession>)
+    authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
+                     callback:(OIDAuthStateAuthorizationCallback)callback API_AVAILABLE(ios(11));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/iOS/OIDAuthState+IOS.h
+++ b/Source/iOS/OIDAuthState+IOS.h
@@ -43,7 +43,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
                      presentingViewController:(UIViewController *)presentingViewController
-                                     callback:(OIDAuthStateAuthorizationCallback)callback NS_DEPRECATED_IOS(7, 11, "This method has been deprecated. Call authStateByPresentingAuthorizationRequest without passing UIViewController instead.");
+                                     callback:(OIDAuthStateAuthorizationCallback)callback
+                                     NS_DEPRECATED_IOS(7, 11, "This method has been deprecated. Call\
+                                                       authStateByPresentingAuthorizationRequest without passing\
+                                                       UIViewController instead.");
 
 /*! @brief Convenience method for iOS 11+ devices to create a @c OIDAuthState
         by presenting an authorization request and performing the authorization code exchange

--- a/Source/iOS/OIDAuthState+IOS.h
+++ b/Source/iOS/OIDAuthState+IOS.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
                      presentingViewController:(UIViewController *)presentingViewController
-                                     callback:(OIDAuthStateAuthorizationCallback)callback;
+                                     callback:(OIDAuthStateAuthorizationCallback)callback NS_DEPRECATED_IOS(7, 11, "This method has been deprecated. Call authStateByPresentingAuthorizationRequest without passing UIViewController instead.");
 
 /*! @brief Convenience method for iOS 11+ devices to create a @c OIDAuthState
         by presenting an authorization request and performing the authorization code exchange

--- a/Source/iOS/OIDAuthState+IOS.m
+++ b/Source/iOS/OIDAuthState+IOS.m
@@ -38,8 +38,7 @@
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
                                      callback:(OIDAuthStateAuthorizationCallback)callback {
   return [self authStateByPresentingAuthorizationRequest:authorizationRequest
-                                presentingViewController:[UIViewController new]
-                                                callback:callback];
+                                       externalUserAgent:[[OIDExternalUserAgentIOS alloc] init] callback:callback];
 }
 
 @end

--- a/Source/iOS/OIDAuthState+IOS.m
+++ b/Source/iOS/OIDAuthState+IOS.m
@@ -34,4 +34,12 @@
                                                 callback:callback];
 }
 
++ (id<OIDExternalUserAgentSession>)
+    authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
+                                     callback:(OIDAuthStateAuthorizationCallback)callback {
+  return [self authStateByPresentingAuthorizationRequest:authorizationRequest
+                                presentingViewController:[UIViewController new]
+                                                callback:callback];
+}
+
 @end

--- a/Source/iOS/OIDAuthState+IOS.m
+++ b/Source/iOS/OIDAuthState+IOS.m
@@ -36,9 +36,11 @@
 
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
-                                     callback:(OIDAuthStateAuthorizationCallback)callback {
+                                  callback:(OIDAuthStateAuthorizationCallback)callback {
+  OIDExternalUserAgentIOS *externalUserAgent = [[OIDExternalUserAgentIOS alloc] init];
   return [self authStateByPresentingAuthorizationRequest:authorizationRequest
-                                       externalUserAgent:[[OIDExternalUserAgentIOS alloc] init] callback:callback];
+                                       externalUserAgent:externalUserAgent
+                                                callback:callback];
 }
 
 @end

--- a/Source/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/iOS/OIDExternalUserAgentIOS.h
@@ -29,17 +29,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 
-/*! @internal
-    @brief Unavailable. Please use @c initWithPresentingViewController:
+/*! @brief The convenience initializer for devices with iOS 11+
  */
-- (nonnull instancetype)init NS_UNAVAILABLE;
+- (nullable instancetype)init API_AVAILABLE(ios(11));
 
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the
         \SFSafariViewController.
  */
 - (nullable instancetype)initWithPresentingViewController:
-    (UIViewController *)presentingViewController
+    (nullable UIViewController *)presentingViewController
     NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -44,11 +44,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)init {
-  return [self initWithPresentingViewController: nil];  
+  return [self initWithPresentingViewController:nil];
 }
 
 - (nullable instancetype)initWithPresentingViewController:
-        (nullable UIViewController  *)presentingViewController {
+        (nullable UIViewController *)presentingViewController {
   self = [super init];
   if (self) {
     _presentingViewController = presentingViewController;

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -43,8 +43,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 }
 
+- (nullable instancetype)init {
+  return [self initWithPresentingViewController: nil];  
+}
+
 - (nullable instancetype)initWithPresentingViewController:
-        (UIViewController *)presentingViewController {
+        (nullable UIViewController  *)presentingViewController {
   self = [super init];
   if (self) {
     _presentingViewController = presentingViewController;
@@ -126,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
   // iOS 9 and 10, use SFSafariViewController
   if (@available(iOS 9.0, *)) {
-    if (!openedUserAgent) {
+    if (!openedUserAgent && _presentingViewController) {
       SFSafariViewController *safariVC =
           [[SFSafariViewController alloc] initWithURL:requestURL];
       safariVC.delegate = self;


### PR DESCRIPTION
This PR is referring to #338, iOS 11+ devices don't need to pass UIViewController in order to present an external user agent. 

```objc
// builds authentication request for apps that support iOS 11+
OIDAuthorizationRequest *request =
    [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
                                                  clientId:kClientID
                                                    scopes:@[OIDScopeOpenID,
                                                             OIDScopeProfile]
                                               redirectURL:KRedirectURI
                                              responseType:OIDResponseTypeCode
                                      additionalParameters:nil];

// performs authentication request
AppDelegate *appDelegate =
    (AppDelegate *)[UIApplication sharedApplication].delegate;


appDelegate.currentAuthorizationFlow =
    [OIDAuthState authStateByPresentingAuthorizationRequest:request
                        callback:^(OIDAuthState *_Nullable authState,
                                   NSError *_Nullable error) {
  if (authState) {
    NSLog(@"Got authorization tokens. Access token: %@",
          authState.lastTokenResponse.accessToken);
    [self setAuthState:authState];
  } else {
    NSLog(@"Authorization error: %@", [error localizedDescription]);
    [self setAuthState:nil];
  }
}];
``` 