### PR TITLE
Update App-Auth-iOS for Swift 6 Strict Concurrency Compatibility

### DIFF
--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -202,8 +202,18 @@ NS_ASSUME_NONNULL_BEGIN
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 #pragma mark - ASWebAuthenticationPresentationContextProviding
 
-- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)){
-  return _presentingViewController.view.window;
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)) {
+  __block UIWindow *window;
+  
+  if ([NSThread isMainThread]) {
+    window = _presentingViewController.view.window;
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      window = _presentingViewController.view.window;
+    });
+  }
+  
+  return window;
 }
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -100,7 +100,18 @@ NS_ASSUME_NONNULL_BEGIN
   // iOS 12 and later, use ASWebAuthenticationSession
   if (@available(iOS 12.0, *)) {
     // ASWebAuthenticationSession doesn't work with guided access (rdar://40809553)
-    if (!UIAccessibilityIsGuidedAccessEnabled()) {
+    
+    __block BOOL isUIAccessibilityIsGuidedAccessEnabled = NO;
+    
+    if ([NSThread isMainThread]) {
+      isUIAccessibilityIsGuidedAccessEnabled = UIAccessibilityIsGuidedAccessEnabled();
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), ^{
+        isUIAccessibilityIsGuidedAccessEnabled = UIAccessibilityIsGuidedAccessEnabled();
+      });
+    }
+    
+    if (!isUIAccessibilityIsGuidedAccessEnabled) {
       __weak OIDExternalUserAgentIOS *weakSelf = self;
       NSString *redirectScheme = request.redirectScheme;
       ASWebAuthenticationSession *authenticationVC =

--- a/Sources/AppAuthCore/OIDAuthorizationResponse.h
+++ b/Sources/AppAuthCore/OIDAuthorizationResponse.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
     @see https://tools.ietf.org/html/rfc6749#section-5.1
     @see http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse
  */
+__attribute__((swift_attr("@Sendable")))
 @interface OIDAuthorizationResponse : NSObject <NSCopying, NSSecureCoding>
 
 /*! @brief The request which was serviced.

--- a/Sources/AppAuthCore/OIDEndSessionResponse.h
+++ b/Sources/AppAuthCore/OIDEndSessionResponse.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief Represents the response to an End Session request.
     @see http://openid.net/specs/openid-connect-session-1_0.html#RPLogout
  */
-
+__attribute__((swift_attr("@Sendable")))
 @interface OIDEndSessionResponse : NSObject <NSCopying, NSSecureCoding>
 
 /*! @brief The request which was serviced.

--- a/Sources/AppAuthCore/OIDRegistrationResponse.h
+++ b/Sources/AppAuthCore/OIDRegistrationResponse.h
@@ -50,6 +50,7 @@ extern NSString *const OIDRegistrationClientURIParam;
 /*! @brief Represents a registration response.
     @see https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse
  */
+__attribute__((swift_attr("@Sendable")))
 @interface OIDRegistrationResponse : NSObject <NSCopying, NSSecureCoding>
 
 /*! @brief The request which was serviced.

--- a/Sources/AppAuthCore/OIDServiceConfiguration.h
+++ b/Sources/AppAuthCore/OIDServiceConfiguration.h
@@ -32,6 +32,7 @@ typedef void (^OIDServiceConfigurationCreated)
 
 /*! @brief Represents the information needed to construct a @c OIDAuthorizationService.
  */
+__attribute__((swift_attr("@Sendable")))
 @interface OIDServiceConfiguration : NSObject <NSCopying, NSSecureCoding>
 
 /*! @brief The authorization endpoint URI.

--- a/Sources/AppAuthCore/OIDTokenResponse.h
+++ b/Sources/AppAuthCore/OIDTokenResponse.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
     @see https://tools.ietf.org/html/rfc6749#section-3.2
     @see https://tools.ietf.org/html/rfc6749#section-4.1.3
  */
+__attribute__((swift_attr("@Sendable")))
 @interface OIDTokenResponse : NSObject <NSCopying, NSSecureCoding>
 
 /*! @brief The request which was serviced.

--- a/Sources/AppAuthTV/OIDTVAuthorizationResponse.h
+++ b/Sources/AppAuthTV/OIDTVAuthorizationResponse.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief Represents the response to a TV authorization request.
     @see https://tools.ietf.org/html/rfc8628#section-3.5
  */
+__attribute__((swift_attr("@Sendable")))
 @interface OIDTVAuthorizationResponse : OIDAuthorizationResponse
 
 /*! @brief The verification URI that should be displayed to the user instructing them to visit the


### PR DESCRIPTION
This PR updates the App-Auth-iOS Objective-C library to support Swift 6's strict concurrency model. Key changes include:

- Marked response models as Sendable to ensure safe usage across concurrency domains.

- Refactored code involving UIWindow and UIAccessibilityIsGuidedAccessEnabled() to allow invocation outside of the GCD main queue, improving flexibility and concurrency safety.