### PR TITLE
fixed wrong variable for additional http headers in OIDTokenRequest (#770)

### DIFF
--- a/Source/AppAuthCore/OIDTokenRequest.m
+++ b/Source/AppAuthCore/OIDTokenRequest.m
@@ -330,7 +330,7 @@ static NSString *const kAdditionalHeadersKey = @"additionalHeaders";
   }
   
   for (id header in _additionalHeaders) {
-    [URLRequest setValue:httpHeaders[header] forHTTPHeaderField:header];
+    [URLRequest setValue:_additionalHeaders[header] forHTTPHeaderField:header];
   }
 
   return URLRequest;

--- a/UnitTests/OIDTokenRequestTests.m
+++ b/UnitTests/OIDTokenRequestTests.m
@@ -56,6 +56,14 @@ static NSString *const kTestAdditionalHeaderKey = @"B";
  */
 static NSString *const kTestAdditionalHeaderValue = @"2";
 
+/*! @brief Test key for the @c additionalHeaders property.
+ */
+static NSString *const kTestAdditionalHeaderKey2 = @"C";
+
+/*! @brief Test value for the @c additionalHeaders property.
+ */
+static NSString *const kTestAdditionalHeaderValue2 = @"3";
+
 @implementation OIDTokenRequestTests
 
 + (OIDTokenRequest *)testInstance {
@@ -154,6 +162,32 @@ static NSString *const kTestAdditionalHeaderValue = @"2";
   return request;
 }
 
++ (OIDTokenRequest *)testInstanceAdditionalHeaders {
+  OIDAuthorizationResponse *authResponse = [OIDAuthorizationResponseTests testInstance];
+  NSArray<NSString *> *scopesArray =
+      [OIDScopeUtilities scopesArrayWithString:authResponse.request.scope];
+  NSDictionary *additionalParameters =
+      @{ kTestAdditionalParameterKey : kTestAdditionalParameterValue };
+  NSDictionary *additionalHeaders = @{
+    kTestAdditionalHeaderKey : kTestAdditionalHeaderValue,
+    kTestAdditionalHeaderKey2 : kTestAdditionalHeaderValue2
+  };
+  
+  OIDTokenRequest *request =
+      [[OIDTokenRequest alloc] initWithConfiguration:authResponse.request.configuration
+                                           grantType:OIDGrantTypeAuthorizationCode
+                                   authorizationCode:authResponse.authorizationCode
+                                         redirectURL:authResponse.request.redirectURL
+                                            clientID:authResponse.request.clientID
+                                        clientSecret:authResponse.request.clientSecret
+                                              scopes:scopesArray
+                                        refreshToken:kRefreshTokenTestValue
+                                        codeVerifier:authResponse.request.codeVerifier
+                                additionalParameters:additionalParameters
+                                   additionalHeaders:additionalHeaders];
+  return request;
+}
+
 /*! @brief Tests the @c NSCopying implementation by round-tripping an instance through the copying
         process and checking to make sure the source and destination instances are equivalent.
  */
@@ -242,7 +276,7 @@ static NSString *const kTestAdditionalHeaderValue = @"2";
   
   NSURLRequest *urlRequest = [request URLRequest];
   XCTAssertEqualObjects([urlRequest.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
-                        kTestAdditionalHeaderValue, @"");
+                        kTestAdditionalHeaderValue);
 
   NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
   OIDTokenRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
@@ -270,7 +304,7 @@ static NSString *const kTestAdditionalHeaderValue = @"2";
   
   NSURLRequest *urlrequestCopy = [requestCopy URLRequest];
   XCTAssertEqualObjects([urlrequestCopy.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
-                        kTestAdditionalHeaderValue, @"");
+                        kTestAdditionalHeaderValue);
 }
 
 - (void)testURLRequestNoClientAuth {
@@ -308,6 +342,17 @@ static NSString *const kTestAdditionalHeaderValue = @"2";
                                                     codeVerifier:authResponse.request.codeVerifier
                                             additionalParameters:additionalParameters
                                                additionalHeaders:additionalHeaders], @"");
+}
+
+- (void)testThatAdditionalHeadersAreInTokenRequest {
+  OIDTokenRequest *request = [[self class] testInstanceAdditionalHeaders];
+  NSURLRequest* urlRequest = [request URLRequest];
+
+  XCTAssertEqualObjects([urlRequest.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
+                        kTestAdditionalHeaderValue);
+  
+  XCTAssertEqualObjects([urlRequest.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey2],
+                        kTestAdditionalHeaderValue2);
 }
 
 @end

--- a/UnitTests/OIDTokenRequestTests.m
+++ b/UnitTests/OIDTokenRequestTests.m
@@ -239,6 +239,10 @@ static NSString *const kTestAdditionalHeaderValue = @"2";
   XCTAssertNotNil(request.additionalHeaders, @"");
   XCTAssertEqualObjects(request.additionalHeaders[kTestAdditionalHeaderKey],
                         kTestAdditionalHeaderValue, @"");
+  
+  NSURLRequest *urlRequest = [request URLRequest];
+  XCTAssertEqualObjects([urlRequest.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
+                        kTestAdditionalHeaderValue, @"");
 
   NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
   OIDTokenRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
@@ -262,6 +266,10 @@ static NSString *const kTestAdditionalHeaderValue = @"2";
                         kTestAdditionalParameterValue, @"");
   XCTAssertNotNil(requestCopy.additionalHeaders, @"");
   XCTAssertEqualObjects(requestCopy.additionalHeaders[kTestAdditionalHeaderKey],
+                        kTestAdditionalHeaderValue, @"");
+  
+  NSURLRequest *urlrequestCopy = [requestCopy URLRequest];
+  XCTAssertEqualObjects([urlrequestCopy.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
                         kTestAdditionalHeaderValue, @"");
 }
 


### PR DESCRIPTION
This update fixes wrong variable copy-pasted code for additional http headers in OIDTokenRequest.