### PR TITLE
Add Swift-specific argument label for resumeExternalUserAgentFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Add Swift name to `resumeExternalUserAgentFlowWithURL:error:` and update hint. (#966)
+
 # 2.1.0
 - Add SwiftUI + Swift Package Manager sample app under `Examples/Example-iOS_Swift-SPM`. ([#952](https://github.com/openid/AppAuth-iOS/pull/952))
 - Removed external browser (Safari) fallback from `OIDExternalUserAgentIOS`. If `ASWebAuthenticationSession` fails to start (e.g., Guided Access is enabled), the authorization flow now fails with an error instead of opening an external browser. ([#954](https://github.com/openid/AppAuth-iOS/pull/954))

--- a/Examples/Example-iOS_Swift-Carthage/Source/AppDelegate.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Source/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // such as no pending flow, which previously surfaced as an NSException.
         if let authorizationFlow = self.currentAuthorizationFlow {
             do {
-                try authorizationFlow.resumeExternalUserAgentFlow(with: url)
+                try authorizationFlow.resumeExternalUserAgentFlow?(with: url)
                 self.currentAuthorizationFlow = nil
                 return true
             } catch {

--- a/Examples/Example-iOS_Swift-SPM/Example/AppDelegate.swift
+++ b/Examples/Example-iOS_Swift-SPM/Example/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // such as no pending flow, which previously surfaced as an NSException.
         if let authorizationFlow = self.currentAuthorizationFlow {
             do {
-                try authorizationFlow.resumeExternalUserAgentFlow(with: url)
+                try authorizationFlow.resumeExternalUserAgentFlow?(url)
                 self.currentAuthorizationFlow = nil
                 return true
             } catch {

--- a/Sources/AppAuthCore/OIDExternalUserAgentSession.h
+++ b/Sources/AppAuthCore/OIDExternalUserAgentSession.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
         NO if the URL did not match (\@c OIDErrorCodeURLMismatch) or no authorization flow
         was pending (\@c OIDErrorCodeInvalidAuthorizationFlow).
  */
-- (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL error:(NSError *_Nullable *_Nullable)error;
+- (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL error:(NSError *_Nullable *_Nullable)error NS_SWIFT_NAME(resumeExternalUserAgentFlow(_:));
 
 @required
 /*! @brief @c OIDExternalUserAgent or clients should call this method when the

--- a/Sources/AppAuthCore/OIDExternalUserAgentSession.h
+++ b/Sources/AppAuthCore/OIDExternalUserAgentSession.h
@@ -51,7 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
     @remarks Has no effect if called more than once, or after a @c cancel message was received.
     @return YES if the passed URL matches the expected redirect URL and was consumed, NO otherwise.
  */
-- (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL __deprecated_msg("Use resumeExternalUserAgentFlowWithURL:error: instead");
+- (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL
+  __deprecated_msg("Use resumeExternalUserAgentFlowWithURL:error: instead. "
+                   "Swift: Use the throwing resumeExternalUserAgentFlow(_:)");
 
 @optional
 /*! @brief Clients should call this method with the result of the external user-agent code flow if


### PR DESCRIPTION
Fixes #964. Because there's a naming collision between the old & new methods, the NSError**-to-throws special-casing doesn't complete, leaving the real type lost in the `Void`. Which is to say, we were (unfortunately) successful in preserving backwards-compatibility, as the sample app only emitted a warning that the old method was being called. This PR also updates the call in the sample app to ensure this new signature is compiled correctly.