### PR TITLE
Add support for app2app on iOS

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -84,6 +84,26 @@ NS_ASSUME_NONNULL_BEGIN
 
   _externalUserAgentFlowInProgress = YES;
   _session = session;
+  NSURL *requestURL = [request externalUserAgentRequestURL];
+
+  if (@available(iOS 10.0, *)) {
+    // first try universal link, the authorization server may have an app which is present and
+    // supports app2app
+    [UIApplication.sharedApplication openURL:requestURL
+                                     options:@{UIApplicationOpenURLOptionUniversalLinksOnly: @YES}
+                           completionHandler:^(BOOL success) {
+      if (!success) {
+        [self continuePresentExternalUserAgentRequest:request session:session];
+      }
+    }];
+    return YES;
+  } else {
+    return [self continuePresentExternalUserAgentRequest:request session:session];
+  }
+}
+
+- (BOOL)continuePresentExternalUserAgentRequest:(id<OIDExternalUserAgentRequest>)request
+                                        session:(id<OIDExternalUserAgentSession>)session {
   BOOL openedUserAgent = NO;
   NSURL *requestURL = [request externalUserAgentRequestURL];
 


### PR DESCRIPTION
If the user has an app installed that has a Universal Link registered
for the authorization endpoint, then launching that app will provide a
better user experience.

If the launch fails, we continue as before to use an in-app browser
tab etc.

See this OpenID Foundation blog post for further details:

https://openid.net/2019/10/21/guest-blog-implementing-app-to-app-authorisation-in-oauth2-openid-connect/

There was a question about whether to make this the default behaviour
or not; the documentation for OIDExternalUserAgentIOS says:

> An iOS specific external user-agent that uses the best possible
> user-agent available ...

so I think it's consistent with the documented goal to enable app2app
by default.