### PR TITLE
Added NSNull as a JSONType in OIDFieldMapping.

### DIFF
--- a/Sources/AppAuthCore/OIDFieldMapping.m
+++ b/Sources/AppAuthCore/OIDFieldMapping.m
@@ -96,7 +96,8 @@
     [NSDictionary class],
     [NSArray class],
     [NSString class],
-    [NSNumber class]
+    [NSNumber class],
+    [NSNull class],
   ]];
 }
 


### PR DESCRIPTION
Addresses https://github.com/openid/AppAuth-iOS/issues/904.

This change allows OIDTokenResponse to decode NSNull classes (https://github.com/openid/AppAuth-iOS/blob/master/Sources/AppAuthCore/OIDTokenResponse.m#L131) when using [archivedDataWithRootObject:requiringSecureCoding:error:](https://developer.apple.com/documentation/foundation/nskeyedarchiver/2962880-archiveddatawithrootobject?language=objc) to decode OIDAuthState.  This change is relevant to cases where OIDTokenResponse objects have null fields, such as the refresh token. 