### PR TITLE
Update runners to macOS 15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        # Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
+	fail-fast: false
+       	# Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
         flags: [
           "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -sdk 'iphonesimulator'",
           "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx'",
@@ -28,6 +29,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Warm up simulator runtimes
+      run: xcrun simctl list devices available
     - name: Ensure tvOS simulator runtime
       run: xcodebuild -downloadPlatform tvOS
     - name: Run unit test targets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,22 +12,22 @@ on:
 jobs:
 
   xcode-project-test:
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         # Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
         flags: [
-          "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' -sdk 'iphonesimulator18.2'",
-          "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
-          "-scheme AppAuth_macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx15.2'",
-          "-scheme AppAuth-tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'",
-          "-scheme AppAuth_tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'",
-          "-scheme AppAuthTV -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.2' -sdk 'appletvsimulator18.2'"
+          "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -sdk 'iphonesimulator'",
+          "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx'",
+          "-scheme AppAuth_macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx'",
+          "-scheme AppAuth-tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.5' -sdk 'appletvsimulator'",
+          "-scheme AppAuth_tvOS -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.5' -sdk 'appletvsimulator'",
+          "-scheme AppAuthTV -destination 'platform=tvOS Simulator,name=Apple TV,OS=18.5' -sdk 'appletvsimulator'"
         ]
     steps:
     - uses: actions/checkout@v3
     - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Run unit test targets
       run: |
         xcodebuild test \
@@ -35,7 +35,7 @@ jobs:
           ${{ matrix.flags }}
 
   pod-lib-lint:
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         flags: [
@@ -53,7 +53,7 @@ jobs:
       run: pod lib lint --verbose ${{ matrix.flags }}
 
   spm-build-test:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v3
     - name: Build unit test target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: Ensure tvOS simulator runtime
+      run: xcodebuild -downloadPlatform tvOS
     - name: Run unit test targets
       run: |
         xcodebuild test \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       	# Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
+        # Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
         flags: [
           "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -sdk 'iphonesimulator'",
           "-scheme AppAuth-macOS -destination 'platform=macOS,arch=x86_64' -sdk 'macosx'",
@@ -31,8 +31,6 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - name: Warm up simulator runtimes
       run: xcrun simctl list devices available
-    - name: Ensure tvOS simulator runtime
-      run: xcodebuild -downloadPlatform tvOS
     - name: Run unit test targets
       run: |
         xcodebuild test \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
   xcode-project-test:
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
-	fail-fast: false
        	# Check the Github runner images when updating this matrix: https://github.com/actions/runner-images/tree/main/images/macos
         flags: [
           "-scheme AppAuth-iOS -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -sdk 'iphonesimulator'",


### PR DESCRIPTION
The macOS 14 image begins deprecation on July 6th. https://github.com/actions/runner-images/issues/13518

Separately, GitHub removed the simulator runtimes for Xcode <16.3 from macos-15, so the current Xcode 16.2 / iOS 18.2 / tvOS 18.2 pins do not exist on macOS 15, and must thus be updated.

The sister repo GoogleSignIn-iOS runs this same setup on (macos-15 + Xcode 16.4 + iOS 18.6) on its daily builds, so I've updated them to match.