### PR TITLE
Fixed SwiftPM package example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ add the following `dependency` to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/openid/AppAuth-iOS.git", .upToNextMajor(from: "1.3.0"))
+    .package(name: "AppAuth", url: "https://github.com/openid/AppAuth-iOS.git", .upToNextMajor(from: "1.4.0"))
 ]
 ```
 


### PR DESCRIPTION
Example was missing package name and for that reason was not updating. Added name and it started to work.