### PR TITLE
Change iOS deployment target for Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,14 +20,28 @@ import PackageDescription
        limitations under the License.
 */
 
+var platforms: [SupportedPlatform] {
+    #if compiler(<5.3)
+        return [
+            .macOS(.v10_10),
+            .iOS(.v8),
+            .tvOS(.v9),
+            .watchOS(.v2),
+        ]
+    #else
+        // Xcode 12 (which ships with Swift 5.3) drops support for iOS 8
+        return [
+            .macOS(.v10_10),
+            .iOS(.v9),
+            .tvOS(.v9),
+            .watchOS(.v2),
+        ]
+    #endif
+}
+
 let package = Package(
     name: "AppAuth",
-    platforms: [
-        .macOS(.v10_10),
-        .iOS(.v8),
-        .tvOS(.v9),
-        .watchOS(.v2)
-    ],
+    platforms: platforms,
     products: [
         .library(
             name: "AppAuthCore",


### PR DESCRIPTION
This removes the warning about iOS 8 no longer being supported in Xcode 12 while maintaining support for older versions of Xcode. Technically checking the compiler version isn’t an exact 1:1 for checking for Xcode version, but in practice should work in all scenarios.