### PR TITLE
Fixed an issue with the sample code for the Swift authorization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ let appDelegate = UIApplication.shared.delegate as! AppDelegate
 appDelegate.currentAuthorizationFlow =
     OIDAuthState.authState(byPresenting: request, presenting: self) { authState, error in
   if let authState = authState {
-    self.setAuthState(authState)
+    self.authState = authState
     print("Got authorization tokens. Access token: " +
           "\(authState.lastTokenResponse?.accessToken ?? "nil")")
   } else {
     print("Authorization error: \(error?.localizedDescription ?? "Unknown error")")
-    self.setAuthState(nil)
+    self.authState = nil
   }
 }
 ```


### PR DESCRIPTION
Previously the sample code for the authorization flow was assigning the authState to the current variable with

self.setAuthState(authState)

which is a literal translation of the Objective-C version, but doesn't actually compile, as variables in Swift are assigned directly, not through a method call.