### PR TITLE
Update runner to macos-13.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   xcode-project-test:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         flags: [
@@ -32,7 +32,7 @@ jobs:
           ${{ matrix.flags }}
 
   pod-lib-lint:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         flags: [
@@ -50,7 +50,7 @@ jobs:
       run: pod lib lint --verbose ${{ matrix.flags }}
 
   spm-build-test:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - name: Build unit test target


### PR DESCRIPTION
Update runners to macos-13.

macos-12 was deprecated according to: https://github.com/actions/runner-images/issues/10721