### PR TITLE
Make ExternalUserAgent default subspec and depend on Core subspec

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -62,5 +62,5 @@ It follows the OAuth 2.0 for Native Apps best current practice
     externalUserAgent.osx.deployment_target = '10.9'
   end
   
-  s.default_subspec = "ExternalUserAgent"
+  s.default_subspec = 'Core', 'ExternalUserAgent'
 end

--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -56,10 +56,8 @@ It follows the OAuth 2.0 for Native Apps best current practice
 
     # macOS
     externalUserAgent.osx.source_files = "Source/AppAuth/macOS/**/*.{h,m}"
-    externalUserAgent.osx.deployment_target = '10.9'    
-      
+    externalUserAgent.osx.deployment_target = '10.9'      
   end
   
   s.default_subspec = "ExternalUserAgent"
-  
 end

--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -31,7 +31,10 @@ It follows the OAuth 2.0 for Native Apps best current practice
   #       classes of AppAuth with tokens on watchOS and tvOS, but currently the
   #       library won't help you obtain authorization grants on those platforms.
 
-  s.platforms    = { :ios => "7.0", :osx => "10.9", :watchos => "2.0", :tvos => "9.0" }
+  s.ios.deployment_target = "7.0"
+  s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/openid/AppAuth-iOS.git", :tag => s.version }
   s.requires_arc = true

--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -47,7 +47,6 @@ It follows the OAuth 2.0 for Native Apps best current practice
     externalUserAgent.dependency 'AppAuth/Core'
     
     externalUserAgent.source_files = "Source/AppAuth.h", "Source/AppAuth/*.{h,m}"
-    externalUserAgent.source_files = "Source/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.*"
     
     # iOS
     externalUserAgent.ios.source_files      = "Source/AppAuth/iOS/**/*.{h,m}"

--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -59,7 +59,7 @@ It follows the OAuth 2.0 for Native Apps best current practice
 
     # macOS
     externalUserAgent.osx.source_files = "Source/AppAuth/macOS/**/*.{h,m}"
-    externalUserAgent.osx.deployment_target = '10.9'      
+    externalUserAgent.osx.deployment_target = '10.9'
   end
   
   s.default_subspec = "ExternalUserAgent"

--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -44,8 +44,10 @@ It follows the OAuth 2.0 for Native Apps best current practice
 
   # Subspec for the full AppAuth library, including platform-dependant external user agents.
   s.subspec 'ExternalUserAgent' do |externalUserAgent|
-
-    externalUserAgent.source_files = "Source/*.{h,m}", "Source/AppAuthCore/*.{h,m}", "Source/AppAuth/*.{h,m}"
+    externalUserAgent.dependency 'AppAuth/Core'
+    
+    externalUserAgent.source_files = "Source/AppAuth.h", "Source/AppAuth/*.{h,m}"
+    externalUserAgent.source_files = "Source/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.*"
     
     # iOS
     externalUserAgent.ios.source_files      = "Source/AppAuth/iOS/**/*.{h,m}"
@@ -56,5 +58,9 @@ It follows the OAuth 2.0 for Native Apps best current practice
     # macOS
     externalUserAgent.osx.source_files = "Source/AppAuth/macOS/**/*.{h,m}"
     externalUserAgent.osx.deployment_target = '10.9'    
+      
   end
+  
+  s.default_subspec = "ExternalUserAgent"
+  
 end


### PR DESCRIPTION
- Make the ExternalUserAgent depend on the Core subspec
- Make the ExternalUserAgent the default subspec

(This is in preparation for an EnterpriseUserAgent subspec which would in turn depend on ExternalUserAgent)
