### PR TITLE
Expose HTTP response headers in `NSError` for non-2xx responses

### DIFF
--- a/Sources/AppAuthCore/OIDError.h
+++ b/Sources/AppAuthCore/OIDError.h
@@ -73,6 +73,14 @@ extern NSString *const OIDHTTPErrorDomain;
  */
 extern NSString *const OIDOAuthErrorResponseErrorKey;
 
+/*! @brief An error key used to access the HTTP response headers from a failed AppAuth request.
+    @discussion When an AppAuth request fails due to a non-2xx HTTP response, the server's
+        response headers are attached to the returned NSError's `userInfo` dictionary under this key.
+        The value is an NSDictionary<NSString *, id>, matching the structure of
+        NSHTTPURLResponse.allHeaderFields.
+ */
+extern NSString *const OIDHTTPResponseHeadersKey;
+
 /*! @brief The key of the 'error' response field in a RFC6749 Section 5.2 response.
     @remark error
     @see https://tools.ietf.org/html/rfc6749#section-5.2

--- a/Sources/AppAuthCore/OIDError.m
+++ b/Sources/AppAuthCore/OIDError.m
@@ -38,6 +38,8 @@ NSString *const OIDOAuthExceptionInvalidTokenRequestNullRedirectURL = @"A OIDTok
 
 NSString *const OIDOAuthErrorResponseErrorKey = @"OIDOAuthErrorResponseErrorKey";
 
+NSString *const OIDHTTPResponseHeadersKey = @"OIDHTTPResponseHeadersKey";
+
 NSString *const OIDOAuthErrorFieldError = @"error";
 
 NSString *const OIDOAuthErrorFieldErrorDescription = @"error_description";

--- a/Sources/AppAuthCore/OIDErrorUtilities.m
+++ b/Sources/AppAuthCore/OIDErrorUtilities.m
@@ -133,6 +133,11 @@
       userInfo[NSLocalizedDescriptionKey] = serverResponse;
     }
   }
+  
+  if (HTTPURLResponse.allHeaderFields) {
+    userInfo[OIDHTTPResponseHeadersKey] = HTTPURLResponse.allHeaderFields;
+  }
+  
   NSError *serverError =
       [NSError errorWithDomain:OIDHTTPErrorDomain
                           code:HTTPURLResponse.statusCode


### PR DESCRIPTION
### Problem

When a token request returns a non-2xx HTTP status (for example 400), AppAuth currently exposes only the response body and status code in the resulting `NSError`.
There is no way for SDK users to access the response headers, which are required in some flows.

### Solution

Include `HTTPURLResponse.allHeaderFields` in the `NSError.userInfo` for non-2xx responses under a new exported key:

```objc
extern NSString *const OIDHTTPResponseHeadersKey;
```

This change is minimal and fully backward compatible. Successful responses are not affected.

### Background

[DPoP (RFC 9449 §8)](https://datatracker.ietf.org/doc/html/rfc9449#section-8) specifies a case where an authorization server responds to a token request with a 400 status and includes a `DPoP-Nonce` header. Clients must extract this nonce and retry the request with a re-signed proof.

Without access to the response headers, it is impossible to implement a compliant DPoP flow using AppAuth.