### PR TITLE
Update minimum iOS version from 10 to 12.

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -31,7 +31,7 @@ It follows the OAuth 2.0 for Native Apps best current practice
   #       classes of AppAuth with tokens on watchOS and tvOS, but currently the
   #       library won't help you obtain authorization grants on those platforms.
 
-  ios_deployment_target = "9.0"
+  ios_deployment_target = "12.0"
   osx_deployment_target = "10.12"
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target

--- a/AppAuth.xcodeproj/project.pbxproj
+++ b/AppAuth.xcodeproj/project.pbxproj
@@ -2815,7 +2815,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2873,7 +2873,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -2907,7 +2907,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/";
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.AppAuthTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2924,7 +2924,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/";
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.AppAuthTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3038,7 +3038,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/CoreFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.AppAuthCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3064,7 +3064,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/CoreFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.openid.AppAuthCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3089,7 +3089,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOS";
 				PRODUCT_NAME = AppAuth;
@@ -3114,7 +3114,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOS";
 				PRODUCT_NAME = AppAuth;
@@ -3133,7 +3133,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3147,7 +3147,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3401,7 +3401,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-ExtensionTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3415,7 +3415,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				HEADER_SEARCH_PATHS = .;
 				INFOPLIST_FILE = UnitTests/UnitTestsInfo.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.openid.AppAuth-ExtensionTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     name: "AppAuth",
     platforms: [
         .macOS(.v10_12),
-        .iOS(.v9),
+        .iOS(.v12),
         .tvOS(.v9),
         .watchOS(.v2)
     ],

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For tvOS, AppAuth implements [OAuth 2.0 Device Authorization Grant
 
 #### Supported Versions
 
-AppAuth supports iOS 7 and above.
+AppAuth supports iOS 12 and above.
 
 iOS 9+ uses the in-app browser tab pattern
 (via `SFSafariViewController`), and falls back to the system browser (mobile

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -41,10 +41,8 @@ API_UNAVAILABLE(macCatalyst)
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the authentication UI.
     @discussion The specific authentication UI used depends on the iOS version and accessibility
-        options. iOS 8 uses the system browser, iOS 9-10 use @c SFSafariViewController, iOS 11 uses
-        @c SFAuthenticationSession
-        (unless Guided Access is on which does not work) or uses @c SFSafariViewController, and iOS
-        12+ uses @c ASWebAuthenticationSession (unless Guided Access is on).
+        options. iOS 12+ uses @c ASWebAuthenticationSession (unless Guided Access is on),
+        otherwise local browser is used.
  */
 - (nullable instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -50,7 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   __weak SFSafariViewController *_safariVC;
-  SFAuthenticationSession *_authenticationVC;
   ASWebAuthenticationSession *_webAuthenticationVC;
 #pragma clang diagnostic pop
 }
@@ -154,7 +153,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   SFSafariViewController *safariVC = _safariVC;
-  SFAuthenticationSession *authenticationVC = _authenticationVC;
   ASWebAuthenticationSession *webAuthenticationVC = _webAuthenticationVC;
 #pragma clang diagnostic pop
   
@@ -163,10 +161,6 @@ NS_ASSUME_NONNULL_BEGIN
   if (webAuthenticationVC) {
     // dismiss the ASWebAuthenticationSession
     [webAuthenticationVC cancel];
-    if (completion) completion();
-  } else if (authenticationVC) {
-    // dismiss the SFAuthenticationSession
-    [authenticationVC cancel];
     if (completion) completion();
   } else if (safariVC) {
     // dismiss the SFSafariViewController
@@ -180,7 +174,6 @@ NS_ASSUME_NONNULL_BEGIN
   // The weak references to |_safariVC| and |_session| are set to nil to avoid accidentally using
   // them while not in an authorization flow.
   _safariVC = nil;
-  _authenticationVC = nil;
   _webAuthenticationVC = nil;
   _session = nil;
   _externalUserAgentFlowInProgress = NO;

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOSCustomBrowser.m
@@ -145,11 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *testURLString = [NSString stringWithFormat:@"%@://example.com", _canOpenURLScheme];
     NSURL *testURL = [NSURL URLWithString:testURLString];
     if (![[UIApplication sharedApplication] canOpenURL:testURL]) {
-      if (@available(iOS 10.0, *)) {
-        [[UIApplication sharedApplication] openURL:_appStoreURL options:@{} completionHandler:nil];
-      } else {
-        [[UIApplication sharedApplication] openURL:_appStoreURL];
-      }
+      [[UIApplication sharedApplication] openURL:_appStoreURL options:@{} completionHandler:nil];
       return NO;
     }
   }
@@ -157,14 +153,9 @@ NS_ASSUME_NONNULL_BEGIN
   // Transforms the request URL and opens it.
   NSURL *requestURL = [request externalUserAgentRequestURL];
   requestURL = _URLTransformation(requestURL);
-  if (@available(iOS 10.0, *)) {
-    BOOL willOpen = [[UIApplication sharedApplication] canOpenURL:requestURL];
+  BOOL willOpen = [[UIApplication sharedApplication] canOpenURL:requestURL];
     [[UIApplication sharedApplication] openURL:requestURL options:@{} completionHandler:nil];
     return willOpen;
-  } else {
-    BOOL openedInBrowser = [[UIApplication sharedApplication] openURL:requestURL];
-    return openedInBrowser;
-  }
 }
 
 - (void)dismissExternalUserAgentAnimated:(BOOL)animated

--- a/Sources/AppAuthCore/OIDRegistrationRequest.m
+++ b/Sources/AppAuthCore/OIDRegistrationRequest.m
@@ -130,12 +130,15 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
                          forKey:kConfigurationKey];
   NSString *initialAccessToken = [aDecoder decodeObjectOfClass:[NSString class]
                                                         forKey:kInitialAccessToken];
