### PR TITLE
Replace case range with explicit case labels in OIDTokenUtilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- Replace case range with explicit case labels in OIDTokenUtilities. Addresses issue #947. ([#962](https://github.com/openid/AppAuth-iOS/pull/962))
+
 # 2.1.0
 - Add SwiftUI + Swift Package Manager sample app under `Examples/Example-iOS_Swift-SPM`. ([#952](https://github.com/openid/AppAuth-iOS/pull/952))
 - Removed external browser (Safari) fallback from `OIDExternalUserAgentIOS`. If `ASWebAuthenticationSession` fails to start (e.g., Guided Access is enabled), the authorization flow now fails with an error instead of opening an external browser. ([#954](https://github.com/openid/AppAuth-iOS/pull/954))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # UNRELEASED
-- Replace case range with explicit case labels in OIDTokenUtilities. Addresses issue #947. ([#962](https://github.com/openid/AppAuth-iOS/pull/962))
+- Replace case range with explicit case labels in OIDTokenUtilities. Addresses issue #947. ([#963](https://github.com/openid/AppAuth-iOS/pull/963))
 
 # 2.1.0
 - Add SwiftUI + Swift Package Manager sample app under `Examples/Example-iOS_Swift-SPM`. ([#952](https://github.com/openid/AppAuth-iOS/pull/952))

--- a/Sources/AppAuthCore/OIDTokenUtilities.m
+++ b/Sources/AppAuthCore/OIDTokenUtilities.m
@@ -61,7 +61,7 @@ static NSString *const kFormUrlEncodedAllowedCharacters =
   switch(inputString.length){
     case 0:
       return @"";
-    case 1 ... 8:
+    case 1: case 2: case 3: case 4: case 5: case 6: case 7: case 8:
       return @"[redacted]";
     case 9:
     default:


### PR DESCRIPTION
Addresses issue #947.

Case ranges were added to C2y support in Clang 20.1.0 ([release notes](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#c2y-feature-support)), and so they now receive a warning. Since we use the warnings-as-errors flag, this creates a compilation failure on the 26.4+ builds that ship Clang 21.0.0 (observed by [xcodereleases](https://techhub.social/@xcodereleases/116121437511398526)).