### PR TITLE
Update OIDRedirectHTTPHandler.h

### DIFF
--- a/Source/AppAuth/macOS/OIDRedirectHTTPHandler.h
+++ b/Source/AppAuth/macOS/OIDRedirectHTTPHandler.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
         Calling this more than once will result in the previous listener being cancelled (equivalent
         of @c cancelHTTPListener being called).
  */
-- (NSURL *)startHTTPListener:(NSError **)returnError withPort:(uint16_t)port;
+- (nullable NSURL *)startHTTPListener:(NSError **)returnError withPort:(uint16_t)port;
 
 /*! @brief Starts listening on the loopback interface on a random available port, and returns a URL
         with the base address. Use the returned redirect URI to build a @c OIDExternalUserAgentRequest,
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
         Calling this more than once will result in the previous listener being cancelled (equivalent
         of @c cancelHTTPListener being called).
  */
-- (NSURL *)startHTTPListener:(NSError **)returnError;
+- (nullable NSURL *)startHTTPListener:(NSError **)returnError;
 
 /*! @brief Stops listening the loopback interface and sends an cancellation error (in the domain
         ::OIDGeneralErrorDomain, with the code ::OIDErrorCodeProgramCanceledAuthorizationFlow) to


### PR DESCRIPTION
fix macOS startHTTPListener memory crash if there is an error and return nil URL

related issue: https://github.com/openid/AppAuth-iOS/issues/107
When there is a starting error happened, the Swift call to startHTTPListener will crash, because of the return URL is nullable but the interface announce it nonnull.

The right behavior should throw an SwiftError.
 after this fix, the Swift call to startHTTPListener will be right to handle the error.