-  NSArray<NSURL *> *redirectURIs = [aDecoder decodeObjectOfClass:[NSArray<NSURL *> class]
-                                                          forKey:kRedirectURIsKey];
-  NSArray<NSString *> *responseTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
-                                                              forKey:kResponseTypesKey];
-  NSArray<NSString *> *grantTypes = [aDecoder decodeObjectOfClass:[NSArray<NSString *> class]
-                                                           forKey:kGrantTypesKey];
+  NSArray<NSURL *> *redirectURIs =
+      [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSURL class]]]
+                               forKey:kRedirectURIsKey];
+  NSArray<NSString *> *responseTypes =
+      [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]]
+                               forKey:kResponseTypesKey];
+  NSArray<NSString *> *grantTypes =
+      [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSString class]]]
+                               forKey:kGrantTypesKey];
   NSString *subjectType = [aDecoder decodeObjectOfClass:[NSString class]
                                                  forKey:kSubjectTypeKey];
   NSString *tokenEndpointAuthenticationMethod =

--- a/UnitTests/OIDAuthorizationRequestTests.m
+++ b/UnitTests/OIDAuthorizationRequestTests.m
@@ -322,8 +322,22 @@ static int const kCodeVerifierRecommendedLength = 43;
   XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
                         kTestAdditionalParameterValue, @"");
 
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
-  OIDAuthorizationRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDAuthorizationRequest *requestCopy;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:request
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDAuthorizationRequest class]
+                                                     fromData:data
+                                                        error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:request];
+    requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
   // to make sure the configuration IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDAuthorizationResponseTests.m
+++ b/UnitTests/OIDAuthorizationResponseTests.m
@@ -158,8 +158,22 @@ static NSString *const kTestScope = @"Scope";
  */
 - (void)testSecureCoding {
   OIDAuthorizationResponse *response = [[self class] testInstance];
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
-  OIDAuthorizationResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDAuthorizationResponse *responseCopy;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:response
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    responseCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDAuthorizationResponse class]
+                                                     fromData:data
+                                                        error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:response];
+    responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   // Not a full test of the request deserialization, but should be sufficient as a smoke test
   // to make sure the request IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDEndSessionRequestTests.m
