### PR TITLE
Prep for 3.0.0 release

### DIFF
--- a/AppAuth.podspec
+++ b/AppAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "AppAuth"
-  s.version      = "2.1.0"
+  s.version      = "3.0.0"
   s.summary      = "AppAuth for iOS and macOS is a client SDK for communicating with OAuth 2.0 and OpenID Connect providers."
 
   s.description  = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 3.0.0
-- BREAKING: Updates made to support Xcode 27.
+- BREAKING: Updates made to support Xcode 27. ([#972](https://github.com/openid/AppAuth-iOS/pull/972), [#973](https://github.com/openid/AppAuth-iOS/pull/973))
 -- Raised minimum deployment targets to iOS 15.0, macOS 12.0, tvOS 15.0 and watchOS 9.0 (minimum for Xcode 27).
 -- Swift Package Manager users: The required `swift-tools-version` bump from 5.3 to 5.7, to pickup the new platforms,
 	results in package resolution now requiring Swift 5.7 / Xcode 14 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-# UNRELEASED
+# 3.0.0
 - BREAKING: Updates made to support Xcode 27.
 -- Raised minimum deployment targets to iOS 15.0, macOS 12.0, tvOS 15.0 and watchOS 9.0 (minimum for Xcode 27).
 -- Swift Package Manager users: The required `swift-tools-version` bump from 5.3 to 5.7, to pickup the new platforms,
 	results in package resolution now requiring Swift 5.7 / Xcode 14 or later.
 -- Projects that must keep supporting iOS 12-14 should stay on AppAuth 2.x, which remains buildable with Xcode 26 and earlier.
-- BREAKING: `resumeExternalUserAgentFlowWithURL:error:` is now required in `OIDExternalUserAgentSession` to fix a Swift compiler crash (no workaround) caused by its `@optional` status with `NSError **`. Implementers must now provide this method. Affects projects since 2.1.0. ([#955](https://github.com/openid/AppAuth-iOS/pull/955))
-- Swift callers now spell the method `resumeExternalUserAgentFlow(_:)`. Since the method is no longer optional, you don't need optional-chaining anymore. For those migrating from 2.1.0, replace `try session.resumeExternalUserAgentFlow?(with: url)` with `try session.resumeExternalUserAgentFlow(url)`. Objective-C callers are unaffected. ([#966](https://github.com/openid/AppAuth-iOS/pull/966))
+- BREAKING: `resumeExternalUserAgentFlowWithURL:error:` is now required in `OIDExternalUserAgentSession` to fix a Swift compiler crash (no workaround) caused by its `@optional` status with `NSError **`. Implementers must now provide this method. Affects projects since 2.1.0. ([#955](https://github.com/openid/AppAuth-iOS/pull/955), [#970](https://github.com/openid/AppAuth-iOS/pull/970))
+- Swift callers now spell the method `resumeExternalUserAgentFlow(_:)`. Since the method is no longer optional, you don't need optional-chaining anymore. For those migrating from 2.1.0, replace `try session.resumeExternalUserAgentFlow?(with: url)` with `try session.resumeExternalUserAgentFlow(url)`. Objective-C callers are unaffected. ([#966](https://github.com/openid/AppAuth-iOS/pull/966), [#970](https://github.com/openid/AppAuth-iOS/pull/970))
 - Replace case range with explicit case labels in OIDTokenUtilities. Addresses issue #947. ([#963](https://github.com/openid/AppAuth-iOS/pull/963))
+- Update the `addressable` gem to address CVE-2026-35611. Addresses issue #958. ([#965](https://github.com/openid/AppAuth-iOS/pull/965))
 
 # 2.1.0
 - Add SwiftUI + Swift Package Manager sample app under `Examples/Example-iOS_Swift-SPM`. ([#952](https://github.com/openid/AppAuth-iOS/pull/952))

--- a/Examples/Example-iOS_Swift-SPM/Config/Example.xcconfig
+++ b/Examples/Example-iOS_Swift-SPM/Config/Example.xcconfig
@@ -11,4 +11,7 @@ OIDC_REDIRECT_URI_SCHEME = com.example.app
 // Example.local.xcconfig if you need Manual signing with a specific provisioning profile.
 CODE_SIGN_STYLE = Automatic
 
+// The bundle identifier for the sample app.
+PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.SwiftExample
+
 #include? "Example.local.xcconfig"


### PR DESCRIPTION
Prepares for the 3.0.0 release: version bump and changelog. This release carries two source-breaking changes, so SemVer requires a major bump.

REVIEW NOTE: This PR includes a cherry-pick of #975, which is in review.

Here are the public-facing changes:
- #963 — explicit case labels in `OIDTokenUtilities` (issue #947)
- #965 — `addressable` gem bumped for CVE-2026-35611 (issue #958)
- #966 — Swift-specific argument label, `resumeExternalUserAgentFlow(_:)`
- #970 — `resumeExternalUserAgentFlowWithURL:error:` made required
- #972, #973 — Xcode 27 minimum versions and CI

These changes are also included, though they are internal: #959, #960, #961 and #971 are CI runners, Node action versions, example bundle identifiers and gitignore entries.

