### PR TITLE
Increase swift version to 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
@@ -23,10 +23,10 @@ import PackageDescription
 let package = Package(
     name: "AppAuth",
     platforms: [
-        .macOS(.v10_10),
-        .iOS(.v9),
-        .tvOS(.v9),
-        .watchOS(.v2)
+        .macOS(.v10_13),
+        .iOS(.v11),
+        .tvOS(.v11),
+        .watchOS(.v4)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 


### PR DESCRIPTION
The reason I need this upgrade is to be able to use `moduleAliases` in my Package when using AppAuth dependent packages like [GoogleSigIn](https://github.com/google/GoogleSignIn-iOS/blob/main/Package.swift) 

here is the explanation of this issue:
https://github.com/apple/swift-package-manager/issues/5762

cc @mdmathias 