### PR TITLE
Set prefersEphemeralWebBrowserSession to true 

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -116,6 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
           authenticationVC.presentationContextProvider = self;
+          authenticationVC.prefersEphemeralWebBrowserSession = YES;
       }
 #endif
       _webAuthenticationVC = authenticationVC;


### PR DESCRIPTION
…wser doesn’t share cookies or other browsing data between the authentication session and the user’s normal browser session.