### PR TITLE
Fix capitalisation of the framework name for tvOS

### DIFF
--- a/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth_tvOS.xcscheme
+++ b/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth_tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "343AAAA51E83489A00F9D36E"
-               BuildableName = "AppAUth.framework"
+               BuildableName = "AppAuth.framework"
                BlueprintName = "AppAuth_tvOS"
                ReferencedContainer = "container:AppAuth.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "343AAAA51E83489A00F9D36E"
-            BuildableName = "AppAUth.framework"
+            BuildableName = "AppAuth.framework"
             BlueprintName = "AppAuth_tvOS"
             ReferencedContainer = "container:AppAuth.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "343AAAA51E83489A00F9D36E"
-            BuildableName = "AppAUth.framework"
+            BuildableName = "AppAuth.framework"
             BlueprintName = "AppAuth_tvOS"
             ReferencedContainer = "container:AppAuth.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "343AAAA51E83489A00F9D36E"
-            BuildableName = "AppAUth.framework"
+            BuildableName = "AppAuth.framework"
             BlueprintName = "AppAuth_tvOS"
             ReferencedContainer = "container:AppAuth.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
AppAuth.framework name was building as AppAUth.framework for tvOS making it difficult to import for multi platform projects as it required a different name to be imported for tvOS than iOS due to the capitalisation of the U.