### PR TITLE
Crash fix - when cancelling an authentication session

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "AppAuth"
-  s.version      = "2.0.0"
+  s.version      = "1.7.6"
   s.summary      = "AppAuth for iOS and macOS is a client SDK for communicating with OAuth 2.0 and OpenID Connect providers."
 
   s.description  = <<-DESC
@@ -31,7 +31,7 @@ It follows the OAuth 2.0 for Native Apps best current practice
   #       classes of AppAuth with tokens on watchOS and tvOS, but currently the
   #       library won't help you obtain authorization grants on those platforms.
 
-  ios_deployment_target = "12.0"
+  ios_deployment_target = "9.0"
   osx_deployment_target = "10.12"
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -2815,7 +2815,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2873,7 +2873,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -2888,7 +2888,6 @@
 		340E73861C5D819B0076B1F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -2897,7 +2896,6 @@
 		340E73871C5D819B0076B1F6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -2909,7 +2907,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/";
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.AppAuthTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2926,7 +2924,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/";
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.AppAuthTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3040,7 +3038,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/CoreFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.AppAuthCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3066,7 +3064,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/CoreFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.AppAuthCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3091,7 +3089,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOS";
 				PRODUCT_NAME = AppAuth;
@@ -3116,7 +3114,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOS";
 				PRODUCT_NAME = AppAuth;
