### PR TITLE
Remove unmatched diagnostic pop

### DIFF
--- a/UnitTests/AppAuthTV/OIDTVAuthorizationResponseTests.m
+++ b/UnitTests/AppAuthTV/OIDTVAuthorizationResponseTests.m
@@ -281,5 +281,3 @@ static int const kTestInterval = 5;
 }
 
 @end
-
-#pragma GCC diagnostic pop


### PR DESCRIPTION
There seems to be a hanging diagnostic pop that has no push which is causing Travis to fail.

It's been in this file throughout the history of the repo with no matching push so I deleted it.