### PR TITLE
Use the UIViewController's window as the presenting anchor

### DIFF
--- a/Source/iOS/OIDAuthState+IOS.h
+++ b/Source/iOS/OIDAuthState+IOS.h
@@ -34,7 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
         OIDAuthState.updateWithTokenResponse:error:).
     @param authorizationRequest The authorization request to present.
     @param presentingViewController The view controller from which to present the
-        @c SFSafariViewController.
+        @c SFSafariViewController. On iOS 13, the window of this UIViewController
+        is used as the ASPresentationAnchor.
     @param callback The method called when the request has completed or failed.
     @return A @c OIDExternalUserAgentSession instance which will terminate when it
         receives a @c OIDExternalUserAgentSession.cancel message, or after processing a
@@ -43,26 +44,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
                      presentingViewController:(UIViewController *)presentingViewController
-                                     callback:(OIDAuthStateAuthorizationCallback)callback
-                                     NS_DEPRECATED_IOS(7, 11, "This method has been deprecated. Call\
-                                                       authStateByPresentingAuthorizationRequest without passing\
-                                                       UIViewController instead.");
+                                     callback:(OIDAuthStateAuthorizationCallback)callback;
 
-/*! @brief Convenience method for iOS 11+ devices to create a @c OIDAuthState
-        by presenting an authorization request and performing the authorization code exchange
-        in the case of code flow requests. For the hybrid flow, the caller should validate
-        the id_token and c_hash, then perform the token request
-        (@c OIDAuthorizationService.performTokenRequest:callback:) and update the OIDAuthState
-        with the results (@c OIDAuthState.updateWithTokenResponse:error:).
-    @param authorizationRequest The authorization request to present.
-    @param callback The method called when the request has completed or failed.
-    @return A @c OIDExternalUserAgentSession instance which will terminate when it
-        receives a @c OIDExternalUserAgentSession.cancel message, or after processing a
-        @c OIDExternalUserAgentSession.resumeExternalUserAgentFlowWithURL: message.
- */
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
-                     callback:(OIDAuthStateAuthorizationCallback)callback API_AVAILABLE(ios(11));
+                     callback:(OIDAuthStateAuthorizationCallback)callback API_AVAILABLE(ios(11))
+    __deprecated_msg("This method will not work on iOS 13. Use "
+        "authStateByPresentingAuthorizationRequest:presentingViewController:callback:");
 
 @end
 

--- a/Source/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/iOS/OIDExternalUserAgentIOS.h
@@ -29,16 +29,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 
-/*! @brief The convenience initializer for devices with iOS 11+
- */
-- (nullable instancetype)init API_AVAILABLE(ios(11));
+- (nullable instancetype)init API_AVAILABLE(ios(11))
+    __deprecated_msg("This method will not work on iOS 13, use "
+                     "initWithPresentingViewController:presentingViewController");
 
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the
         \SFSafariViewController.
  */
 - (nullable instancetype)initWithPresentingViewController:
-    (nullable UIViewController *)presentingViewController
+    (UIViewController *)presentingViewController
     NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -49,13 +49,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable instancetype)init {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
   return [self initWithPresentingViewController:nil];
+#pragma clang diagnostic pop
 }
 
 - (nullable instancetype)initWithPresentingViewController:
-        (nullable UIViewController *)presentingViewController {
+    (UIViewController *)presentingViewController {
   self = [super init];
   if (self) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    NSAssert(presentingViewController != nil,
+             @"presentingViewController cannot be nil on iOS 13");
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    
     _presentingViewController = presentingViewController;
   }
   return self;
@@ -228,9 +236,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - ASWebAuthenticationPresentationContextProviding
 
 - (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)){
-    return UIApplication.sharedApplication.keyWindow;
+  return _presentingViewController.view.window;
 }
-#endif
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 
 @end
 


### PR DESCRIPTION
Replaces use of the deprecated UIApplication.keyWindow. Alternative implementation of #428 

Undoes some changes made in #340
- Presenting UIViewController is required again for all versions of iOS
- Reversed deprecation of methods

Added assertion for iOS 13 to ensure the UIViewController is nonnull as required.