### PR TITLE
feat: allow custom nonce in OIDAuthorizationRequest

### DIFF
--- a/Source/AppAuthCore/OIDAuthorizationRequest.h
+++ b/Source/AppAuthCore/OIDAuthorizationRequest.h
@@ -159,6 +159,29 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
              responseType:(NSString *)responseType
      additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 
+/*! @brief Creates an authorization request with custom nonce, a secure @c state,
+        and PKCE with S256 as the @c code_challenge_method.
+    @param configuration The service's configuration.
+    @param clientID The client identifier.
+    @param scopes An array of scopes to combine into a single scope string per the OAuth2 spec.
+    @param redirectURL The client's redirect URI.
+    @param responseType The expected response type.
+    @param nonce String value used to associate a Client session with an ID Token. Can be set to nil
+        if not using OpenID Connect, although pure OAuth servers should ignore params they don't
+        understand anyway.
+    @param additionalParameters The client's additional authorization parameters.
+    @remarks This convenience initializer generates a state parameter and PKCE challenges
+        automatically.
+ */
+- (instancetype)
+    initWithConfiguration:(OIDServiceConfiguration *)configuration
+                 clientId:(NSString *)clientID
+                   scopes:(nullable NSArray<NSString *> *)scopes
+              redirectURL:(NSURL *)redirectURL
+             responseType:(NSString *)responseType
+                    nonce:(NSString *)nonce
+     additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
 /*! @brief Creates an authorization request with opinionated defaults (a secure @c state, @c nonce,
         and PKCE with S256 as the @c code_challenge_method).
     @param configuration The service's configuration.

--- a/Source/AppAuthCore/OIDAuthorizationRequest.h
+++ b/Source/AppAuthCore/OIDAuthorizationRequest.h
@@ -179,7 +179,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
                    scopes:(nullable NSArray<NSString *> *)scopes
               redirectURL:(NSURL *)redirectURL
              responseType:(NSString *)responseType
-                    nonce:(NSString *)nonce
+                    nonce:(nullable NSString *)nonce
      additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 
 /*! @brief Creates an authorization request with opinionated defaults (a secure @c state, @c nonce,

--- a/Source/AppAuthCore/OIDAuthorizationRequest.m
+++ b/Source/AppAuthCore/OIDAuthorizationRequest.m
@@ -208,7 +208,7 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
                    scopes:(nullable NSArray<NSString *> *)scopes
               redirectURL:(NSURL *)redirectURL
              responseType:(NSString *)responseType
-                    nonce:(NSString *)nonce
+                    nonce:(nullable NSString *)nonce
     additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
   // generates PKCE code verifier and challenge
   NSString *codeVerifier = [[self class] generateCodeVerifier];

--- a/Source/AppAuthCore/OIDAuthorizationRequest.m
+++ b/Source/AppAuthCore/OIDAuthorizationRequest.m
@@ -202,6 +202,32 @@ NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256 = @"S256";
                 additionalParameters:additionalParameters];
 }
 
+- (instancetype)
+    initWithConfiguration:(OIDServiceConfiguration *)configuration
+                 clientId:(NSString *)clientID
+                   scopes:(nullable NSArray<NSString *> *)scopes
+              redirectURL:(NSURL *)redirectURL
+             responseType:(NSString *)responseType
+                    nonce:(NSString *)nonce
+    additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters {
+  // generates PKCE code verifier and challenge
+  NSString *codeVerifier = [[self class] generateCodeVerifier];
+  NSString *codeChallenge = [[self class] codeChallengeS256ForVerifier:codeVerifier];
+
+  return [self initWithConfiguration:configuration
+                            clientId:clientID
+                        clientSecret:nil
+                               scope:[OIDScopeUtilities scopesWithArray:scopes]
+                         redirectURL:redirectURL
+                        responseType:responseType
+                               state:[[self class] generateState]
+                               nonce:nonce
+                        codeVerifier:codeVerifier
+                       codeChallenge:codeChallenge
+                 codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+                additionalParameters:additionalParameters];
+}
+
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(nullable NSZone *)zone {

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -237,7 +237,7 @@ static int const kCodeVerifierRecommendedLength = 43;
                                                        nonce:kTestNonce
                                         additionalParameters:nil];
 
-  XCTAssertEqualObjects(request.nonce, kTestNonce, @"");
+  XCTAssertEqualObjects(request.nonce, kTestNonce, @"Expected the request nonce to be equal to the one provided to the initializer");
   XCTAssertEqualObjects(request.responseType, @"code", @"");
   XCTAssertEqualObjects(request.scope, @"", @"");
   XCTAssertEqualObjects(request.clientID, kTestClientID, @"");

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -241,7 +241,7 @@ static int const kCodeVerifierRecommendedLength = 43;
   XCTAssertEqualObjects(request.responseType, @"code");
   XCTAssertEqualObjects(request.scope, @"");
   XCTAssertEqualObjects(request.clientID, kTestClientID);
-  XCTAssertEqualObjects(request.clientSecret, nil);
+  XCTAssertNil(request.clientSecret);
   XCTAssertEqualObjects(request.redirectURL, [NSURL URLWithString:kTestRedirectURL]);
   XCTAssertEqualObjects(@(request.additionalParameters.count), @0);
 }

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -223,6 +223,29 @@ static int const kCodeVerifierRecommendedLength = 43;
                         kTestAdditionalParameterValue, @"");
 }
 
+
+/*! @brief Tests the initializer which takes a nonce
+ */
+- (void)testNonceInitializer {
+  OIDServiceConfiguration *configuration = [OIDServiceConfigurationTests testInstance];
+  OIDAuthorizationRequest *request =
+      [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
+                                                    clientId:kTestClientID
+                                                      scopes:@[]
+                                                 redirectURL:[NSURL URLWithString:kTestRedirectURL]
+                                                responseType:OIDResponseTypeCode
+                                                       nonce:kTestNonce
+                                        additionalParameters:nil];
+
+  XCTAssertEqualObjects(request.nonce, kTestNonce, @"");
+  XCTAssertEqualObjects(request.responseType, @"code", @"");
+  XCTAssertEqualObjects(request.scope, @"", @"");
+  XCTAssertEqualObjects(request.clientID, kTestClientID, @"");
+  XCTAssertEqualObjects(request.clientSecret, nil, @"");
+  XCTAssertEqualObjects(request.redirectURL, [NSURL URLWithString:kTestRedirectURL], @"");
+  XCTAssertEqualObjects(@(request.additionalParameters.count), @0);
+}
+
 - (void)testScopeInitializerWithManyScopesAndClientSecret {
   NSDictionary *additionalParameters =
       @{ kTestAdditionalParameterKey : kTestAdditionalParameterValue };

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -238,11 +238,11 @@ static int const kCodeVerifierRecommendedLength = 43;
                                         additionalParameters:nil];
 
   XCTAssertEqualObjects(request.nonce, kTestNonce, @"Expected the request nonce to be equal to the one provided to the initializer");
