### PR TITLE
separating pod for Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Docs/
 xcuserdata/
 Carthage/
+AppAuth.xcodeproj/.idea/

--- a/AppAuthCore.podspec
+++ b/AppAuthCore.podspec
@@ -1,0 +1,43 @@
+Pod::Spec.new do |s|
+
+  s.name         = "AppAuthCore"
+  s.version      = "1.4.0"
+  s.summary      = "AppAuth for iOS and macOS is a client SDK for communicating with OAuth 2.0 and OpenID Connect providers."
+
+  s.description  = <<-DESC
+
+AppAuth for iOS and macOS is a client SDK for communicating with [OAuth 2.0]
+(https://tools.ietf.org/html/rfc6749) and [OpenID Connect]
+(http://openid.net/specs/openid-connect-core-1_0.html) providers. It strives to
+directly map the requests and responses of those specifications, while following
+the idiomatic style of the implementation language. In addition to mapping the
+raw protocol flows, convenience methods are available to assist with common
+tasks like performing an action with fresh tokens.
+
+It follows the OAuth 2.0 for Native Apps best current practice
+([RFC 8252](https://tools.ietf.org/html/rfc8252)).
+
+                   DESC
+
+  s.homepage     = "https://openid.github.io/AppAuth-iOS"
+  s.license      = "Apache License, Version 2.0"
+  s.authors      = { "William Denniss" => "wdenniss@google.com",
+                     "Steven E Wright" => "stevewright@google.com",
+                     "Julien Bodet" => "julien.bodet92@gmail.com"
+                   }
+
+  # Note: While watchOS and tvOS are specified here, only iOS and macOS have
+  #       UI implementations of the authorization service. You can use the
+  #       classes of AppAuth with tokens on watchOS and tvOS, but currently the
+  #       library won't help you obtain authorization grants on those platforms.
+
+  s.ios.deployment_target = "7.0"
+  s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+
+  s.source       = { :git => "https://github.com/agensdev/AppAuth-iOS.git", :tag => s.version }
+  s.requires_arc = true
+
+  s.source_files = "Source/AppAuthCore.h", "Source/AppAuthCore/*.{h,m}"
+end


### PR DESCRIPTION
In the scenario where the main app uses the full AppAuth framework and a widget extension is in need of using AppAuth/Core, the frameworks imported through cocoapods will both be named AppAuth. This confuses the build-process, and leads to that both targets will be using the last imported framework. In order to be able to build with the described scenario, I have added a podspec for Core that will be treated as a separate framework, that one can import through cocoapods. 
In the scenario where one does not have a requirement for the main-app to use the full framework and an extension to use the Core-only framework, one can still import core as AppAuth/Core in order to keep the framework name AppAuth.
With the added podspec, the separate core framework is called AppAuthCore.