### PR TITLE
Relax redirect URL matching for the forward slash path case

### DIFF
--- a/Source/AppAuthCore/OIDAuthorizationService.m
+++ b/Source/AppAuthCore/OIDAuthorizationService.m
@@ -107,15 +107,17 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)URL:(NSURL *)URL matchesRedirectionURL:(NSURL *)redirectionURL {
   NSURL *standardizedURL = [URL standardizedURL];
   NSURL *standardizedRedirectURL = [redirectionURL standardizedURL];
+  NSString *trimmedStdUrlPath = [standardizedURL.path stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
+  NSString *stdRedirectUrlPath = [standardizedRedirectURL.path stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
+    
 
   return [standardizedURL.scheme caseInsensitiveCompare:standardizedRedirectURL.scheme] == NSOrderedSame
       && OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user)
       && OIDIsEqualIncludingNil(standardizedURL.password, standardizedRedirectURL.password)
       && OIDIsEqualIncludingNil(standardizedURL.host, standardizedRedirectURL.host)
       && OIDIsEqualIncludingNil(standardizedURL.port, standardizedRedirectURL.port)
-      && OIDIsEqualIncludingNil(standardizedURL.path, standardizedRedirectURL.path);
+      && OIDIsEqualIncludingNil(trimmedStdUrlPath, stdRedirectUrlPath);
 }
-
 - (BOOL)shouldHandleURL:(NSURL *)URL {
   return [[self class] URL:URL matchesRedirectionURL:_request.redirectURL];
 }

--- a/Source/AppAuthCore/OIDAuthorizationService.m
+++ b/Source/AppAuthCore/OIDAuthorizationService.m
@@ -107,9 +107,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)URL:(NSURL *)URL matchesRedirectionURL:(NSURL *)redirectionURL {
   NSURL *standardizedURL = [URL standardizedURL];
   NSURL *standardizedRedirectURL = [redirectionURL standardizedURL];
-  // Some servers adds '/' to the end when there is no 'path'. To relax the equality rules below
-  // were decided to normalize pathes. So, pathes like '' are the same to '/' now.
-  // Read more https://github.com/openid/AppAuth-iOS/issues/446
+  // An empty path may be represented as '' or '/'.  In order to treat these two cases as equivalent,
+  // we normalize a path of '/' to ''.
+  // For context: https://github.com/openid/AppAuth-iOS/issues/446
   NSString *normalizedPath = [standardizedURL.path isEqualToString:@"/"] ? @""
       : standardizedURL.path;
   NSString *normalizedRedirectPath = [standardizedRedirectURL.path isEqualToString:@"/"] ? @""

--- a/Source/AppAuthCore/OIDAuthorizationService.m
+++ b/Source/AppAuthCore/OIDAuthorizationService.m
@@ -107,10 +107,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)URL:(NSURL *)URL matchesRedirectionURL:(NSURL *)redirectionURL {
   NSURL *standardizedURL = [URL standardizedURL];
   NSURL *standardizedRedirectURL = [redirectionURL standardizedURL];
+  // Some servers adds '/' to the end when there is no 'path'. To relax the equality rules below
+  // were decided to normalize pathes. So, pathes like '' are the same to '/' now.
+  // Read more https://github.com/openid/AppAuth-iOS/issues/446
   NSString *normalizedPath = [standardizedURL.path isEqualToString:@"/"] ? @""
-    : standardizedURL.path;
+      : standardizedURL.path;
   NSString *normalizedRedirectPath = [standardizedRedirectURL.path isEqualToString:@"/"] ? @""
-    : standardizedRedirectURL.path;
+      : standardizedRedirectURL.path;
 
   return [standardizedURL.scheme caseInsensitiveCompare:standardizedRedirectURL.scheme] == NSOrderedSame
       && OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user)

--- a/Source/AppAuthCore/OIDAuthorizationService.m
+++ b/Source/AppAuthCore/OIDAuthorizationService.m
@@ -107,17 +107,19 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)URL:(NSURL *)URL matchesRedirectionURL:(NSURL *)redirectionURL {
   NSURL *standardizedURL = [URL standardizedURL];
   NSURL *standardizedRedirectURL = [redirectionURL standardizedURL];
-  NSString *trimmedStdUrlPath = [standardizedURL.path stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
-  NSString *stdRedirectUrlPath = [standardizedRedirectURL.path stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]];
-    
+  NSString *normalizedPath = [standardizedURL.path isEqualToString:@"/"] ? @""
+    : standardizedURL.path;
+  NSString *normalizedRedirectPath = [standardizedRedirectURL.path isEqualToString:@"/"] ? @""
+    : standardizedRedirectURL.path;
 
   return [standardizedURL.scheme caseInsensitiveCompare:standardizedRedirectURL.scheme] == NSOrderedSame
       && OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user)
       && OIDIsEqualIncludingNil(standardizedURL.password, standardizedRedirectURL.password)
       && OIDIsEqualIncludingNil(standardizedURL.host, standardizedRedirectURL.host)
       && OIDIsEqualIncludingNil(standardizedURL.port, standardizedRedirectURL.port)
-      && OIDIsEqualIncludingNil(trimmedStdUrlPath, stdRedirectUrlPath);
+      && OIDIsEqualIncludingNil(normalizedPath, normalizedRedirectPath);
 }
+
 - (BOOL)shouldHandleURL:(NSURL *)URL {
   return [[self class] URL:URL matchesRedirectionURL:_request.redirectURL];
 }


### PR DESCRIPTION
Based on issue #446 sometimes a trailing slash added to path for redirect url.
Here a fix to make comparison regardless that trailing slash.

This issue affects react-native-app-auth lib:
https://github.com/FormidableLabs/react-native-app-auth/issues/123
https://github.com/FormidableLabs/react-native-app-auth/issues/336

and a few others. 
