### PR TITLE
Migrate CI runners from macos-13 to macos-14, pin Xcode 16.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       matrix:
         flags: [
-          "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' -sdk 'iphonesimulator17.2'",
+          "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.2' -sdk 'iphonesimulator18.2'",
           "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
           "-scheme AppAuth_macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
-          "-scheme AppAuth-tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.2' -sdk 'appletvsimulator17.2'",
-          "-scheme AppAuth_tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.2' -sdk 'appletvsimulator17.2'",
-          "-scheme AppAuthTV -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.2' -sdk 'appletvsimulator17.2'"
+          "-scheme AppAuth-tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'",
+          "-scheme AppAuth_tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'",
+          "-scheme AppAuthTV -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'"
         ]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         flags: [
-          "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.2' -sdk 'iphonesimulator18.2'",
+          "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' -sdk 'iphonesimulator18.2'",
           "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
           "-scheme AppAuth_macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
           "-scheme AppAuth-tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,19 +12,21 @@ on:
 jobs:
 
   xcode-project-test:
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         flags: [
           "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' -sdk 'iphonesimulator17.2'",
-          "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx14.2'",
-          "-scheme AppAuth_macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx14.2'",
+          "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
+          "-scheme AppAuth_macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
           "-scheme AppAuth-tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.2' -sdk 'appletvsimulator17.2'",
           "-scheme AppAuth_tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.2' -sdk 'appletvsimulator17.2'",
           "-scheme AppAuthTV -destination 'platform=tvOS Simulator,name=Apple TV,OS=17.2' -sdk 'appletvsimulator17.2'"
         ]
     steps:
     - uses: actions/checkout@v3
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - name: Run unit test targets
       run: |
         xcodebuild test \
@@ -32,7 +34,7 @@ jobs:
           ${{ matrix.flags }}
 
   pod-lib-lint:
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         flags: [
@@ -50,7 +52,7 @@ jobs:
       run: pod lib lint --verbose ${{ matrix.flags }}
 
   spm-build-test:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Build unit test target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
+        # Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
         flags: [
           "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' -sdk 'iphonesimulator18.2'",
           "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",


### PR DESCRIPTION
This PR contains the minimum-viable changes to make unit tests work. We should probably update beyond 14, but I'm trying to get this crash fix out...