### PR TITLE
Update OIDExternalUserAgentIOS.m

### DIFF
--- a/Source/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/iOS/OIDExternalUserAgentIOS.m
@@ -111,6 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
       }];
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
+          [authenticationVC setPrefersEphemeralWebBrowserSession:YES];
           authenticationVC.presentationContextProvider = self;
       }
 #endif


### PR DESCRIPTION
This `pr` make sure that we are not saving cookies in ASWebAuthenticationSession on iOS 13 and higher. 
It will solve the problem mentioned in 
1. [issue#655](https://github.com/openid/AppAuth-iOS/issues/655)
2. [issue#390](https://github.com/openid/AppAuth-iOS/issues/390)
3. [issue#386](https://github.com/openid/AppAuth-iOS/issues/386)