### PR TITLE
prefersEphemeralWebBrowserSession

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -46,6 +46,8 @@ API_UNAVAILABLE(macCatalyst)
     (UIViewController *)presentingViewController
     NS_DESIGNATED_INITIALIZER;
 
+@property(nonatomic, assign) BOOL prefersEphemeralWebBrowserSession;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -72,6 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     _presentingViewController = presentingViewController;
   }
+  _prefersEphemeralWebBrowserSession = YES;
   return self;
 }
 
@@ -116,6 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
           authenticationVC.presentationContextProvider = self;
+          authenticationVC.prefersEphemeralWebBrowserSession = self.prefersEphemeralWebBrowserSession;
       }
 #endif
       _webAuthenticationVC = authenticationVC;


### PR DESCRIPTION
A Boolean value that indicates whether the session should ask the browser for a private authentication session.