### PR TITLE
Unarchiving

### DIFF
--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -195,7 +195,12 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   NSError *error;
-  NSDictionary *dictionary = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class], nil] forKey:kDiscoveryDictionaryKey];
+  NSDictionary *dictionary = nil;
+  if (@available(iOS 11.0, *)) {
+    dictionary = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class], nil] forKey:kDiscoveryDictionaryKey];
+  } else {
+    dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
+  }
   self = [self initWithDictionary:dictionary error:&error];
   if (error) {
     return nil;
@@ -204,7 +209,11 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
+  if (@available(iOS 11.0, *)) {
+    [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
+  } else {
+    [_discoveryDictionary encodeWithCoder:aCoder];
+  }
 }
 
 #pragma mark - Properties

--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -196,7 +196,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   NSError *error;
   NSDictionary *dictionary = nil;
-  if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, macCatalyst 13, macOS 10.13, tvOS 11, watchOS 4, *)) {
     dictionary = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class], nil] forKey:kDiscoveryDictionaryKey];
   } else {
     dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
@@ -209,7 +209,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, macCatalyst 13, macOS 10.13, tvOS 11, watchOS 4, *)) {
     [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
   } else {
     [_discoveryDictionary encodeWithCoder:aCoder];

--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -23,6 +23,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! @brief The key for the @c discoveryDictionary property.
+ */
+static NSString *const kDiscoveryDictionaryKey = @"discoveryDictionary";
+
 /*! Field keys associated with an OpenID Connect Discovery Document. */
 static NSString *const kIssuerKey = @"issuer";
 static NSString *const kAuthorizationEndpointKey = @"authorization_endpoint";
@@ -191,7 +195,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   NSError *error;
-  NSDictionary *dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
+  NSDictionary *dictionary = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSArray class], nil] forKey:kDiscoveryDictionaryKey];
   self = [self initWithDictionary:dictionary error:&error];
   if (error) {
     return nil;
@@ -200,7 +204,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  [_discoveryDictionary encodeWithCoder:aCoder];
+  [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
 }
 
 #pragma mark - Properties

--- a/UnitTests/OIDServiceDiscoveryTests.m
+++ b/UnitTests/OIDServiceDiscoveryTests.m
@@ -128,7 +128,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
     kTokenEndpointAuthSigningAlgorithmValuesSupportedKey :
         @"Token Endpoint Auth Signing Algorithm Values Supported",
     kDisplayValuesSupportedKey : @"Display Values Supported",
-    kClaimTypesSupportedKey : @"Claim Types Supported",
+    kClaimTypesSupportedKey : @[@"normal"],
     kClaimsSupportedKey : @"Claims Supported",
     kServiceDocumentationKey : @"Service Documentation",
     kClaimsLocalesSupportedKey : @"Claims Locales Supported",
@@ -398,6 +398,12 @@ static NSString *const kDiscoveryDocumentNotDictionary =
   OIDServiceDiscovery *unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
+  
+  if (@available(iOS 11.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:discovery requiringSecureCoding:YES error:&error];
+    unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceDiscovery class] fromData:data error:&error];
+    XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
+  }
 }
 
 /*! @brief Tests the NSCopying implementation by round-tripping an instance through the copying

--- a/UnitTests/OIDServiceDiscoveryTests.m
+++ b/UnitTests/OIDServiceDiscoveryTests.m
@@ -399,7 +399,7 @@ static NSString *const kDiscoveryDocumentNotDictionary =
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
   
-  if (@available(iOS 11.0, *)) {
+  if (@available(iOS 11.0, macCatalyst 13, macOS 10.13, tvOS 11, watchOS 4, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery requiringSecureCoding:YES error:&error];
     unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceDiscovery class] fromData:data error:&error];
     XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");


### PR DESCRIPTION
In our project to preserve auth credentials between network sessions we archive the obtained during the successful login `OIDAuthState` object and store it in the keychain. We used to use `+[NSKeyedUnarchiver unarchiveObjectWithData:]` to unarchive it back for the next session. But this method is deprecated started from the iOS 12 so we tried to make use of recommended `+[NSKeyedUnarchiver unarchivedObjectOfClass:fromData:error:]` which brought us to the crush in the depth of AppAuth. The thing is about a dictionary encapsulated by `OIDServiceDiscovery`. Despite confirming to `NSSecureCoding` it uses `-[NSDictionary initWithCoder:]`. It's ok and works and tests are green -- only because test's dictionary is a bit artificial. It contains strings only as a values. But in our real deployment it is full of nested collections. An attempt to use `-[NSDictionary initWithCoder:]` with such a dictionary fails and sets `NSKeyedUnarchiver`'s `error` property to the appropriate error. So this pr improves the test dictionary with such an example and fixes such a bug trying to maintain the compatibility with the previous versions.

Please note though -- I wasn't able to run the tests on the iOS 10 to check if I broke sth. Obviously it's about AuthenticationServices framework which didn't exist at the moment. Our project is runnable on it too. Looks like this thing is a bit beyond my skills. Here is what XCode greets me with.
```
2019-10-31 11:43:30.483 xctest[7825:202958] The bundle “AppAuth-iOSTests” couldn’t be loaded because it is damaged or missing necessary resources. Try reinstalling the bundle.
2019-10-31 11:43:30.483 xctest[7825:202958] (dlopen_preflight(/Users/aurban/Library/Developer/Xcode/DerivedData/AppAuth-amlxwizlqbgrzhfccvbvtyvrncxn/Build/Products/Debug-iphonesimulator/AppAuth-iOSTests.xctest/AppAuth-iOSTests): Library not loaded: /System/Library/Frameworks/AuthenticationServices.framework/AuthenticationServices
  Referenced from: /Users/aurban/Library/Developer/Xcode/DerivedData/AppAuth-amlxwizlqbgrzhfccvbvtyvrncxn/Build/Products/Debug-iphonesimulator/AppAuth-iOSTests.xctest/AppAuth-iOSTests
  Reason: no suitable image found.  Did find:
	/System/Library/Frameworks/AuthenticationServices.framework/AuthenticationServices: mach-o, but not built for iOS simulator)
Program ended with exit code: 82
```