### PR TITLE
Add note to README.md to remind about persisting fresh tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,10 @@ self.authState?.performAction() { (accessToken, idToken, error) in
 }
 ```
 
+This also updates the AuthState object with current access, id, and refresh tokens. 
+If you are storing your AuthState in persistent storage, you should write the updated 
+copy in the callback to this method.
+
 ### Custom User-Agents (iOS and macOS)
 
 Each OAuth flow involves presenting an external user-agent to the user, that


### PR DESCRIPTION
### Motivation and Context
Had an issue using this library for the first time by forgetting to update the persisted authstate after using fresh tokens, especially when integrating with services that have single-use refresh tokens.

### Description
Adds a note to the documentation to help people know that this is required.
