### PR TITLE
Update README.md to get rid of ITMS-90809 (UIWebView)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tasks like performing an action with fresh tokens.
 It follows the best practices set out in 
 [RFC 8252 - OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252)
 including using `SFAuthenticationSession` and `SFSafariViewController` on iOS
-for the auth request. `UIWebView` and `WKWebView` are explicitly *not*
+for the auth request. `UI WebView` and `WKWebView` are explicitly *not*
 supported due to the security and usability reasons explained in
 [Section 8.12 of RFC 8252](https://tools.ietf.org/html/rfc8252#section-8.12).
 


### PR DESCRIPTION
This change should remove App Store warning - ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs.