### PR TITLE
Fix OIDTokenRequest for AppAuthCore and AppAuthTV

### DIFF
--- a/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth-macOS.xcscheme
+++ b/AppAuth.xcodeproj/xcshareddata/xcschemes/AppAuth-macOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "340DAE4D1D58216A00EC285B"
+            BuildableName = "libAppAuth-macOS.a"
+            BlueprintName = "AppAuth-macOS"
+            ReferencedContainer = "container:AppAuth.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "340DAE4D1D58216A00EC285B"
-            BuildableName = "libAppAuth-macOS.a"
-            BlueprintName = "AppAuth-macOS"
-            ReferencedContainer = "container:AppAuth.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:AppAuth.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/AppAuthCore/OIDTokenRequest.h
+++ b/Source/AppAuthCore/OIDTokenRequest.h
@@ -117,6 +117,55 @@ NS_ASSUME_NONNULL_BEGIN
     @param refreshToken The refresh token.
     @param codeVerifier The PKCE code verifier.
     @param additionalParameters The client's additional token request parameters.
+ */
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+               grantType:(NSString *)grantType
+       authorizationCode:(nullable NSString *)code
+             redirectURL:(nullable NSURL *)redirectURL
+                clientID:(NSString *)clientID
+            clientSecret:(nullable NSString *)clientSecret
+                  scopes:(nullable NSArray<NSString *> *)scopes
+            refreshToken:(nullable NSString *)refreshToken
+            codeVerifier:(nullable NSString *)codeVerifier
+    additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @param configuration The service's configuration.
+    @param grantType the type of token being sent to the token endpoint, i.e. "authorization_code"
+        for the authorization code exchange, or "refresh_token" for an access token refresh request.
+        @see OIDGrantTypes.h
+    @param code The authorization code received from the authorization server.
+    @param redirectURL The client's redirect URI.
+    @param clientID The client identifier.
+    @param clientSecret The client secret.
+    @param scope The value of the scope parameter is expressed as a list of space-delimited,
+        case-sensitive strings.
+    @param refreshToken The refresh token.
+    @param codeVerifier The PKCE code verifier.
+    @param additionalParameters The client's additional token request parameters.
+ */
+- (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
+               grantType:(NSString *)grantType
+       authorizationCode:(nullable NSString *)code
+             redirectURL:(nullable NSURL *)redirectURL
+                clientID:(NSString *)clientID
+            clientSecret:(nullable NSString *)clientSecret
+                   scope:(nullable NSString *)scope
+            refreshToken:(nullable NSString *)refreshToken
+            codeVerifier:(nullable NSString *)codeVerifier
+    additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @param configuration The service's configuration.
+    @param grantType the type of token being sent to the token endpoint, i.e. "authorization_code"
+        for the authorization code exchange, or "refresh_token" for an access token refresh request.
+        @see OIDGrantTypes.h
+    @param code The authorization code received from the authorization server.
+    @param redirectURL The client's redirect URI.
+    @param clientID The client identifier.
+    @param clientSecret The client secret.
+    @param scopes An array of scopes to combine into a single scope string per the OAuth2 spec.
+    @param refreshToken The refresh token.
+    @param codeVerifier The PKCE code verifier.
+    @param additionalParameters The client's additional token request parameters.
     @param additionalHeaders The client's additional token request headers.
  */
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration

--- a/Source/AppAuthCore/OIDTokenRequest.m
+++ b/Source/AppAuthCore/OIDTokenRequest.m
@@ -89,6 +89,52 @@ static NSString *const kAdditionalHeadersKey = @"additionalHeaders";
                       additionalHeaders:)
     )
 
