### PR TITLE
[iOS] Allow using third party app to authenticate

### DIFF
--- a/Source/OIDAuthorizationRequest.m
+++ b/Source/OIDAuthorizationRequest.m
@@ -353,11 +353,13 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
 }
 
 - (NSURL *)appOAuthUrlScheme {
-  NSString* urlScheme = [self.additionalParameters valueForKey:kAppOAuthUrlScheme];
-  if (urlScheme != NULL) {
-    OIDURLQueryComponent *query = [self queryComponent];
-    NSURL *url = [NSURL URLWithString:urlScheme];
-    return [query URLByReplacingQueryInURL:url];
+  if (self.additionalParameters != NULL) {
+    NSString* urlScheme = [self.additionalParameters valueForKey:kAppOAuthUrlScheme];
+    if (urlScheme != NULL) {
+      OIDURLQueryComponent *query = [self queryComponent];
+      NSURL *url = [NSURL URLWithString:urlScheme];
+      return [query URLByReplacingQueryInURL:url];
+    }
   }
   return NULL;
 }

--- a/Source/OIDEndSessionRequest.m
+++ b/Source/OIDEndSessionRequest.m
@@ -156,6 +156,10 @@ static NSString *const OIDMissingEndSessionEndpointMessage =
   return [self endSessionRequestURL];
 }
 
+- (NSURL *)appOAuthUrlScheme {
+  return NULL;
+}
+
 - (NSString *)redirectScheme {
   return [_postLogoutRedirectURL scheme];
 }

--- a/Source/OIDExternalUserAgentRequest.h
+++ b/Source/OIDExternalUserAgentRequest.h
@@ -27,6 +27,11 @@
  */
 - (NSURL*)externalUserAgentRequestURL;
 
+/*! @brief Method to create and return the complete request oauth URL instance.
+   @return A @c NSURL instance of app scheme
+*/
+- (NSURL*)appOAuthUrlScheme;
+
 /*! @brief If this external user-agent request has a redirect URL, this should return its scheme.
         Since some external requests have optional callbacks (such as the end session endpoint), the
         return value of this method is nullable.

--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -78,6 +78,17 @@ NS_ASSUME_NONNULL_BEGIN
 
   _externalUserAgentFlowInProgress = YES;
   _session = session;
+    
+  // Check if having app url scheme
+  NSURL *appScheme = [request appOAuthUrlScheme];
+  if (appScheme != NULL) {
+    BOOL canHandle = [[UIApplication sharedApplication] canOpenURL:appScheme];
+    if (canHandle) {
+      [[UIApplication sharedApplication] openURL:appScheme];
+      return YES;
+    }
+  }
+  
   BOOL openedUserAgent = NO;
   NSURL *requestURL = [request externalUserAgentRequestURL];
 


### PR DESCRIPTION
Authenticate using app instead of webview.

# How it works
Check if there is `appOAuthUrlScheme` inside `additionalParameters` then build URL for requested app and open it.
# Example
Open `Strava` app for authenticating
```
// builds authentication request
  NSDictionary* parameters = @{ @"appOAuthUrlScheme" : @"strava://oauth/mobile/authorize"};
  OIDAuthorizationRequest *request =
      [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
                                                    clientId:clientID
                                                clientSecret:clientSecret
                                                      scopes:@[ OIDScopeOpenID, OIDScopeProfile ]
                                                 redirectURL:redirectURI
                                                responseType:OIDResponseTypeCode
                                        additionalParameters:parameters];
```