### PR TITLE
Add reference to Carthage (Swift) example

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -10,6 +10,7 @@ Each example has docs on how to configure:
 
 * [Example for iOS (Objective-C)](Example-iOS_ObjC/README.md)
 * [Example for iOS w/ Carthage (Objective-C)](Example-iOS_ObjC-Carthage/README.md)
+* [Example for iOS w/ Carthage (Swift)](Example-iOS_Swift-Carthage/README.md)
 * [Example for macOS](Example-macOS/README.md)
 
 To get the Issuer, Client ID, and Redirect URI, for your particular IdP, you


### PR DESCRIPTION
Seemingly left out link to the Carthage Swift example, which does exist.