### PR TITLE
Allow using a background queue with OIDAuthState

### DIFF
--- a/Sources/AppAuthCore/OIDAuthState.h
+++ b/Sources/AppAuthCore/OIDAuthState.h
@@ -237,8 +237,7 @@ static NSString *const kRefreshTokenRequestException =
 
 /*! @brief Calls the block with a valid access token (refreshing it first, if needed), or if a
         refresh was needed and failed, with the error that caused it to fail.
-    @param action The block to execute with a fresh token. This block will be executed on the main
-        thread.
+    @param action The block to execute with a fresh token.
     @param additionalParameters Additional parameters for the token request if token is
         refreshed.
     @param dispatchQueue The dispatchQueue on which to dispatch the action block.
@@ -252,6 +251,17 @@ static NSString *const kRefreshTokenRequestException =
         called, even if the current tokens are considered valid.
  */
 - (void)setNeedsTokenRefresh;
+
+/*! @brief The shared queue used for token refresh operations and delegate callbacks.
+    @discussion By default, all token refresh operations and delegate callbacks occur on
+        the main queue. Set this to a background queue if you need to call
+        @c OIDAuthState.performActionWithFreshTokens: synchronously without risking deadlock.
+        When using a custom queue, @c OIDAuthState should only be used from that queue, because it is not thread-safe.
+        Delelegate calls are dispatched from this queue as well. 
+        This is a class-level property that affects all @c OIDAuthState instances.
+        The getter returns the main queue if no custom queue has been set.
+ */
+@property(class, nonatomic, strong, nullable) dispatch_queue_t sharedDelegateQueue;
 
 /*! @brief Creates a token request suitable for refreshing an access token.
     @return A @c OIDTokenRequest suitable for using a refresh token to obtain a new access token.

--- a/Sources/AppAuthCore/OIDAuthState.m
+++ b/Sources/AppAuthCore/OIDAuthState.m
@@ -102,6 +102,14 @@ static const NSUInteger kExpiryTimeTolerance = 60;
 
 @end
 
+static dispatch_queue_t dispatch_get_oidAuthStateQueue(void) {
+    static dispatch_queue_t queue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        queue = dispatch_queue_create("OIDAuthStateQueue", NULL);
+    });
+    return queue;
+}
 
 @implementation OIDAuthState {
   /*! @brief Array of pending actions (use @c _pendingActionsSyncObject to synchronize access).
@@ -547,6 +555,7 @@ static const NSUInteger kExpiryTimeTolerance = 60;
       [self tokenRefreshRequestWithAdditionalParameters:additionalParameters];
   [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
                  originalAuthorizationResponse:_lastAuthorizationResponse
+                                 dispatchQueue: dispatch_get_oidAuthStateQueue()
                                       callback:^(OIDTokenResponse *_Nullable response,
                                                  NSError *_Nullable error) {
     // update OIDAuthState based on response

--- a/Sources/AppAuthCore/OIDAuthorizationService.h
+++ b/Sources/AppAuthCore/OIDAuthorizationService.h
@@ -152,11 +152,12 @@ typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable reg
 /*! @brief Performs a token request.
     @param request The token request.
     @param authorizationResponse The original authorization response related to this token request.
+    @param callbackDispatchQueue The dispatch queue on which to call the callback.
     @param callback The method called when the request has completed or failed.
  */
 + (void)performTokenRequest:(OIDTokenRequest *)request
     originalAuthorizationResponse:(OIDAuthorizationResponse *_Nullable)authorizationResponse
-                    dispatchQueue:(dispatch_queue_t)dispatchQueue
+           callbackDispatchQueue:(dispatch_queue_t)callbackDispatchQueue
                          callback:(OIDTokenCallback)callback;
 
 + (void)performTokenRequest:(OIDTokenRequest *)request

