### PR TITLE
import missing headers for OIDC logout in AppAuthCore.h

### DIFF
--- a/Source/AppAuthCore.h
+++ b/Source/AppAuthCore.h
@@ -40,4 +40,5 @@
 #import "OIDTokenResponse.h"
 #import "OIDTokenUtilities.h"
 #import "OIDURLSessionProvider.h"
-
+#import "OIDEndSessionRequest.h"
+#import "OIDEndSessionResponse.h"

--- a/Source/CoreFramework/AppAuthCore.h
+++ b/Source/CoreFramework/AppAuthCore.h
@@ -48,5 +48,6 @@ FOUNDATION_EXPORT const unsigned char AppAuthCoreVersionString[];
 #import <AppAuthCore/OIDTokenResponse.h>
 #import <AppAuthCore/OIDTokenUtilities.h>
 #import <AppAuthCore/OIDURLSessionProvider.h>
-
+#import "AppAuthCore/OIDEndSessionRequest.h"
+#import "AppAuthCore/OIDEndSessionResponse.h"
 

--- a/Source/CoreFramework/AppAuthCore.h
+++ b/Source/CoreFramework/AppAuthCore.h
@@ -48,6 +48,6 @@ FOUNDATION_EXPORT const unsigned char AppAuthCoreVersionString[];
 #import <AppAuthCore/OIDTokenResponse.h>
 #import <AppAuthCore/OIDTokenUtilities.h>
 #import <AppAuthCore/OIDURLSessionProvider.h>
-#import "AppAuthCore/OIDEndSessionRequest.h"
-#import "AppAuthCore/OIDEndSessionResponse.h"
+#import <AppAuthCore/OIDEndSessionRequest.h>
+#import <AppAuthCore/OIDEndSessionResponse.h>
 


### PR DESCRIPTION
`OIDEndSessionRequest` and `OIDEndSessionResponse` were missing when importing AppAuthCore framework with Carthage.