### PR TITLE
Release testing clean-up: example deployment target + bundle identifier

### DIFF
--- a/Examples/Example-iOS_ObjC/Podfile
+++ b/Examples/Example-iOS_ObjC/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 use_frameworks! 
 

--- a/Examples/Example-iOS_Swift-SPM/Example.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS_Swift-SPM/Example.xcodeproj/project.pbxproj
@@ -293,7 +293,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.experimental0.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -322,7 +321,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.google.experimental0.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;


### PR DESCRIPTION
This PR cleans up two example-app configuration issues that came up whilst testing the 2.1.0 release packaging.

Bump `platform :ios` from `11.0` to `12.0`. AppAuth's podspec has required iOS 12 since 2.0.0 (#918), so `pod install` on the sample app currently fails with *"Specs satisfying the `AppAuth` dependency were found, but they required a higher minimum deployment target."*

Remove the hardcoded `PRODUCT_BUNDLE_IDENTIFIER` from the Xcode project so the bundle identifier is driven by `Config/Example.local.xcconfig` (the gitignored local override), which was accidentally checked in. The value was already public, as it is in the site associations file, so further scrubbing is not required.

Tested that `pod install` + iOS Simulator build & launch of `Example-iOS_ObjC` succeed with the bumped Podfile.