+++ b/UnitTests/OIDEndSessionRequestTests.m
@@ -97,8 +97,22 @@ static NSString *const kTestIdTokenHint = @"id-token-hint";
     XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
                           kTestAdditionalParameterValue);
 
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
-    OIDEndSessionRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    OIDEndSessionRequest *requestCopy;
+    NSError *error;
+    NSData *data;
+    if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+      data = [NSKeyedArchiver archivedDataWithRootObject:request
+                                   requiringSecureCoding:YES
+                                                   error:&error];
+      requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDEndSessionRequest class]
+                                                      fromData:data
+                                                         error:&error];
+    } else {
+#if !TARGET_OS_IOS
+      data = [NSKeyedArchiver archivedDataWithRootObject:request];
+      requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+    }
 
     XCTAssertNotNil(requestCopy.configuration);
     XCTAssertEqualObjects(requestCopy.configuration.authorizationEndpoint,

--- a/UnitTests/OIDRegistrationRequestTests.m
+++ b/UnitTests/OIDRegistrationRequestTests.m
@@ -142,8 +142,22 @@ static NSString *kTokenEndpointAuthMethodTestValue = @"client_secret_basic";
   XCTAssertEqualObjects(request.additionalParameters[kTestAdditionalParameterKey],
                         kTestAdditionalParameterValue);
 
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
-  OIDRegistrationRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDRegistrationRequest *requestCopy;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:request
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDRegistrationRequest class]
+                                                    fromData:data
+                                                       error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:request];
+    requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
   // to make sure the configuration IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDRegistrationResponseTests.m
+++ b/UnitTests/OIDRegistrationResponseTests.m
@@ -119,8 +119,22 @@ static NSString *const kTestAdditionalParameterValue = @"example_value";
  */
 - (void)testSecureCoding {
   OIDRegistrationResponse *response = [[self class] testInstance];
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
-  OIDRegistrationResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDRegistrationResponse *responseCopy;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:response
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    responseCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDRegistrationResponse class]
+                                                     fromData:data
+                                                        error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:response];
+    responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   // Not a full test of the request deserialization, but should be sufficient as a smoke test
   // to make sure the request IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDServiceConfigurationTests.m
+++ b/UnitTests/OIDServiceConfigurationTests.m
@@ -363,8 +363,22 @@ static NSString *const kIssuerTestExpectedFullDiscoveryURL =
  */
 - (void)testSecureCoding {
   OIDServiceConfiguration *configuration = [[self class] testInstance];
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:configuration];
-  OIDServiceConfiguration *unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDServiceConfiguration *unarchived;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:configuration
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceConfiguration class]
+                                                   fromData:data
+                                                      error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:configuration];
+    unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   XCTAssertEqualObjects(configuration.authorizationEndpoint, unarchived.authorizationEndpoint, @"");
   XCTAssertEqualObjects(configuration.tokenEndpoint, unarchived.tokenEndpoint, @"");

--- a/UnitTests/OIDServiceDiscoveryTests.m
+++ b/UnitTests/OIDServiceDiscoveryTests.m
@@ -448,21 +448,25 @@ static NSString *const kDiscoveryDocumentNotDictionary =
       [[OIDServiceDiscovery alloc] initWithDictionary:serviceDiscoveryDictionary
                                                              error:&error];
   NSData *data;
-  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery
                                  requiringSecureCoding:YES
                                                  error:&error];
   } else {
+#if !TARGET_OS_IOS
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
+#endif
   }
   
   OIDServiceDiscovery *unarchived;
-  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDServiceDiscovery class]
                                                    fromData:data
                                                       error:&error];
   } else {
+#if !TARGET_OS_IOS
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
   }
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);
@@ -478,16 +482,18 @@ static NSString *const kDiscoveryDocumentNotDictionary =
       [[OIDServiceDiscoveryOldEncoding alloc] initWithDictionary:serviceDiscoveryDictionary
                                                            error:&error];
   NSData *data;
