### PR TITLE
Remove object from NSLog and add prompt to enable AppAuthRequestTrace

### DIFF
--- a/Source/AppAuthCore/OIDAuthState.m
+++ b/Source/AppAuthCore/OIDAuthState.m
@@ -377,10 +377,12 @@ static const NSUInteger kExpiryTimeTolerance = 60;
     // Calling updateWithTokenResponse while in an error state probably means the developer obtained
     // a new token and did the exchange without also calling updateWithAuthorizationResponse.
     // Attempts to handle gracefully, but warns the developer that this is unexpected.
-    NSLog(@"OIDAuthState:updateWithTokenResponse should not be called in an error state [%@] call"
-         "updateWithAuthorizationResponse with the result of the fresh authorization response"
-         "first",
-         _authorizationError);
+    NSLog(@"OIDAuthState:updateWithTokenResponse should not be called in an error state."
+          "Enable AppAuthRequestTrace to see the details.");
+    AppAuthRequestTrace(@"OIDAuthState:updateWithTokenResponse should not be called in an error state"
+                        "[%@] call updateWithAuthorizationResponse with the result of the fresh"
+                        "authorization response first",
+                        _authorizationError);
 
     _authorizationError = nil;
   }

--- a/Source/AppAuthCore/OIDIDToken.m
+++ b/Source/AppAuthCore/OIDIDToken.m
@@ -27,6 +27,7 @@ static NSString *const kIatKey = @"iat";
 static NSString *const kNonceKey = @"nonce";
 
 #import "OIDFieldMapping.h"
+#import "OIDDefines.h"
 
 @implementation OIDIDToken
 
@@ -117,7 +118,8 @@ static NSString *const kNonceKey = @"nonce";
   NSError *error;
   id object = [NSJSONSerialization JSONObjectWithData:decodedData options:0 error:&error];
   if (error) {
-    NSLog(@"Error %@ parsing token payload %@", error, sectionString);
+    NSLog(@"Error parsing token payload. Enable AppAuthRequestTrace to see the details.");
+    AppAuthRequestTrace(@"Error %@ parsing token payload %@", error, sectionString);
   }
   if ([object isKindOfClass:[NSDictionary class]]) {
     return (NSDictionary *)object;


### PR DESCRIPTION
Addresses #519 to remove the object from 2 NSLog statements and instead prompts developers to enable AppAuthRequestTrace to view the details.