### PR TITLE
Fix nullability annotation for -[OIDExternalUserAgentIOS init]

### DIFF
--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 API_UNAVAILABLE(macCatalyst)
 @interface OIDExternalUserAgentIOS : NSObject<OIDExternalUserAgent>
 
-- (nullable instancetype)init API_AVAILABLE(ios(11))
+- (null_unspecified instancetype)init API_AVAILABLE(ios(11))
     __deprecated_msg("This method will not work on iOS 13, use "
                      "initWithPresentingViewController:presentingViewController");
 

--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 }
 
-- (nullable instancetype)init {
+- (null_unspecified instancetype)init {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
   return [self initWithPresentingViewController:nil];


### PR DESCRIPTION
This PR fixes this build warning:
> Source/AppAuth/iOS/OIDExternalUserAgentIOS.h:37:1: warning build: conflicting nullability specifier on return types, 'nullable' conflicts with existing specifier 'nonnull'

Unfortunately, this warning is misleading. `-[NSObject init]` doesn't have any nullability annotation, which is equivalent to `null_unspecified`, but `-[OIDExternalUserAgentIOS init]` has the conflicting `nullable` annotation.

The straightforward solution would be to remove the annotation here to get in sync with the base class, but this would be incorrect: In line 34, `NS_ASSUME_NONNULL_BEGIN` is used, which would make the annotation default to `nonnull` instead of `null_unspecified`, which is why `null_unspecified` has to be used explicitly.

To verify the fix, run the iOS tests in this repository with and without this PR. With this PR applied, the warning will no longer show up.

Fixes #442 