### PR TITLE
Use the macos-11 runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   xcode-project-test:
-    runs-on: macOS-11
+    runs-on: macos-11
     strategy:
       matrix:
         flags: [
@@ -32,7 +32,7 @@ jobs:
           ${{ matrix.flags }}
 
   pod-lib-lint:
-    runs-on: macOS-11
+    runs-on: macos-11
     strategy:
       matrix:
         flags: [
@@ -50,7 +50,7 @@ jobs:
       run: pod lib lint --verbose ${{ matrix.flags }}
 
   spm-build-test:
-    runs-on: macOS-11
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Build unit test target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   xcode-project-test:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     strategy:
       matrix:
         flags: [
@@ -32,7 +32,7 @@ jobs:
           ${{ matrix.flags }}
 
   pod-lib-lint:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     strategy:
       matrix:
         flags: [
@@ -50,7 +50,7 @@ jobs:
       run: pod lib lint --verbose ${{ matrix.flags }}
 
   spm-build-test:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
     - name: Build unit test target


### PR DESCRIPTION
Use the [macos-11 runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) until we're ready to switch to macos-12.