### PR TITLE
Fix OIDExternalUserAgentIOSCustomBrowser on iOS 10+

### DIFF
--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.m
@@ -145,7 +145,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *testURLString = [NSString stringWithFormat:@"%@://example.com", _canOpenURLScheme];
     NSURL *testURL = [NSURL URLWithString:testURLString];
     if (![[UIApplication sharedApplication] canOpenURL:testURL]) {
-      [[UIApplication sharedApplication] openURL:_appStoreURL];
+      if (@available(iOS 10.0, *)) {
+        [[UIApplication sharedApplication] openURL:_appStoreURL options:@{} completionHandler:nil];
+      } else {
+        [[UIApplication sharedApplication] openURL:_appStoreURL];
+      }
       return NO;
     }
   }
@@ -153,8 +157,14 @@ NS_ASSUME_NONNULL_BEGIN
   // Transforms the request URL and opens it.
   NSURL *requestURL = [request externalUserAgentRequestURL];
   requestURL = _URLTransformation(requestURL);
-  BOOL openedInBrowser = [[UIApplication sharedApplication] openURL:requestURL];
-  return openedInBrowser;
+  if (@available(iOS 10.0, *)) {
+    BOOL willOpen = [[UIApplication sharedApplication] canOpenURL:requestURL];
+    [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:nil];
+    return willOpen;
+  } else {
+    BOOL openedInBrowser = [[UIApplication sharedApplication] openURL:requestURL];
+    return openedInBrowser;
+  }
 }
 
 - (void)dismissExternalUserAgentAnimated:(BOOL)animated


### PR DESCRIPTION
[`UIApplication openURL:`](
https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl?language=objc) is deprecated and has no effect.

On iOS 10.0+, [`UIApplication openURL:options:completionHandler:`](https://developer.apple.com/documentation/uikit/uiapplication/1648685-openurl?language=objc) should be used instead.

I am contributing on behalf of Google, which has a CLA with the OpenID Foundation.

Relevant issue: https://github.com/openid/AppAuth-iOS/issues/703