### PR TITLE
Strip logging for non-trace errors

### DIFF
--- a/Sources/AppAuthCore/OIDAuthState.m
+++ b/Sources/AppAuthCore/OIDAuthState.m
@@ -371,10 +371,10 @@ static const NSUInteger kExpiryTimeTolerance = 60;
     // Calling updateWithTokenResponse while in an error state probably means the developer obtained
     // a new token and did the exchange without also calling updateWithAuthorizationResponse.
     // Attempts to handle gracefully, but warns the developer that this is unexpected.
-    NSLog(@"OIDAuthState:updateWithTokenResponse should not be called in an error state [%@] call"
-         "updateWithAuthorizationResponse with the result of the fresh authorization response"
-         "first",
-         _authorizationError);
+    AppAuthRequestTrace(@"OIDAuthState:updateWithTokenResponse should not be called in an error state [%@] call"
+                        "updateWithAuthorizationResponse with the result of the fresh authorization response"
+                        "first",
+                        _authorizationError);
 
     _authorizationError = nil;
   }

--- a/Sources/AppAuthCore/OIDIDToken.m
+++ b/Sources/AppAuthCore/OIDIDToken.m
@@ -27,6 +27,7 @@ static NSString *const kIatKey = @"iat";
 static NSString *const kNonceKey = @"nonce";
 
 #import "OIDFieldMapping.h"
+#import "OIDDefines.h"
 
 @implementation OIDIDToken
 
@@ -117,7 +118,7 @@ static NSString *const kNonceKey = @"nonce";
   NSError *error;
   id object = [NSJSONSerialization JSONObjectWithData:decodedData options:0 error:&error];
   if (error) {
-    NSLog(@"Error %@ parsing token payload %@", error, sectionString);
+    AppAuthRequestTrace(@"Error %@ parsing token payload %@", error, sectionString);
   }
   if ([object isKindOfClass:[NSDictionary class]]) {
     return (NSDictionary *)object;


### PR DESCRIPTION
For OpenID Connect (OIDC) implementations, it is recommended to remove any logging from release builds for security and performance reasons. During my investigation of this project, I identified two log messages that were not covered by the newly introduced request trace mechanism, which was designed to allow logging only for debugging purposes.

This improvement aims to enhance security by ensuring that sensitive or unnecessary logs are not present in release builds.

Request:
If these log messages are intentional and have a specific purpose, please provide an explanation of why they should remain. Your feedback will help clarify their necessity.