### PR TITLE
Fixing the unarchivedObject

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,3 +20,4 @@ Hernan Zalazar <hernan.zalazar@gmail.com> https://github.com/hzalaz
 Joseph Heenan <joseph@emobix.co.uk> https://github.com/jogu
 Julien Bodet <julien.bodet92@gmail.com> https://github.com/julienbodet
 Tobias Schröpf <schroepf@gmail.com> https://github.com/schroepf
+Amin Amjadi <ma.amjadi@outlook.com> https://github.com/maamjadi

--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -56,24 +56,24 @@ NS_ASSUME_NONNULL_BEGIN
                          registrationEndpoint:(nullable NSURL *)registrationEndpoint
                            endSessionEndpoint:(nullable NSURL *)endSessionEndpoint
                             discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument
-                            NS_DESIGNATED_INITIALIZER;
+NS_DESIGNATED_INITIALIZER;
 
 @end
 
 @implementation OIDServiceConfiguration
 
 - (instancetype)init
-    OID_UNAVAILABLE_USE_INITIALIZER(@selector(
-        initWithAuthorizationEndpoint:
-                        tokenEndpoint:)
-    )
+OID_UNAVAILABLE_USE_INITIALIZER(@selector(
+                                          initWithAuthorizationEndpoint:
+                                          tokenEndpoint:)
+                                )
 
 - (instancetype)initWithAuthorizationEndpoint:(NSURL *)authorizationEndpoint
-        tokenEndpoint:(NSURL *)tokenEndpoint
-               issuer:(nullable NSURL *)issuer
- registrationEndpoint:(nullable NSURL *)registrationEndpoint
-   endSessionEndpoint:(nullable NSURL *)endSessionEndpoint
-    discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument {
+                                tokenEndpoint:(NSURL *)tokenEndpoint
+                                       issuer:(nullable NSURL *)issuer
+                         registrationEndpoint:(nullable NSURL *)registrationEndpoint
+                           endSessionEndpoint:(nullable NSURL *)endSessionEndpoint
+                            discoveryDocument:(nullable OIDServiceDiscovery *)discoveryDocument {
 
   self = [super init];
   if (self) {
@@ -179,14 +179,14 @@ NS_ASSUME_NONNULL_BEGIN
   NSURL *registrationEndpoint = [aDecoder decodeObjectOfClass:[NSURL class]
                                                        forKey:kRegistrationEndpointKey];
   NSURL *endSessionEndpoint = [aDecoder decodeObjectOfClass:[NSURL class]
-                                                       forKey:kEndSessionEndpointKey];
+                                                     forKey:kEndSessionEndpointKey];
   // We don't accept nil authorizationEndpoints or tokenEndpoints.
   if (!authorizationEndpoint || !tokenEndpoint) {
     return nil;
   }
 
-  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClass:[OIDServiceDiscovery class]
-                                                                  forKey:kDiscoveryDocumentKey];
+  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[OIDServiceDiscovery class], [NSArray class], nil]
+                                                                    forKey:kDiscoveryDocumentKey];
 
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint
@@ -209,13 +209,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description {
   return [NSString stringWithFormat:
-      @"OIDServiceConfiguration authorizationEndpoint: %@, tokenEndpoint: %@, "
+          @"OIDServiceConfiguration authorizationEndpoint: %@, tokenEndpoint: %@, "
           "registrationEndpoint: %@, endSessionEndpoint: %@, discoveryDocument: [%@]",
-      _authorizationEndpoint,
-      _tokenEndpoint,
-      _registrationEndpoint,
-      _endSessionEndpoint,
-      _discoveryDocument];
+          _authorizationEndpoint,
+          _tokenEndpoint,
+          _registrationEndpoint,
+          _endSessionEndpoint,
+          _discoveryDocument];
 }
 
 @end


### PR DESCRIPTION
NSCoder is not very good at decoding heterogeneous objects.. With this work the issue with `decodeObject` is fixed as result of which `NSKeyedUnarchiver.unarchivedObject(ofClass: OIDAuthState.self, from: decoded) throws` should work as expected.
This PR is relate to the issue https://github.com/openid/AppAuth-iOS/issues/479