### PR TITLE
Require resumeExternalUserAgentFlowWithURL:error:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # UNRELEASED
-- Add Swift name to `resumeExternalUserAgentFlowWithURL:error:` and update hint. (#966)
+- BREAKING: `resumeExternalUserAgentFlowWithURL:error:` is now required in `OIDExternalUserAgentSession` to fix a Swift compiler crash (no workaround) caused by its `@optional` status with `NSError **`. Implementers must now provide this method. Affects projects since 2.1.0. ([#955](https://github.com/openid/AppAuth-iOS/pull/955))
+- Swift callers now spell the method `resumeExternalUserAgentFlow(_:)`. Since the method is no longer optional, you don't need optional-chaining anymore. For those migrating from 2.1.0, replace `try session.resumeExternalUserAgentFlow?(with: url)` with `try session.resumeExternalUserAgentFlow(url)`. Objective-C callers are unaffected. ([#966](https://github.com/openid/AppAuth-iOS/pull/966))
 - Replace case range with explicit case labels in OIDTokenUtilities. Addresses issue #947. ([#963](https://github.com/openid/AppAuth-iOS/pull/963))
 
 # 2.1.0

--- a/Examples/Example-iOS_Swift-Carthage/Source/AppDelegate.swift
+++ b/Examples/Example-iOS_Swift-Carthage/Source/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // such as no pending flow, which previously surfaced as an NSException.
         if let authorizationFlow = self.currentAuthorizationFlow {
             do {
-                try authorizationFlow.resumeExternalUserAgentFlow?(with: url)
+                try authorizationFlow.resumeExternalUserAgentFlow(url)
                 self.currentAuthorizationFlow = nil
                 return true
             } catch {

--- a/Examples/Example-iOS_Swift-SPM/Example/AppDelegate.swift
+++ b/Examples/Example-iOS_Swift-SPM/Example/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // such as no pending flow, which previously surfaced as an NSException.
         if let authorizationFlow = self.currentAuthorizationFlow {
             do {
-                try authorizationFlow.resumeExternalUserAgentFlow?(url)
+                try authorizationFlow.resumeExternalUserAgentFlow(url)
                 self.currentAuthorizationFlow = nil
                 return true
             } catch {

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ func application(_ app: UIApplication,
   // mismatches (OIDErrorCodeURLMismatch) are kept silent.
   if let authorizationFlow = self.currentAuthorizationFlow {
     do {
-      try authorizationFlow.resumeExternalUserAgentFlow(with: url)
+      try authorizationFlow.resumeExternalUserAgentFlow(url)
       self.currentAuthorizationFlow = nil
       return true
     } catch let error as NSError where error.code == OIDErrorCodeInvalidAuthorizationFlow.rawValue {

--- a/Sources/AppAuthCore/OIDExternalUserAgentSession.h
+++ b/Sources/AppAuthCore/OIDExternalUserAgentSession.h
@@ -67,7 +67,6 @@ NS_ASSUME_NONNULL_BEGIN
         Two specific error cases: (1) OIDErrorCodeURLMismatch when the URL does not match the
         expected redirect, (2) OIDErrorCodeInvalidAuthorizationFlow when no pending authorization
         flow exists.
-        This method was optional when introduced in 2.1.0.
     @remarks Has no effect if called more than once, or after a @c cancel message was received.
     @return YES if the passed URL matches the expected redirect URL and was consumed.
         NO if the URL did not match (\@c OIDErrorCodeURLMismatch) or no authorization flow

--- a/Sources/AppAuthCore/OIDExternalUserAgentSession.h
+++ b/Sources/AppAuthCore/OIDExternalUserAgentSession.h
@@ -55,19 +55,19 @@ NS_ASSUME_NONNULL_BEGIN
   __deprecated_msg("Use resumeExternalUserAgentFlowWithURL:error: instead. "
                    "Swift: Use the throwing resumeExternalUserAgentFlow(_:)");
 
-@optional
 /*! @brief Clients should call this method with the result of the external user-agent code flow if
         it becomes available. This is the preferred replacement for the deprecated version.
     @param URL The redirect URL invoked by the server.
     @param error On failure, an NSError describing why the URL was not handled. Pass NULL if you do
         not need the error.
-    @discussion When the URL represented a valid response, implementations should clean up any
-        left-over UI state from the request, for example by closing the
-        \SFSafariViewController or loopback HTTP listener if those were used. The completion block
-        of the pending request should then be invoked.
+    @discussion Conforming types are required to implement this method. When the URL represented a
+        valid response, implementations should clean up any left-over UI state from the request, for
+        example by closing the \SFSafariViewController or loopback HTTP listener if those were used.
+        The completion block of the pending request should then be invoked.
         Two specific error cases: (1) OIDErrorCodeURLMismatch when the URL does not match the
         expected redirect, (2) OIDErrorCodeInvalidAuthorizationFlow when no pending authorization
         flow exists.
+        This method was optional when introduced in 2.1.0.
     @remarks Has no effect if called more than once, or after a @c cancel message was received.
     @return YES if the passed URL matches the expected redirect URL and was consumed.
         NO if the URL did not match (\@c OIDErrorCodeURLMismatch) or no authorization flow
@@ -75,7 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL error:(NSError *_Nullable *_Nullable)error NS_SWIFT_NAME(resumeExternalUserAgentFlow(_:));
 
-@required
 /*! @brief @c OIDExternalUserAgent or clients should call this method when the
         external user-agent flow failed with a non-OAuth error.
     @param error The error that is the reason for the failure of this external flow.


### PR DESCRIPTION
Mark this method as required due to esoteric crashes in the language interpreter. The build system tragically didn't catch the build error, and for some reason, local succeeded.

Fixes #967