-  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery
                                  requiringSecureCoding:YES
                                                  error:&error];
   } else {
+#if !TARGET_OS_IOS
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
+#endif
   }
   
   OIDServiceDiscovery *unarchived;
-  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[OIDServiceDiscovery class],
                                                          [NSDictionary class],
                                                          [NSArray class],
@@ -498,7 +504,9 @@ static NSString *const kDiscoveryDocumentNotDictionary =
                                                      fromData:data
                                                         error:&error];
   } else {
+#if !TARGET_OS_IOS
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
   }
 
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);
@@ -514,16 +522,18 @@ static NSString *const kDiscoveryDocumentNotDictionary =
       [[OIDServiceDiscoveryOldDecoding alloc] initWithDictionary:serviceDiscoveryDictionary
                                                            error:&error];
   NSData *data;
-  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery
                                  requiringSecureCoding:YES
                                                  error:&error];
   } else {
+#if !TARGET_OS_IOS
     data = [NSKeyedArchiver archivedDataWithRootObject:discovery];
+#endif
   }
   
   OIDServiceDiscovery *unarchived;
-  if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
     NSSet<Class> *allowedClasses = [NSSet setWithArray:@[[OIDServiceDiscoveryOldDecoding class],
                                                          [NSDictionary class],
                                                          [NSArray class],
@@ -534,7 +544,9 @@ static NSString *const kDiscoveryDocumentNotDictionary =
                                                      fromData:data
                                                         error:&error];
   } else {
+#if !TARGET_OS_IOS
     unarchived = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
   }
   XCTAssertNil(error);
   XCTAssertEqualObjects(discovery.discoveryDictionary, unarchived.discoveryDictionary);

--- a/UnitTests/OIDTokenRequestTests.m
+++ b/UnitTests/OIDTokenRequestTests.m
@@ -278,8 +278,22 @@ static NSString *const kTestAdditionalHeaderValue2 = @"3";
   XCTAssertEqualObjects([urlRequest.allHTTPHeaderFields objectForKey:kTestAdditionalHeaderKey],
                         kTestAdditionalHeaderValue);
 
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:request];
-  OIDTokenRequest *requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDTokenRequest *requestCopy;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:request
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    requestCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDTokenRequest class]
+                                                    fromData:data
+                                                       error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:request];
+    requestCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   // Not a full test of the configuration deserialization, but should be sufficient as a smoke test
   // to make sure the configuration IS actually getting serialized and deserialized in the

--- a/UnitTests/OIDTokenResponseTests.m
+++ b/UnitTests/OIDTokenResponseTests.m
@@ -175,8 +175,22 @@ static NSString *const kTestAdditionalParameterValue = @"example_value";
  */
 - (void)testSecureCoding {
   OIDTokenResponse *response = [[self class] testInstance];
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:response];
-  OIDTokenResponse *responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  OIDTokenResponse *responseCopy;
+  NSError *error;
+  NSData *data;
+  if (@available(iOS 12.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+    data = [NSKeyedArchiver archivedDataWithRootObject:response
+                                 requiringSecureCoding:YES
+                                                 error:&error];
+    responseCopy = [NSKeyedUnarchiver unarchivedObjectOfClass:[OIDTokenResponse class]
+                                                     fromData:data
+                                                        error:&error];
+  } else {
+#if !TARGET_OS_IOS
+    data = [NSKeyedArchiver archivedDataWithRootObject:response];
+    responseCopy = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+#endif
+  }
 
   // Not a full test of the request deserialization, but should be sufficient as a smoke test
   // to make sure the request IS actually getting serialized and deserialized in the


### PR DESCRIPTION
Update the minimum supported iOS version from 10 to 12 and remove any deprecations. 

This PR will remove references relating to [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession) which is marked deprecated as of iOS 12.
Additionally, this PR will fix deprecation errors coming in relating to [archivedData(withRootObject:)](https://developer.apple.com/documentation/foundation/nskeyedarchiver/archiveddata(withrootobject:)) which has also been deprecated as of iOS 12.