### PR TITLE
Add .gemini/ directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Docs/
 xcuserdata/
 Carthage/
+.gemini/


### PR DESCRIPTION
The policies/ subdirectory of .gemini/ is used by Gemini CLI's policy engine for fine-grained control over tool calls.