### PR TITLE
Replaced UIApplication.keyWindow usage with searching for a fitting WindowScene

### DIFF
--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -228,7 +228,35 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - ASWebAuthenticationPresentationContextProviding
 
 - (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)){
-    return UIApplication.sharedApplication.keyWindow;
+    UIWindowScene *preferedWindowScene;
+    UIWindow *preferedWindow = nil;
+    
+    for(UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if([scene isKindOfClass:[UIWindowScene class]] && ((UIWindowScene *)scene).windows.count > 0) {
+            if (scene.activationState == UISceneActivationStateForegroundActive) {
+                preferedWindowScene = (UIWindowScene *)scene;
+                // We won't find a better scene than this one
+                break;
+            }
+            if (scene.activationState == UISceneActivationStateForegroundInactive) {
+                preferedWindowScene = (UIWindowScene *)scene;
+            } else if (scene.activationState == UISceneActivationStateBackground && preferedWindowScene != nil && preferedWindowScene.activationState == UISceneActivationStateUnattached) {
+                preferedWindowScene = (UIWindowScene *)scene;
+            } else if (preferedWindowScene == nil) {
+                preferedWindowScene = (UIWindowScene *)scene;
+            }
+        }
+    }
+    
+    if(preferedWindowScene != nil) {
+        preferedWindow = [preferedWindowScene.windows filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIWindow *window, NSDictionary *bindings) {
+            return window.isKeyWindow;
+        }]].firstObject;
+        
+        preferedWindow = preferedWindow ?: preferedWindowScene.windows.firstObject;
+    }
+    
+    return preferedWindow;
 }
 #endif
 


### PR DESCRIPTION
UIApplication.keyWindow was deprecated in iOS13 since there is no single keyWindow anymore when dealing with mutliple windows. Using keyWindow can result in the authenticationVC beign presented on a window that is not currently in the foreground. So the way to solve it is to look through all connected scenes and use a window of the most fitting windowScene.

Note:
When having multiple scenes of the same app in the foreground via splitView or slideover, this solution might result in the authenticationVC beign displayed on any of these scenes. But there is currently no better solution since there is no way to tell in which scene the user has triggered the authentication.