### PR TITLE
[#574] Remove external browser fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+- Removed external browser (Safari) fallback from `OIDExternalUserAgentIOS`. If `ASWebAuthenticationSession` fails to start (e.g., Guided Access is enabled), the authorization flow now fails with an error instead of opening an external browser.
+
 # 2.0.0
 - Raise minimum supported iOS version to iOS 12. ([#918](https://github.com/openid/AppAuth-iOS/pull/918))
 - Remove deprecated `[UIApplication openURL:]` method to compile with Xcode 16. ([#911](https://github.com/openid/AppAuth-iOS/pull/911))

--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ For tvOS, AppAuth implements [OAuth 2.0 Device Authorization Grant
 
 AppAuth supports iOS 12 and above.
 
-iOS 9+ uses the in-app browser tab pattern
-(via `SFSafariViewController`), and falls back to the system browser (mobile
-Safari) on earlier versions.
+Authentication is performed using `ASWebAuthenticationSession`.
 
 #### Authorization Server Requirements
 

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -40,9 +40,7 @@ API_UNAVAILABLE(macCatalyst)
 
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the authentication UI.
-    @discussion The specific authentication UI used depends on the iOS version and accessibility
-        options. iOS 12+ uses @c ASWebAuthenticationSession (unless Guided Access is on),
-        otherwise local browser is used.
+    @discussion The specific authentication UI used depends on the iOS version and accessibility options. Uses @c ASWebAuthenticationSession. If Guided Access is enabled or the session cannot be started, the method returns NO and the authorization flow fails with an error.
  */
 - (nullable instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController
@@ -52,8 +50,7 @@ API_UNAVAILABLE(macCatalyst)
     @param presentingViewController The view controller from which to present the browser.
     @param prefersEphemeralSession Whether the caller prefers to use a private authentication
         session. See @c ASWebAuthenticationSession.prefersEphemeralWebBrowserSession for more.
-    @discussion Authentication is performed with @c ASWebAuthenticationSession (unless Guided Access
-        is on), setting the ephemerality based on the argument.
+    @discussion Authentication is performed with @c ASWebAuthenticationSession, setting the ephemerality based on the argument. If Guided Access is enabled or the session cannot be started, the method returns NO and the authorization flow fails with an error.
  */
 - (nullable instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -40,7 +40,9 @@ API_UNAVAILABLE(macCatalyst)
 
 /*! @brief The designated initializer.
     @param presentingViewController The view controller from which to present the authentication UI.
-    @discussion The specific authentication UI used depends on the iOS version and accessibility options. Uses @c ASWebAuthenticationSession. If Guided Access is enabled or the session cannot be started, the method returns NO and the authorization flow fails with an error.
+    @discussion The specific authentication UI used depends on the iOS version and accessibility
+        options. Uses @c ASWebAuthenticationSession. If Guided Access is enabled or the session
+        cannot be started, the method returns NO and the authorization flow fails with an error.
  */
 - (nullable instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController
@@ -50,7 +52,9 @@ API_UNAVAILABLE(macCatalyst)
     @param presentingViewController The view controller from which to present the browser.
     @param prefersEphemeralSession Whether the caller prefers to use a private authentication
         session. See @c ASWebAuthenticationSession.prefersEphemeralWebBrowserSession for more.
-    @discussion Authentication is performed with @c ASWebAuthenticationSession, setting the ephemerality based on the argument. If Guided Access is enabled or the session cannot be started, the method returns NO and the authorization flow fails with an error.
+    @discussion Authentication is performed with @c ASWebAuthenticationSession, setting the
+        ephemerality based on the argument. If Guided Access is enabled or the session cannot
+        be started, the method returns NO and the authorization flow fails with an error.
  */
 - (nullable instancetype)initWithPresentingViewController:
     (UIViewController *)presentingViewController

--- a/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Sources/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -133,12 +133,9 @@ NS_ASSUME_NONNULL_BEGIN
       openedUserAgent = [authenticationVC start];
     }
   }
-  // If all else failed use the local browser.
-  if (!openedUserAgent){
-    [[UIApplication sharedApplication] openURL:requestURL
-                                       options:@{}
-                             completionHandler:nil];
-    openedUserAgent = YES;
+  if (!openedUserAgent) {
+    [self cleanUp];
+    return NO;
   }
 
   return openedUserAgent;


### PR DESCRIPTION
This PR "fixes" the crash in GSI 9.0 by removing `OIDExternalUserAgentiOS`'s call to `[UIApplication sharedApplication] openURL:requestURL]`. Since the `ASWebAuthenticationSession` can be used for almost all sign-ins, the fallback is much less relevant.

There is one caveat - Guided Access Mode. Before this change, the app would _crash_ when attempting to open the external browser in Guided Access Mode. Now, it fails silently. While this is a strict improvement in behaviour, it offers no real way for AppAuth-iOS to be used by applications utilizing Guided Access Mode. I explored the new API Apple provided, and was unsuccessful in routing to a functioning browser. As this change is still an improvement over the current behaviour, I'll leave additional investigation for future work - filed as issue #953.

Testing: I've tested successful sign-in via the new Swift sample app. I also confirmed that Guided Access Mode replicates the crash; and that this change causes an internal error rather than a crash.