### PR TITLE
Ignore local release-testing artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Docs/
 xcuserdata/
 Carthage/
 .gemini/
+release-testing/


### PR DESCRIPTION
Testing screenshots get dumped in the release-testing/ directory, and should not be uploaded to the main repo.