### PR TITLE
Update OIDEndSessionRequest method signature to match nullability on type

### DIFF
--- a/Source/AppAuthCore/OIDEndSessionRequest.h
+++ b/Source/AppAuthCore/OIDEndSessionRequest.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 */
 - (instancetype)
     initWithConfiguration:(OIDServiceConfiguration *)configuration
-              idTokenHint:(NSString *)idTokenHint
+              idTokenHint:(nullable NSString *)idTokenHint
     postLogoutRedirectURL:(NSURL *)postLogoutRedirectURL
      additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)
     initWithConfiguration:(OIDServiceConfiguration *)configuration
-              idTokenHint:(NSString *)idTokenHint
+              idTokenHint:(nullable NSString *)idTokenHint
     postLogoutRedirectURL:(NSURL *)postLogoutRedirectURL
                     state:(NSString *)state
      additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters

--- a/Source/AppAuthCore/OIDEndSessionRequest.m
+++ b/Source/AppAuthCore/OIDEndSessionRequest.m
@@ -64,7 +64,7 @@ static NSString *const OIDMissingEndSessionEndpointMessage =
     )
 
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
-                          idTokenHint:(NSString *)idTokenHint
+                          idTokenHint:(nullable NSString *)idTokenHint
                 postLogoutRedirectURL:(NSURL *)postLogoutRedirectURL
                                 state:(NSString *)state
                  additionalParameters:(NSDictionary<NSString *,NSString *> *)additionalParameters
@@ -82,7 +82,7 @@ static NSString *const OIDMissingEndSessionEndpointMessage =
 }
 
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
-                          idTokenHint:(NSString *)idTokenHint
+                          idTokenHint:(nullable NSString *)idTokenHint
                 postLogoutRedirectURL:(NSURL *)postLogoutRedirectURL
                  additionalParameters:(NSDictionary<NSString *,NSString *> *)additionalParameters
 {

--- a/UnitTests/OIDEndSessionRequestTests.m
+++ b/UnitTests/OIDEndSessionRequestTests.m
@@ -64,7 +64,7 @@ static NSString *const kTestIdTokenHint = @"id-token-hint";
                                           additionalParameters:additionalParameters];
 }
 
-+ (OIDEndSessionRequest *)testInstance_withNilIdToken {
++ (OIDEndSessionRequest *)testInstanceWithNilIdToken {
     NSDictionary *additionalParameters =
         @{ kTestAdditionalParameterKey : kTestAdditionalParameterValue };
 
@@ -144,7 +144,7 @@ static NSString *const kTestIdTokenHint = @"id-token-hint";
  process and checking to make sure the source and destination instances are equivalent.
  */
 - (void)testCopying_withNilIdToken {
-    OIDEndSessionRequest *request = [[self class] testInstance_withNilIdToken];
+    OIDEndSessionRequest *request = [[self class] testInstanceWithNilIdToken];
 
     XCTAssertNil(request.idTokenHint);
     XCTAssertEqualObjects(request.postLogoutRedirectURL, [NSURL URLWithString:kTestRedirectURL]);
@@ -165,7 +165,7 @@ static NSString *const kTestIdTokenHint = @"id-token-hint";
  checking to make sure the source and destination instances are equivalent.
  */
 - (void)testSecureCoding_WithNilIdToken {
-    OIDEndSessionRequest *request = [[self class] testInstance_withNilIdToken];
+    OIDEndSessionRequest *request = [[self class] testInstanceWithNilIdToken];
 
     XCTAssertNil(request.idTokenHint);
     XCTAssertEqualObjects(request.postLogoutRedirectURL, [NSURL URLWithString:kTestRedirectURL]);
@@ -185,7 +185,7 @@ static NSString *const kTestIdTokenHint = @"id-token-hint";
 }
 
 - (void)testLogoutRequestURL_withNilIdToken {
-    OIDEndSessionRequest *request = [[self class] testInstance_withNilIdToken];
+    OIDEndSessionRequest *request = [[self class] testInstanceWithNilIdToken];
     NSURL *endSessionRequestURL = request.endSessionRequestURL;
 
     NSURLComponents *components = [NSURLComponents componentsWithString:endSessionRequestURL.absoluteString];


### PR DESCRIPTION
This updates the idTokenHint nullability annotation in OIDEndSessionRequest's initializers to match the property attributes on the type, so that Swift clients can use these methods more easily. 
`idTokenHint` is declared as nullable on OIDEndSessionRequest and the implementation of this class already accounts for the possibility of the property being nil. However, the initializer methods omit the nullable annotation for the idTokenHint parameter. 
In Objective-C based clients this does not present a problem, since the compiler will allow nil to be passed in the init method. Swift clients, however, will fail to compile because the Swift interface treats idTokenHint as a `String` and not a `String?`. 

This results in the following updated Swift interface:
```
/** @brief Creates an authorization request with opinionated defaults (a secure @c state).
        @param configuration The service's configuration.
        @param idTokenHint The previously issued ID Token
        @param postLogoutRedirectURL The client's post-logout redirect URI.
            callback.
        @param additionalParameters The client's additional authorization parameters.
    */
    public convenience init(configuration: OIDServiceConfiguration, idTokenHint: String?, postLogoutRedirectURL: URL, additionalParameters: [String : String]?)

    
    /** @brief Designated initializer.
        @param configuration The service's configuration.
        @param idTokenHint The previously issued ID Token
        @param postLogoutRedirectURL The client's post-logout redirect URI.
        @param state An opaque value used by the client to maintain state between the request and
            callback.
        @param additionalParameters The client's additional authorization parameters.
     */
    public init(configuration: OIDServiceConfiguration, idTokenHint: String?, postLogoutRedirectURL: URL, state: String, additionalParameters: [String : String]?)
```

This PR resolves the issue reported in https://github.com/openid/AppAuth-iOS/issues/665