### PR TITLE
Ensure nil callback is called on the main thread to fix Swift 6 crash

### DIFF
--- a/Sources/AppAuthCore/OIDAuthState.m
+++ b/Sources/AppAuthCore/OIDAuthState.m
@@ -165,7 +165,9 @@ static const NSUInteger kExpiryTimeTolerance = 60;
                                callback(authState, authorizationError);
                              }
                            } else {
-                             callback(nil, authorizationError);
+                             dispatch_async(dispatch_get_main_queue(), ^{
+                               callback(nil, authorizationError);
+                             });
                            }
                          }];
   return authFlowSession;


### PR DESCRIPTION
Fixed #881 