### PR TITLE
Swift Package Manager: Fix NS_BLOCK_ASSERTIONS for release builds 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,10 @@ let package = Package(
             name: "AppAuthCore",
             path: "Sources/AppAuthCore",
             resources: [.copy("Resources/PrivacyInfo.xcprivacy")],
-            publicHeadersPath: ""
+            publicHeadersPath: "",
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
+            ]
         ),
         .target(
             name: "AppAuth",
@@ -58,6 +61,7 @@ let package = Package(
                 .headerSearchPath("iOS"),
                 .headerSearchPath("macOS"),
                 .headerSearchPath("macOS/LoopbackHTTPServer"),
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
             ]
         ),
         .target(


### PR DESCRIPTION
There is an issue in Swift Package Manager where any NSAssert inside of packages will throw fatal exceptions on release builds.

I don't believe this is intentional behavior of AppAuth. Including a new cSettings in the Package.swift file resolves the issue.

Here is a thread on the Swift forums discussing the issue
https://forums.swift.org/t/assertions-in-swift-packages/42692

