### PR TITLE
Add support for the special common/organizations/consumers Azure AD tenants

### DIFF
--- a/Source/AppAuthCore/OIDServiceDiscovery.m
+++ b/Source/AppAuthCore/OIDServiceDiscovery.m
@@ -102,6 +102,16 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
     return nil;
   }
 
+  NSString *issuer = (NSString *) json[@"issuer"];
+  if (issuer && [issuer containsString:@"{tenantid}"]) {
+    // The Azure AD discovery document's "issuer" value contains the special placeholder
+    // "{tenantid}". '{' and '}' are invalid characters in URLs and have to be URL encoded before
+    // the issuer URL can be parsed by NSURL.
+    NSMutableDictionary *newJson = [NSMutableDictionary dictionaryWithDictionary:json];
+    newJson[@"issuer"] = [issuer stringByReplacingOccurrencesOfString:@"{tenantid}" withString:@"%7Btenantid%7D"];
+    json = newJson;
+  }
+
   return [self initWithDictionary:json error:error];
 }
 


### PR DESCRIPTION
When not targeting a specific Azure AD tenant (specified by a tenant GUID in
the discovery document URL) but rather one of the "common", "organizations"
or "consumers" multi-tenant aliases (see 1), discovery document parsing and ID
token validation require a few extra steps:

* The discovery document's "issuer" value contains the special placeholder
  "{tenantid}". As '{' and '}' are invalid characters in URLs, AppAuth has to
  URL encode these characters before the issuer URL can be parsed by NSURL in
  OIDServiceDiscovery.m.
* The same "{tenantid}" placeholder needs to be replaced with the actual
  tenant ID of the authenticated user, from the "tid" claim (see 2) of the ID
  token, before ID token validation is performed in OIDAuthorizationService.m.

1: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#fetch-the-openid-connect-metadata-document
2: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#payload-claims