### PR TITLE
Fix SPM Sample's install failure

### DIFF
--- a/Examples/Example-iOS_Swift-SPM/Config/Example.xcconfig
+++ b/Examples/Example-iOS_Swift-SPM/Config/Example.xcconfig
@@ -11,4 +11,7 @@ OIDC_REDIRECT_URI_SCHEME = com.example.app
 // Example.local.xcconfig if you need Manual signing with a specific provisioning profile.
 CODE_SIGN_STYLE = Automatic
 
+// The bundle identifier for the sample app.
+PRODUCT_BUNDLE_IDENTIFIER = net.openid.appauth.SwiftExample
+
 #include? "Example.local.xcconfig"


### PR DESCRIPTION
The SPM sample was missing a default bundle ID, which causes the sample to fail to install during testing (when using the default values).