### PR TITLE
Implement missing cancelWithCompletion: in OIDEndSessionImplementation

### DIFF
--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -232,12 +232,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)cancel {
+  [self cancelWithCompletion:nil];
+}
+
+- (void)cancelWithCompletion:(nullable void (^)(void))completion {
   [_externalUserAgent dismissExternalUserAgentAnimated:YES completion:^{
     NSError *error = [OIDErrorUtilities
                       errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
                       underlyingError:nil
                       description:nil];
     [self didFinishWithResponse:nil error:error];
+    if (completion) completion();
   }];
 }
 


### PR DESCRIPTION
This fixes the [build error](https://travis-ci.org/openid/AppAuth-iOS/builds/543991588?utm_source=github_status&utm_medium=notification) on master.