### PR TITLE
Replace itms-apps with https in OIDExternalAgentIOSCustomBrowser

### DIFF
--- a/Source/AppAuthEnterpriseUserAgent/iOS/OIDExternalUserAgentIOSCustomBrowser.m
+++ b/Source/AppAuthEnterpriseUserAgent/iOS/OIDExternalUserAgentIOSCustomBrowser.m
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
   // Chrome iOS documentation: https://developer.chrome.com/multidevice/ios/links
   OIDCustomBrowserURLTransformation transform = [[self class] URLTransformationSchemeSubstitutionHTTPS:@"googlechromes" HTTP:@"googlechrome"];
   NSURL *appStoreURL =
-  [NSURL URLWithString:@"itms-apps://itunes.apple.com/us/app/chrome/id535886823"];
+  [NSURL URLWithString:@"https://itunes.apple.com/us/app/chrome/id535886823"];
   return [[[self class] alloc] initWithURLTransformation:transform
                                         canOpenURLScheme:@"googlechromes"
                                              appStoreURL:appStoreURL];
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
   OIDCustomBrowserURLTransformation transform =
       [[self class] URLTransformationSchemeConcatPrefix:@"firefox://open-url?url="];
   NSURL *appStoreURL =
-  [NSURL URLWithString:@"itms-apps://itunes.apple.com/us/app/firefox-web-browser/id989804926"];
+  [NSURL URLWithString:@"https://itunes.apple.com/us/app/firefox-web-browser/id989804926"];
   return [[[self class] alloc] initWithURLTransformation:transform
                                         canOpenURLScheme:@"firefox"
                                              appStoreURL:appStoreURL];
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
   OIDCustomBrowserURLTransformation transform =
       [[self class] URLTransformationSchemeSubstitutionHTTPS:@"opera-https" HTTP:@"opera-http"];
   NSURL *appStoreURL =
-  [NSURL URLWithString:@"itms-apps://itunes.apple.com/us/app/opera-mini-web-browser/id363729560"];
+  [NSURL URLWithString:@"https://itunes.apple.com/us/app/opera-mini-web-browser/id363729560"];
   return [[[self class] alloc] initWithURLTransformation:transform
                                         canOpenURLScheme:@"opera-https"
                                              appStoreURL:appStoreURL];


### PR DESCRIPTION
Addresses https://github.com/openid/AppAuth-iOS/issues/506 by removing the use of "itms-apps".

OIDExternalAgentIOSCustomBrowser opens the App Store to install custom browsers if not installed, using the URI itms-apps://. This was replaced by https://, which was tested to instantly launch the App Store in iOS 13. Upon research this behavior may go back as far as iOS 6. In the worst case, https:// would cause a redirect to the browser followed by a redirect to the App Store.