--- a/Sources/AppAuthCore/OIDAuthorizationService.h
+++ b/Sources/AppAuthCore/OIDAuthorizationService.h
@@ -156,6 +156,11 @@ typedef void (^OIDRegistrationCompletion)(OIDRegistrationResponse *_Nullable reg
  */
 + (void)performTokenRequest:(OIDTokenRequest *)request
     originalAuthorizationResponse:(OIDAuthorizationResponse *_Nullable)authorizationResponse
+                    dispatchQueue:(dispatch_queue_t)dispatchQueue
+                         callback:(OIDTokenCallback)callback;
+
++ (void)performTokenRequest:(OIDTokenRequest *)request
+    originalAuthorizationResponse:(OIDAuthorizationResponse *_Nullable)authorizationResponse
                          callback:(OIDTokenCallback)callback;
 
 /*! @brief Performs a registration request.

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -423,7 +423,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)performTokenRequest:(OIDTokenRequest *)request callback:(OIDTokenCallback)callback {
   [[self class] performTokenRequest:request
       originalAuthorizationResponse:nil
-                      dispatchQueue:dispatch_get_main_queue()
+              callbackDispatchQueue:dispatch_get_main_queue()
                            callback:callback];
 }
 + (void)performTokenRequest:(OIDTokenRequest *)request
@@ -431,13 +431,13 @@ NS_ASSUME_NONNULL_BEGIN
                    callback:(OIDTokenCallback)callback {
     [self performTokenRequest:request
 originalAuthorizationResponse:authorizationResponse
-                dispatchQueue:dispatch_get_main_queue()
+        callbackDispatchQueue:dispatch_get_main_queue()
                      callback:callback];
 }
 
 + (void)performTokenRequest:(OIDTokenRequest *)request
     originalAuthorizationResponse:(OIDAuthorizationResponse *_Nullable)authorizationResponse
-                    dispatchQueue:(dispatch_queue_t)dispatchQueue
+           callbackDispatchQueue:(dispatch_queue_t)callbackDispatchQueue
                          callback:(OIDTokenCallback)callback {
 
   NSURLRequest *URLRequest = [request URLRequest];
@@ -463,7 +463,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeNetworkError
                            underlyingError:error
                                description:errorDescription];
-      dispatch_async(dispatchQueue, ^{
+      dispatch_async(callbackDispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -492,7 +492,7 @@ originalAuthorizationResponse:authorizationResponse
             [OIDErrorUtilities OAuthErrorWithDomain:OIDOAuthTokenErrorDomain
                                       OAuthResponse:json
                                     underlyingError:serverError];
-          dispatch_async(dispatchQueue, ^{
+          dispatch_async(callbackDispatchQueue, ^{
             callback(nil, oauthError);
           });
           return;
@@ -508,7 +508,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeServerError
                            underlyingError:serverError
                                description:errorDescription];
-      dispatch_async(dispatchQueue, ^{
+      dispatch_async(callbackDispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -526,7 +526,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeJSONDeserializationError
                            underlyingError:jsonDeserializationError
                                description:errorDescription];
-      dispatch_async(dispatchQueue, ^{
+      dispatch_async(callbackDispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -540,7 +540,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeTokenResponseConstructionError
                            underlyingError:jsonDeserializationError
                                description:@"Token response invalid."];
-      dispatch_async(dispatchQueue, ^{
+      dispatch_async(callbackDispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -561,7 +561,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenParsingError
                            underlyingError:nil
                                description:@"ID Token parsing failed"];
-        dispatch_async(dispatchQueue, ^{
+        dispatch_async(callbackDispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -578,7 +578,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:@"Issuer mismatch"];
-        dispatch_async(dispatchQueue, ^{
+        dispatch_async(callbackDispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -594,7 +594,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:@"Audience mismatch"];
-        dispatch_async(dispatchQueue, ^{
+        dispatch_async(callbackDispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -620,7 +620,7 @@ originalAuthorizationResponse:authorizationResponse
             [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                              underlyingError:nil
                                  description:@"ID Token expired"];
-        dispatch_async(dispatchQueue, ^{
+        dispatch_async(callbackDispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -638,7 +638,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:message];
-        dispatch_async(dispatchQueue, ^{
+        dispatch_async(callbackDispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -654,7 +654,7 @@ originalAuthorizationResponse:authorizationResponse
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:@"Nonce mismatch"];
-          dispatch_async(dispatchQueue, ^{
+          dispatch_async(callbackDispatchQueue, ^{
             callback(nil, invalidIDToken);
           });
           return;
@@ -669,7 +669,7 @@ originalAuthorizationResponse:authorizationResponse
     }
 
     // Success
-    dispatch_async(dispatchQueue, ^{
+    dispatch_async(callbackDispatchQueue, ^{
       callback(tokenResponse, nil);
     });
   }] resume];

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -423,11 +423,21 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)performTokenRequest:(OIDTokenRequest *)request callback:(OIDTokenCallback)callback {
   [[self class] performTokenRequest:request
       originalAuthorizationResponse:nil
+                      dispatchQueue:dispatch_get_main_queue()
                            callback:callback];
+}
++ (void)performTokenRequest:(OIDTokenRequest *)request
+    originalAuthorizationResponse:(OIDAuthorizationResponse *_Nullable)authorizationResponse
+                   callback:(OIDTokenCallback)callback {
+    [self performTokenRequest:request
+originalAuthorizationResponse:authorizationResponse
+                dispatchQueue:dispatch_get_main_queue()
+                     callback:callback];
 }
 
 + (void)performTokenRequest:(OIDTokenRequest *)request
     originalAuthorizationResponse:(OIDAuthorizationResponse *_Nullable)authorizationResponse
+                    dispatchQueue:(dispatch_queue_t)dispatchQueue
                          callback:(OIDTokenCallback)callback {
 
   NSURLRequest *URLRequest = [request URLRequest];
@@ -453,7 +463,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeNetworkError
                            underlyingError:error
                                description:errorDescription];
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -482,7 +492,7 @@ NS_ASSUME_NONNULL_BEGIN
             [OIDErrorUtilities OAuthErrorWithDomain:OIDOAuthTokenErrorDomain
                                       OAuthResponse:json
                                     underlyingError:serverError];
-          dispatch_async(dispatch_get_main_queue(), ^{
+          dispatch_async(dispatchQueue, ^{
             callback(nil, oauthError);
           });
           return;
@@ -498,7 +508,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeServerError
                            underlyingError:serverError
                                description:errorDescription];
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -516,7 +526,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeJSONDeserializationError
                            underlyingError:jsonDeserializationError
                                description:errorDescription];
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -530,7 +540,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeTokenResponseConstructionError
                            underlyingError:jsonDeserializationError
                                description:@"Token response invalid."];
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatchQueue, ^{
         callback(nil, returnedError);
       });
       return;
@@ -551,7 +561,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenParsingError
                            underlyingError:nil
                                description:@"ID Token parsing failed"];
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -568,7 +578,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:@"Issuer mismatch"];
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -584,7 +594,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:@"Audience mismatch"];
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -610,7 +620,7 @@ NS_ASSUME_NONNULL_BEGIN
             [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                              underlyingError:nil
                                  description:@"ID Token expired"];
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -628,7 +638,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:message];
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(dispatchQueue, ^{
           callback(nil, invalidIDToken);
         });
         return;
@@ -644,7 +654,7 @@ NS_ASSUME_NONNULL_BEGIN
           [OIDErrorUtilities errorWithCode:OIDErrorCodeIDTokenFailedValidationError
                            underlyingError:nil
                                description:@"Nonce mismatch"];
-          dispatch_async(dispatch_get_main_queue(), ^{
+          dispatch_async(dispatchQueue, ^{
             callback(nil, invalidIDToken);
           });
           return;
@@ -659,7 +669,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Success
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatchQueue, ^{
       callback(tokenResponse, nil);
     });
   }] resume];


### PR DESCRIPTION
This commit is related to this issue: https://github.com/openid/AppAuth-iOS/issues/667, which we also ran into. 

The problem was that `OIDAuthorizationService`'s `performTokenRequest` still dispatched a lot of callbacks on the main dispatch queue, which in turn caused a deadlock for us when calling `OIDAuthState`'s `performAction`.

This change allows setting a queue for OIDAuthState to use when calling `performTokenRequest`.

This change does not make OIDAuthState thread safe. 
The default behaviour stays as is, expecting the user to use the main thread.
If a queue is specified, all method calls on the OIDAuthState then also need to be dispatched from that queue to avoid potential threading issues.