-  XCTAssertEqualObjects(request.responseType, @"code", @"");
-  XCTAssertEqualObjects(request.scope, @"", @"");
-  XCTAssertEqualObjects(request.clientID, kTestClientID, @"");
-  XCTAssertEqualObjects(request.clientSecret, nil, @"");
-  XCTAssertEqualObjects(request.redirectURL, [NSURL URLWithString:kTestRedirectURL], @"");
+  XCTAssertEqualObjects(request.responseType, @"code");
+  XCTAssertEqualObjects(request.scope, @"");
+  XCTAssertEqualObjects(request.clientID, kTestClientID);
+  XCTAssertEqualObjects(request.clientSecret, nil);
+  XCTAssertEqualObjects(request.redirectURL, [NSURL URLWithString:kTestRedirectURL]);
   XCTAssertEqualObjects(@(request.additionalParameters.count), @0);
 }
 

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -237,7 +237,7 @@ static int const kCodeVerifierRecommendedLength = 43;
                                                        nonce:kTestNonce
                                         additionalParameters:nil];
 
-  XCTAssertEqualObjects(request.nonce, kTestNonce, @"Expected the request nonce to be equal to the one provided to the initializer");
+  XCTAssertEqualObjects(request.nonce, kTestNonce);
   XCTAssertEqualObjects(request.responseType, @"code");
   XCTAssertEqualObjects(request.scope, @"");
   XCTAssertEqualObjects(request.clientID, kTestClientID);


### PR DESCRIPTION
this PR is in response to this PR which has been opened ~ year ago and appears to be in a limbo

https://github.com/google/GoogleSignIn-iOS/pull/244

The PR did get a review from @mdmathias who pointed out one issue [here](https://github.com/google/GoogleSignIn-iOS/pull/244#discussion_r1213748728) that seems to prevent the PR from getting merged. 

There is a substantial community interest to get the PR merged and it appears there is willingness on the google side as well.

I'm attempting to unblock the PR by adding the initializer that is being asked for in the review comment (linked above).

Thank you in advance for your review