### PR TITLE
Update to Carthage instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ line to your `Cartfile`:
 
     github "openid/AppAuth-iOS" "master"
 
-Then run `carthage bootstrap`.
+Then run `carthage update`.
 
 ### Static Library
 


### PR DESCRIPTION
Running `carthage bootstrap` only applies if you've run `Carthage update` at least once and the dependency has been added to your `Cartfile.resolved`. 

On an initial add, you'll want to add the dependency to your `Cartfile` as is already stated in the README, but you'll need to run `carthage update` instead.