### PR TITLE
Add back missing method to OIDAuthorizationResponse

### DIFF
--- a/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth-iOS.xcscheme
+++ b/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth-iOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "340E737B1C5D819B0076B1F6"
+            BuildableName = "libAppAuth-iOS.a"
+            BlueprintName = "AppAuth-iOS"
+            ReferencedContainer = "container:AppAuth.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "340E737B1C5D819B0076B1F6"
-            BuildableName = "libAppAuth-iOS.a"
-            BlueprintName = "AppAuth-iOS"
-            ReferencedContainer = "container:AppAuth.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:AppAuth.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth-tvOS.xcscheme
+++ b/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth-tvOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "341E707D1DE18744004353C1"
+            BuildableName = "libAppAuth-tvOS.a"
+            BlueprintName = "AppAuth-tvOS"
+            ReferencedContainer = "container:AppAuth.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "341E707D1DE18744004353C1"
-            BuildableName = "libAppAuth-tvOS.a"
-            BlueprintName = "AppAuth-tvOS"
-            ReferencedContainer = "container:AppAuth.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:AppAuth.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/AppAuthCore/OIDAuthorizationResponse.h
+++ b/Source/AppAuthCore/OIDAuthorizationResponse.h
@@ -121,6 +121,17 @@ NS_ASSUME_NONNULL_BEGIN
     @see https://tools.ietf.org/html/rfc6749#section-4.1.3
  */
 - (nullable OIDTokenRequest *)tokenExchangeRequestWithAdditionalParameters:
+    (nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @brief Creates a token request suitable for exchanging an authorization code for an access
+        token.
+    @param additionalParameters Additional parameters for the token request.
+    @param additionalHeaders Additional headers for the token request.
+    @return A @c OIDTokenRequest suitable for exchanging an authorization code for an access
+        token.
+    @see https://tools.ietf.org/html/rfc6749#section-4.1.3
+ */
+- (nullable OIDTokenRequest *)tokenExchangeRequestWithAdditionalParameters:
     (nullable NSDictionary<NSString *, NSString *> *)additionalParameters
                                                          additionalHeaders:
     (nullable NSDictionary<NSString *, NSString *> *)additionalHeaders;

--- a/Source/AppAuthCore/OIDAuthorizationResponse.m
+++ b/Source/AppAuthCore/OIDAuthorizationResponse.m
@@ -188,6 +188,12 @@ static NSString *const kTokenExchangeRequestException =
 }
 
 - (OIDTokenRequest *)tokenExchangeRequestWithAdditionalParameters:
+    (NSDictionary<NSString *, NSString *> *)additionalParameters {
+  return [self tokenExchangeRequestWithAdditionalParameters:additionalParameters
+                                          additionalHeaders:nil];
+}
+
+- (OIDTokenRequest *)tokenExchangeRequestWithAdditionalParameters:
     (NSDictionary<NSString *, NSString *> *)additionalParameters
                                                 additionalHeaders:
     (NSDictionary<NSString *, NSString *> *)additionalHeaders {


### PR DESCRIPTION
AppAuth release 1.7.0 inadvertently removed a method from the public interface of `OIDAuthorizationResponse`. This PR adds the method back.

This fix and subsequent release should fix https://github.com/google/GoogleSignIn-iOS/issues/376.