### PR TITLE
Correct OIDServiceDiscovery's NSCoding implementation

### DIFF
--- a/Source/AppAuthCore/OIDServiceConfiguration.m
+++ b/Source/AppAuthCore/OIDServiceConfiguration.m
@@ -185,8 +185,17 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
   }
 
-  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:[NSSet setWithObjects:[OIDServiceDiscovery class], [NSArray class], nil]
-                                                                  forKey:kDiscoveryDocumentKey];
+  NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[OIDServiceDiscovery class],
+                                                       // The following classes are required in
+                                                       // order to support secure decoding of the
+                                                       // old OIDServiceDiscovery encoding.
+                                                       [NSDictionary class],
+                                                       [NSArray class],
+                                                       [NSString class],
+                                                       [NSNumber class],
+                                                       [NSNull class]]];
+  OIDServiceDiscovery *discoveryDocument = [aDecoder decodeObjectOfClasses:allowedClasses
+                                                                    forKey:kDiscoveryDocumentKey];
 
   return [self initWithAuthorizationEndpoint:authorizationEndpoint
                                tokenEndpoint:tokenEndpoint

--- a/Source/AppAuthCore/OIDServiceDiscovery.m
+++ b/Source/AppAuthCore/OIDServiceDiscovery.m
@@ -23,6 +23,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! @brief The key for the @c discoveryDictionary property.
+ */
+static NSString *const kDiscoveryDictionaryKey = @"discoveryDictionary";
+
 /*! Field keys associated with an OpenID Connect Discovery Document. */
 static NSString *const kIssuerKey = @"issuer";
 static NSString *const kAuthorizationEndpointKey = @"authorization_endpoint";
@@ -192,7 +196,27 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   NSError *error;
-  NSDictionary *dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
+  NSDictionary *dictionary;
+  if ([aDecoder containsValueForKey:kDiscoveryDictionaryKey]) {
+    // We're decoding a collection type (NSDictionary) from NSJSONSerialization's
+    // +JSONObjectWithData, so we need to include all classes that could potentially be contained
+    // within.
+    NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[NSDictionary class],
+                                                         [NSArray class],
+                                                         [NSString class],
+                                                         [NSNumber class],
+                                                         [NSNull class]]];
+    dictionary = [aDecoder decodeObjectOfClasses:allowedClasses
+                                          forKey:kDiscoveryDictionaryKey];
+  } else {
+    // Decode using the old encoding which delegated to NSDictionary's encodeWithCoder:
+    // implementation:
+    //
+    // - (void)encodeWithCoder:(NSCoder *)aCoder {
+    //   [_discoveryDictionary encodeWithCoder:aCoder];
+    // }
+    dictionary = [[NSDictionary alloc] initWithCoder:aDecoder];
+  }
   self = [self initWithDictionary:dictionary error:&error];
   if (error) {
     return nil;
@@ -201,7 +225,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  [_discoveryDictionary encodeWithCoder:aCoder];
+  [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
 }
 
 #pragma mark - Properties

--- a/Source/AppAuthCore/OIDServiceDiscovery.m
+++ b/Source/AppAuthCore/OIDServiceDiscovery.m
@@ -226,6 +226,8 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [aCoder encodeObject:_discoveryDictionary forKey:kDiscoveryDictionaryKey];
+  // Provide forward compatibilty by continuing to add the old encoding.
+  [_discoveryDictionary encodeWithCoder:aCoder];
 }
 
 #pragma mark - Properties

--- a/UnitTests/OIDServiceDiscoveryTests.m
+++ b/UnitTests/OIDServiceDiscoveryTests.m
@@ -443,7 +443,7 @@ static NSString *const kDiscoveryDocumentNotDictionary =
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
   }
 
-  XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
+  XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);
 }
 
 /*! @brief To ensure backward compatibility, test our ability to decode the old encoding of @c OIDServiceDiscovery.
@@ -478,7 +478,7 @@ static NSString *const kDiscoveryDocumentNotDictionary =
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
   }
 
-  XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
+  XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);
 }
 
 /*! @brief Tests the NSCopying implementation by round-tripping an instance through the copying

--- a/UnitTests/OIDServiceDiscoveryTests.m
+++ b/UnitTests/OIDServiceDiscoveryTests.m
@@ -30,6 +30,20 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wgnu"
 
+// Define a subclass of @c OIDServiceDiscovery that provides the old implementation of
+// encodeWithCoder:.
+@interface OIDServiceDiscoveryOld : OIDServiceDiscovery
+
+@end
+
+@implementation OIDServiceDiscoveryOld
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  [self.discoveryDictionary encodeWithCoder:coder];
+}
+
+@end
+
 /*! Testing URL used when testing URL conversions. */
 static NSString *const kTestURL = @"http://www.google.com/";
 
@@ -110,7 +124,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
     kJWKSURLKey : @"http://www.example.com/jwks",
     kRegistrationEndpointKey : @"Registration Endpoint",
     kEndSessionEndpointKey : @"https://www.example.com/logout",
-    kScopesSupportedKey : @"Scopes Supported",
+    kScopesSupportedKey : @[ @"scope1", @"scope2" ],
     kResponseTypesSupportedKey : @"Response Types Supported",
     kResponseModesSupportedKey : @"Response Modes Supported",
     kGrantTypesSupportedKey : @"Grant Types Supported",
@@ -411,8 +425,58 @@ static NSString *const kDiscoveryDocumentNotDictionary =
   OIDServiceDiscovery *discovery =
       [[OIDServiceDiscovery alloc] initWithDictionary:serviceDiscoveryDictionary
                                                              error:&error];
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
-  OIDServiceDiscovery *unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  NSData *data;
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:discovery
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+  } else {
+    data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
+  }
+  
+  OIDServiceDiscovery *unarchived;
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceDiscovery class]
+                                                   fromData:data
+                                                      error:&error];
+  } else {
+    unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  }
+
+  XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
+}
+
+/*! @brief To ensure backward compatibility, test our ability to decode the old encoding of @c OIDServiceDiscovery.
+ */
+- (void)testSecureCodingOld {
+  NSError *error;
+  NSDictionary *serviceDiscoveryDictionary = [[self class] completeServiceDiscoveryDictionary];
+  OIDServiceDiscoveryOld *discovery =
+      [[OIDServiceDiscoveryOld alloc] initWithDictionary:serviceDiscoveryDictionary
+                                                   error:&error];
+  NSData *data;
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:discovery
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+  } else {
+    data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
+  }
+  
+  OIDServiceDiscovery *unarchived;
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[OIDServiceDiscovery class],
+                                                         [NSDictionary class],
+                                                         [NSArray class],
+                                                         [NSString class],
+                                                         [NSNumber class],
+                                                         [NSNull class]]];
+    unarchived = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedClasses
+                                                     fromData:data
+                                                        error:&error];
+  } else {
+    unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  }
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary, @"");
 }


### PR DESCRIPTION
Provide our own implementation of `NSCoding` for `OIDServiceDiscovery` rather than delegating to `NSDictionary` and maintain support for decoding the old encoding for backward compatibility.  Ensure that OIDServiceConfiguration can successfully decode the old encoding when `requiresSecureCoding` is enabled.  Test both new and old encodings with `requiresSecureCoding` enabled.