+- (instancetype)initWithConfiguration:(nonnull OIDServiceConfiguration *)configuration
+               grantType:(nonnull NSString *)grantType
+       authorizationCode:(nullable NSString *)code
+             redirectURL:(nullable NSURL *)redirectURL
+                clientID:(nonnull NSString *)clientID
+            clientSecret:(nullable NSString *)clientSecret
+                  scopes:(nullable NSArray<NSString *> *)scopes
+            refreshToken:(nullable NSString *)refreshToken
+            codeVerifier:(nullable NSString *)codeVerifier
+    additionalParameters:(nullable NSDictionary<NSString *,NSString *> *)additionalParameters {
+  return [self initWithConfiguration:configuration
+                           grantType:grantType
+                   authorizationCode:code
+                         redirectURL:redirectURL
+                            clientID:clientID
+                        clientSecret:clientSecret
+                              scopes:scopes
+                        refreshToken:refreshToken
+                        codeVerifier:codeVerifier
+                additionalParameters:additionalParameters
+                   additionalHeaders:_additionalHeaders];
+}
+
+- (instancetype)initWithConfiguration:(nonnull OIDServiceConfiguration *)configuration
+               grantType:(nonnull NSString *)grantType
+       authorizationCode:(nullable NSString *)code
+             redirectURL:(nullable NSURL *)redirectURL
+                clientID:(nonnull NSString *)clientID
+            clientSecret:(nullable NSString *)clientSecret
+                   scope:(nullable NSString *)scope
+            refreshToken:(nullable NSString *)refreshToken
+            codeVerifier:(nullable NSString *)codeVerifier
+    additionalParameters:(nullable NSDictionary<NSString *,NSString *> *)additionalParameters {
+  return [self initWithConfiguration:configuration
+                           grantType:grantType
+                   authorizationCode:code
+                         redirectURL:redirectURL
+                            clientID:clientID
+                        clientSecret:clientSecret
+                               scope:scope
+                        refreshToken:refreshToken
+                        codeVerifier:codeVerifier
+                additionalParameters:additionalParameters
+                   additionalHeaders:_additionalHeaders];
+}
+
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                grantType:(NSString *)grantType
        authorizationCode:(nullable NSString *)code

--- a/Source/AppAuthTV/OIDTVTokenRequest.h
+++ b/Source/AppAuthTV/OIDTVTokenRequest.h
@@ -86,6 +86,20 @@ NS_ASSUME_NONNULL_BEGIN
     @param clientID The client identifier.
     @param clientSecret The client secret (nullable).
     @param additionalParameters The client's additional token request parameters.
+*/
+- (instancetype)initWithConfiguration:(OIDTVServiceConfiguration *)configuration
+                           deviceCode:(NSString *)deviceCode
+                             clientID:(NSString *)clientID
+                         clientSecret:(nullable NSString *)clientSecret
+                 additionalParameters:
+                     (nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @brief Designated initializer.
+    @param configuration The service's configuration.
+    @param deviceCode The device verification code received from the authorization server.
+    @param clientID The client identifier.
+    @param clientSecret The client secret (nullable).
+    @param additionalParameters The client's additional token request parameters.
     @param additionalHeaders The client's additional token request headers.
 */
 - (instancetype)initWithConfiguration:(OIDTVServiceConfiguration *)configuration

--- a/Source/AppAuthTV/OIDTVTokenRequest.m
+++ b/Source/AppAuthTV/OIDTVTokenRequest.m
@@ -94,6 +94,19 @@ static NSString *const kOIDTVDeviceTokenGrantType = @"urn:ietf:params:oauth:gran
                            deviceCode:(NSString *)deviceCode
                              clientID:(NSString *)clientID
                          clientSecret:(NSString *)clientSecret
+                 additionalParameters:(NSDictionary<NSString *, NSString *> *)additionalParameters {
+  return [self initWithConfiguration:configuration
+                          deviceCode:deviceCode
+                            clientID:clientID
+                        clientSecret:clientSecret
+                additionalParameters:additionalParameters
+                   additionalHeaders:nil];
+}
+
+- (instancetype)initWithConfiguration:(OIDTVServiceConfiguration *)configuration
+                           deviceCode:(NSString *)deviceCode
+                             clientID:(NSString *)clientID
+                         clientSecret:(NSString *)clientSecret
                  additionalParameters:(NSDictionary<NSString *, NSString *> *)additionalParameters
                     additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders {
   self = [super initWithConfiguration:configuration


### PR DESCRIPTION
Fixes additional method name changes in #770 impacting https://github.com/google/GoogleSignIn-iOS/issues/376

I tested these changes against the [DaysUntilBirthday sample app in Google Sign-In iOS](https://github.com/google/GoogleSignIn-iOS/tree/main/Samples/Swift/DaysUntilBirthday). That sample built and ran without issue.