### PR TITLE
Update init unavailable doc on OIDServiceDiscovery

### DIFF
--- a/Source/AppAuthCore/OIDServiceDiscovery.h
+++ b/Source/AppAuthCore/OIDServiceDiscovery.h
@@ -326,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! @internal
     @brief Unavailable. Please use @c initWithDictionary:error:, @c initWithJSON:error, or the
-        @c serviceDiscoveryWithURL:callback: factory method.
+        @c discoverServiceConfigurationForDiscoveryURL:callback: from @c OIDAuthorizationService.
  */
 - (nonnull instancetype)init NS_UNAVAILABLE;
 


### PR DESCRIPTION
Initially referred to a non-existent serviceDiscoveryWithURL:callback: method.