@@ -3135,7 +3133,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3149,7 +3147,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3403,7 +3401,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-ExtensionTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3417,7 +3415,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-ExtensionTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 2.0.0
-- Raise minimum supported iOS version to iOS 12. ([#918](https://github.com/openid/AppAuth-iOS/pull/918))
-- Remove deprecated `[UIApplication openURL:]` method to compile with Xcode 16. ([#911](https://github.com/openid/AppAuth-iOS/pull/911))
-
 # 1.7.6
 - Fix OIDExternalUserAgentIOSCustomBrowser on versions iOS 10+ ([#871](https://github.com/openid/AppAuth-iOS/pull/871))
 - Update runners in tests.yml to macos-13. ([#886](https://github.com/openid/AppAuth-iOS/pull/886))

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,4 +20,3 @@ Hernan Zalazar <hernan.zalazar@gmail.com> https://github.com/hzalaz
 Joseph Heenan <joseph@emobix.co.uk> https://github.com/jogu
 Julien Bodet <julien.bodet92@gmail.com> https://github.com/julienbodet
 Tobias Schröpf <schroepf@gmail.com> https://github.com/schroepf
-Dave MacLachlan <dmaclach@gmail.com> https://github.com/dmaclach

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     name: "AppAuth",
     platforms: [
         .macOS(.v10_12),
-        .iOS(.v12),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For tvOS, AppAuth implements [OAuth 2.0 Device Authorization Grant
 
 #### Supported Versions
 
-AppAuth supports iOS 12 and above.
+AppAuth supports iOS 7 and above.
 
 iOS 9+ uses the in-app browser tab pattern
 (via `SFSafariViewController`), and falls back to the system browser (mobile

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -41,8 +41,10 @@ API_UNAVAILABLE(macCatalyst)
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the authentication UI.
     @discussion The specific authentication UI used depends on the iOS version and accessibility
-        options. iOS 12+ uses @c ASWebAuthenticationSession (unless Guided Access is on),
-        otherwise local browser is used.
+        options. iOS 8 uses the system browser, iOS 9-10 use @c SFSafariViewController, iOS 11 uses
+        @c SFAuthenticationSession
+        (unless Guided Access is on which does not work) or uses @c SFSafariViewController, and iOS
+        12+ uses @c ASWebAuthenticationSession (unless Guided Access is on).
  */
 - (nullable instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -41,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 #endif
 
+API_AVAILABLE(ios(12.0))
+static ASWebAuthenticationSession *_webAuthenticationVC;
+
 @implementation OIDExternalUserAgentIOS {
   UIViewController *_presentingViewController;
   BOOL _prefersEphemeralSession;
@@ -51,7 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic ignored "-Wpartial-availability"
   __weak SFSafariViewController *_safariVC;
   SFAuthenticationSession *_authenticationVC;
-  ASWebAuthenticationSession *_webAuthenticationVC;
 #pragma clang diagnostic pop
 }
 
@@ -104,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!UIAccessibilityIsGuidedAccessEnabled()) {
       __weak OIDExternalUserAgentIOS *weakSelf = self;
       NSString *redirectScheme = request.redirectScheme;
-      ASWebAuthenticationSession *authenticationVC =
+      _webAuthenticationVC =
           [[ASWebAuthenticationSession alloc] initWithURL:requestURL
                                         callbackURLScheme:redirectScheme
                                         completionHandler:^(NSURL * _Nullable callbackURL,
@@ -113,7 +115,6 @@ NS_ASSUME_NONNULL_BEGIN
         if (!strongSelf) {
             return;
         }
-        strongSelf->_webAuthenticationVC = nil;
         if (callbackURL) {
           [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
         } else {
@@ -126,12 +127,11 @@ NS_ASSUME_NONNULL_BEGIN
       }];
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
-        authenticationVC.presentationContextProvider = self;
-        authenticationVC.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
+        _webAuthenticationVC.presentationContextProvider = self;
+        _webAuthenticationVC.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
       }
 #endif
-      _webAuthenticationVC = authenticationVC;
-      openedUserAgent = [authenticationVC start];
+      openedUserAgent = [_webAuthenticationVC start];
     }
   }
   // iOS 11, use SFAuthenticationSession

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.m
@@ -145,7 +145,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *testURLString = [NSString stringWithFormat:@"%@://example.com", _canOpenURLScheme];
     NSURL *testURL = [NSURL URLWithString:testURLString];
     if (![[UIApplication sharedApplication] canOpenURL:testURL]) {
-      [[UIApplication sharedApplication] openURL:_appStoreURL options:@{} completionHandler:nil];
+      if (@available(iOS 10.0, *)) {
+        [[UIApplication sharedApplication] openURL:_appStoreURL options:@{} completionHandler:nil];
+      } else {
+        [[UIApplication sharedApplication] openURL:_appStoreURL];
+      }
       return NO;
     }
   }
@@ -153,9 +157,14 @@ NS_ASSUME_NONNULL_BEGIN
   // Transforms the request URL and opens it.
   NSURL *requestURL = [request externalUserAgentRequestURL];
   requestURL = _URLTransformation(requestURL);
-  BOOL willOpen = [[UIApplication sharedApplication] canOpenURL:requestURL];
-  [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:nil];
-  return willOpen;
+  if (@available(iOS 10.0, *)) {
+    BOOL willOpen = [[UIApplication sharedApplication] canOpenURL:requestURL];
+    [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:nil];
+    return willOpen;
+  } else {
+    BOOL openedInBrowser = [[UIApplication sharedApplication] openURL:requestURL];
+    return openedInBrowser;
+  }
 }
 
 - (void)dismissExternalUserAgentAnimated:(BOOL)animated

--- a/Sources/AppAuthCore/OIDRegistrationRequest.m
+++ b/Sources/AppAuthCore/OIDRegistrationRequest.m
@@ -130,15 +130,12 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
                          forKey:kConfigurationKey];
   NSString *initialAccessToken = [aDecoder decodeObjectOfClass:[NSString class]
                                                         forKey:kInitialAccessToken];
-  NSArray<NSURL *> *redirectURIs =
-      [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSURL class]]]
-                               forKey:kRedirectURIsKey];
-  NSArray<NSString *> *responseTypes =
-      [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]]
-                               forKey:kResponseTypesKey];
-  NSArray<NSString *> *grantTypes =
-      [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]]
-                               forKey:kGrantTypesKey];
+  NSArray<NSURL *> *redirectURIs = [aDecoder decodeObjectOfClass:[NSArray<NSURL *> class]
+                                                          forKey:kRedirectURIsKey];
+  NSArray<NSString *> *responseTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
+                                                              forKey:kResponseTypesKey];
+  NSArray<NSString *> *grantTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
+                                                           forKey:kGrantTypesKey];
   NSString *subjectType = [aDecoder decodeObjectOfClass:[NSString class]
                                                  forKey:kSubjectTypeKey];
   NSString *tokenEndpointAuthenticationMethod =

