### PR TITLE
Fix nullability specifier warning UserAgentIOS

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -34,9 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 API_UNAVAILABLE(macCatalyst)
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability"
 - (nullable instancetype)init API_AVAILABLE(ios(11))
     __deprecated_msg("This method will not work on iOS 13, use "
                      "initWithPresentingViewController:presentingViewController");
+#pragma clang diagnostic pop
 
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the


### PR DESCRIPTION
In `OIDExternalUserAgentIOS` we override the default initializer inherited from `NSObject` while also overriding the nullability specifier. In modern Xcode versions this produces a warning.

Ignoring the clang warning removes the warning and states that it was an intended modification.

---

Screenshot from Xcode:
<img width="946" alt="Screen Shot 2022-03-16 at 8 58 22 AM" src="https://user-images.githubusercontent.com/1413987/158544641-e917a5bc-3300-4c30-a923-f49b41d082d9.png">