### PR TITLE
Correct nullability annotations in OIDExternalUserAgentIOS

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 API_UNAVAILABLE(macCatalyst)
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 
-- (nullable instancetype)init API_AVAILABLE(ios(11))
+- (instancetype)init API_AVAILABLE(ios(11))
     __deprecated_msg("This method will not work on iOS 13, use "
                      "initWithPresentingViewController:presentingViewController");
 
@@ -42,7 +42,7 @@ API_UNAVAILABLE(macCatalyst)
     @param presentingViewController The view controller from which to present the
         \SFSafariViewController.
  */
-- (nullable instancetype)initWithPresentingViewController:
+- (instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController
     NS_DESIGNATED_INITIALIZER;
 

--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -54,14 +54,14 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 }
 
-- (nullable instancetype)init {
+- (instancetype)init {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
   return [self initWithPresentingViewController:nil];
 #pragma clang diagnostic pop
 }
 
-- (nullable instancetype)initWithPresentingViewController:
+- (instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController {
   self = [super init];
   if (self) {


### PR DESCRIPTION
Closes #442 

It has been wrong to declare the initializers as `nullable`, because it conflicted with the implementation of `NSObject`. Please see the description in #442.

From the `NSObject` documentation:

> In terms of nullability, callers can assume that the NSObject implementation of init() does not return nil.