--- a/UnitTests/OIDAuthStateTests.m
+++ b/UnitTests/OIDAuthStateTests.m
@@ -204,18 +204,7 @@
   NSError *oauthError =
       [[self class] OAuthTokenInvalidGrantErrorWithUnderlyingError:nonCompliantError];
   [authstate updateWithAuthorizationError:oauthError];
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:authstate
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    XCTAssertNoThrow(data, @"");
-  } else {
-#if !TARGET_OS_IOS
-    XCTAssertNoThrow([NSKeyedArchiver archivedDataWithRootObject:authstate], @"");
-#endif
-  }
+  XCTAssertNoThrow([NSKeyedArchiver archivedDataWithRootObject:authstate], @"");
 }
 
 /*! @brief Tests @c OIDAuthState.updateWithAuthorizationResponse:error: with a success response.
@@ -369,22 +358,8 @@
   XCTAssert([OIDAuthState supportsSecureCoding], @"");
 
   OIDAuthState *authState = [[self class] testInstance];
-  OIDAuthState *authStateCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:authState
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    authStateCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDAuthState class]
-                                                      fromData:data
-                                                         error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:authState];
-    authStateCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:authState];
+  OIDAuthState *authStateCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   XCTAssertEqualObjects(authStateCopy.refreshToken, authState.refreshToken, @"");
   XCTAssertEqualObjects(authStateCopy.scope, authState.scope, @"");
@@ -400,26 +375,9 @@
   // Verify the error object is indeed restored.
   NSError *oauthError = [[self class] OAuthTokenInvalidGrantErrorWithUnderlyingError:nil];
   [authState updateWithTokenResponse:nil error:oauthError];
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:authState
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:authState];
-#endif
-  }
+  data = [NSKeyedArchiver archivedDataWithRootObject:authState];
   XCTAssertNotNil(authState.authorizationError, @"");
-
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    authStateCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDAuthState class]
-                                                      fromData:data
-                                                         error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    authStateCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  authStateCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
   XCTAssertEqualObjects(authStateCopy.authorizationError.domain,
                         authState.authorizationError.domain, @"");
   XCTAssertEqual(authStateCopy.authorizationError.code, authState.authorizationError.code, @"");

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -322,22 +322,8 @@ static int const kCodeVerifierRecommendedLength = 43;
   XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
                         kTestAdditionalParameterValue, @"");
 
-  OIDAuthorizationRequest *requestCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:request
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDAuthorizationRequest class]
-                                                     fromData:data
-                                                        error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:request];
-    requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
+  OIDAuthorizationRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
   // to make sure the configuration IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDAuthorizationResponseTests.m
+++ b/UnitTests/OIDAuthorizationResponseTests.m
@@ -158,22 +158,8 @@ static NSString *const kTestScope = @"Scope";
  */
 - (void)testSecureCoding {
   OIDAuthorizationResponse *response = [[self class] testInstance];
-  OIDAuthorizationResponse *responseCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:response
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    responseCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDAuthorizationResponse class]
-                                                     fromData:data
-                                                        error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:response];
-    responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
+  OIDAuthorizationResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Not a full test of the request deserialization, but should be sufficient as a smoke test
   // to make sure the request IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDEndSessionRequestTests.m
+++ b/UnitTests/OIDEndSessionRequestTests.m
@@ -97,22 +97,8 @@ static NSString *const kTestIdTokenHint = @"id-token-hint";
     XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
                           kTestAdditionalParameterValue);
 
-    OIDEndSessionRequest *requestCopy;
-    NSError *error;
-    NSData *data;
-    if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-      data = [NSKeyedArchiver archivedDataWithRootObject:request
-                                   requiringSecureCoding:YES
-                                                   error:&error];
-      requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDEndSessionRequest class]
-                                                      fromData:data
-                                                         error:&error];
-    } else {
-#if !TARGET_OS_IOS
-      data = [NSKeyedArchiver archivedDataWithRootObject:request];
-      requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-    }
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
+    OIDEndSessionRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
     XCTAssertNotNil(requestCopy.configuration);
     XCTAssertEqualObjects(requestCopy.configuration.authorizationEndpoint,

--- a/UnitTests/OIDRegistrationRequestTests.m
+++ b/UnitTests/OIDRegistrationRequestTests.m
@@ -142,22 +142,8 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
   XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
                         kTestAdditionalParameterValue);
 
-  OIDRegistrationRequest *requestCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:request
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDRegistrationRequest class]
-                                                    fromData:data
-                                                       error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:request];
-    requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
+  OIDRegistrationRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
   // to make sure the configuration IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDRegistrationResponseTests.m
+++ b/UnitTests/OIDRegistrationResponseTests.m
@@ -119,22 +119,8 @@ static NSString *const kTestAdditionalParameterValue = @"example_value";
  */
 - (void)testSecureCoding {
   OIDRegistrationResponse *response = [[self class] testInstance];
-  OIDRegistrationResponse *responseCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:response
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    responseCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDRegistrationResponse class]
-                                                     fromData:data
-                                                        error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:response];
-    responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
+  OIDRegistrationResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Not a full test of the request deserialization, but should be sufficient as a smoke test
   // to make sure the request IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDServiceConfigurationTests.m
+++ b/UnitTests/OIDServiceConfigurationTests.m
@@ -363,22 +363,8 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
  */
 - (void)testSecureCoding {
   OIDServiceConfiguration *configuration = [[self class] testInstance];
-  OIDServiceConfiguration *unarchived;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:configuration
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceConfiguration class]
-                                                   fromData:data
-                                                      error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:configuration];
-    unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:configuration];
+  OIDServiceConfiguration *unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   XCTAssertEqualObjects(configuration.authorizationEndpoint, unarchived.authorizationEndpoint, @"");
   XCTAssertEqualObjects(configuration.tokenEndpoint, unarchived.tokenEndpoint, @"");

