### PR TITLE
sends a different error code depending on when the authentication session was cancelled

### DIFF
--- a/Source/OIDError.h
+++ b/Source/OIDError.h
@@ -151,6 +151,10 @@ typedef NS_ENUM(NSInteger, OIDErrorCode) {
   /*! @brief The ID Token did not pass validation (e.g. issuer, audience checks).
    */
   OIDErrorCodeIDTokenFailedValidationError = -15,
+  
+  /*! @brief Indicates the user manually dismissed the external user agent.
+   */
+  OIDErrorCodeExternalUserAgentDismissed = -16,
 };
 
 /*! @brief Enum of all possible OAuth error codes as defined by RFC6749

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -100,8 +100,11 @@ NS_ASSUME_NONNULL_BEGIN
         if (callbackURL) {
           [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
         } else {
+          int errorCode;
+          NSString *descriptionOfTopView = [[[[[[UIApplication sharedApplication] keyWindow] subviews] lastObject] class] description];
+          errorCode = [descriptionOfTopView compare:@"UITransitionView"] ? OIDErrorCodeExternalUserAgentDismissed : OIDErrorCodeUserCanceledAuthorizationFlow;
           NSError *safariError =
-              [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+              [OIDErrorUtilities errorWithCode:errorCode
                                underlyingError:error
                                    description:nil];
           [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
@@ -135,8 +138,11 @@ NS_ASSUME_NONNULL_BEGIN
         if (callbackURL) {
           [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
         } else {
+          int errorCode;
+          NSString *descriptionOfTopView = [[[[[[UIApplication sharedApplication] keyWindow] subviews] lastObject] class] description];
+          errorCode = [descriptionOfTopView compare:@"UITransitionView"] ? OIDErrorCodeExternalUserAgentDismissed : OIDErrorCodeUserCanceledAuthorizationFlow;
           NSError *safariError =
-              [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+              [OIDErrorUtilities errorWithCode:errorCode
                                underlyingError:error
                                    description:@"User cancelled."];
           [strongSelf->_session failExternalUserAgentFlowWithError:safariError];


### PR DESCRIPTION
This is a possible solution to issue #458 
https://github.com/openid/AppAuth-iOS/issues/458

I have some doubts about using `UITransitionView`.

1) It is an internal class and cannot be referenced using `isKindOfClass`
2) The view at the time of cancelling may not be guaranteed to be `UITransitionView` (although it seems this way)
3) This requires the view before the pop up prompt to **not** be `UITransitionView` as well...