--- a/UnitTests/OIDServiceDiscoveryTests.m
+++ b/UnitTests/OIDServiceDiscoveryTests.m
@@ -448,25 +448,21 @@ static NSString *const kDiscoveryDocumentNotDictionary =
       [[OIDServiceDiscovery alloc] initWithDictionary:serviceDiscoveryDictionary
                                                              error:&error];
   NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery
                                  requiringSecureCoding:YES
                                                  error:&error];
   } else {
-#if !TARGET_OS_IOS
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
-#endif
   }
   
   OIDServiceDiscovery *unarchived;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceDiscovery class]
                                                    fromData:data
                                                       error:&error];
   } else {
-#if !TARGET_OS_IOS
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
   }
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);
@@ -482,18 +478,16 @@ static NSString *const kDiscoveryDocumentNotDictionary =
       [[OIDServiceDiscoveryOldEncoding alloc] initWithDictionary:serviceDiscoveryDictionary
                                                            error:&error];
   NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery
                                  requiringSecureCoding:YES
                                                  error:&error];
   } else {
-#if !TARGET_OS_IOS
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
-#endif
   }
   
   OIDServiceDiscovery *unarchived;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[OIDServiceDiscovery class],
                                                          [NSDictionary class],
                                                          [NSArray class],
@@ -504,9 +498,7 @@ static NSString *const kDiscoveryDocumentNotDictionary =
                                                      fromData:data
                                                         error:&error];
   } else {
-#if !TARGET_OS_IOS
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
   }
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);
@@ -522,18 +514,16 @@ static NSString *const kDiscoveryDocumentNotDictionary =
       [[OIDServiceDiscoveryOldDecoding alloc] initWithDictionary:serviceDiscoveryDictionary
                                                            error:&error];
   NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery
                                  requiringSecureCoding:YES
                                                  error:&error];
   } else {
-#if !TARGET_OS_IOS
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
-#endif
   }
   
   OIDServiceDiscovery *unarchived;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[OIDServiceDiscoveryOldDecoding class],
                                                          [NSDictionary class],
                                                          [NSArray class],
@@ -544,9 +534,7 @@ static NSString *const kDiscoveryDocumentNotDictionary =
                                                      fromData:data
                                                         error:&error];
   } else {
-#if !TARGET_OS_IOS
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
   }
   XCTAssertNil(error);
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);

--- a/UnitTests/OIDTokenRequestTests.m
+++ b/UnitTests/OIDTokenRequestTests.m
@@ -278,22 +278,8 @@ static NSString *const kTestAdditionalHeaderValue2 = @"3";
   XCTAssertEqualObjects([urlRequest.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
                         kTestAdditionalHeaderValue);
 
-  OIDTokenRequest *requestCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:request
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDTokenRequest class]
-                                                    fromData:data
-                                                       error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:request];
-    requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
+  OIDTokenRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
   // to make sure the configuration IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDTokenResponseTests.m
+++ b/UnitTests/OIDTokenResponseTests.m
@@ -175,22 +175,8 @@ static NSString *const kTestAdditionalParameterValue = @"example_value";
  */
 - (void)testSecureCoding {
   OIDTokenResponse *response = [[self class] testInstance];
-  OIDTokenResponse *responseCopy;
-  NSError *error;
-  NSData *data;
-  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-    data = [NSKeyedArchiver archivedDataWithRootObject:response
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    responseCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDTokenResponse class]
-                                                     fromData:data
-                                                        error:&error];
-  } else {
-#if !TARGET_OS_IOS
-    data = [NSKeyedArchiver archivedDataWithRootObject:response];
-    responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
+  OIDTokenResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   // Not a full test of the request deserialization, but should be sufficient as a smoke test
   // to make sure the request IS actually getting serialized and deserialized in the


### PR DESCRIPTION
**Steps to repro**

In Example app,

Tap sign in, hit continue.
Move the app to the background.
Go to Settings > Safari > Clear History and Website Data.
Go into the app again. A new permission dialog is shown.
Tap Cancel. App crashes.

**Recording from example app:** https://streamable.com/5m16cx


**Reasons for crash**

The crash happens because of ASWebAuthenticationSession getting deallocated during or immediately after completion handler
http://ww.openradar.appspot.com/FB12132525

**Fix explanation**

As suggested, this crash can be mitigated by intentionally retaining the authentication session until after the dismiss animation is complete.

