### PR TITLE
Update diagnostic errors for missing `state` in logout responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- Improved the state validation error messages to distinguish a missing `state` parameter from a mismatched one. The end session message now notes that a provider's `end_session_endpoint` may point at a legacy or SAML single-logout endpoint, which does not echo `state`. Addresses issue #956.
+
 # 3.0.0
 - BREAKING: Updates made to support Xcode 27. ([#972](https://github.com/openid/AppAuth-iOS/pull/972), [#973](https://github.com/openid/AppAuth-iOS/pull/973))
 -- Raised minimum deployment targets to iOS 15.0, macOS 12.0, tvOS 15.0 and watchOS 9.0 (minimum for Xcode 27).

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -173,11 +173,11 @@ NS_ASSUME_NONNULL_BEGIN
       if (response.state == nil) {
         userInfo[NSLocalizedDescriptionKey] =
           [NSString stringWithFormat:@"The authorization response is missing the state parameter, "
-                                     "expecting %@. RFC 6749 section 4.1.2 requires the "
-                                     "authorization server to return the exact state value sent "
-                                     "in the request. Authorization response: %@",
-                                     _request.state,
-                                     response];
+                                      "expecting %@. RFC 6749 section 4.1.2 requires the "
+                                      "authorization server to echo the exact state value from "
+                                      "the request. Response: %@",
+                                      _request.state,
+                                      response];
       } else {
         userInfo[NSLocalizedDescriptionKey] =
           [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
@@ -320,24 +320,18 @@ NS_ASSUME_NONNULL_BEGIN
     if (!response.state) {
       userInfo[NSLocalizedDescriptionKey] =
           [NSString stringWithFormat:@"The end session response is missing the state parameter, "
-                                      "expecting %@ but got nil. This commonly means the "
-                                      "configured end_session_endpoint is not an OpenID Connect "
-                                      "RP-Initiated Logout endpoint - some providers advertise a "
-                                      "legacy or SAML single-logout endpoint under that key, and "
-                                      "such endpoints do not echo the OAuth state parameter. "
-                                      "Verify the end_session_endpoint in the provider's "
-                                      "discovery document. If the provider genuinely cannot "
-                                      "return state, the OIDEndSessionRequest may be "
-                                      "constructed without a state value, which disables "
-                                      "state validation and the CSRF protection it provides, "
-                                      "in end session response %@",
+                                      "expecting %@. This usually means end_session_endpoint is "
+                                      "not an OpenID Connect RP-Initiated Logout endpoint; some "
+                                      "providers advertise a legacy or SAML single-logout "
+                                      "endpoint under that key, and those do not echo state. "
+                                      "Check end_session_endpoint in the provider's discovery "
+                                      "document. Response: %@",
                                       _request.state,
                                       response];
     } else {
       userInfo[NSLocalizedDescriptionKey] =
-          [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in end session "
-                                      "response %@. The state in the response does not match "
-                                      "the state in the request.",
+          [NSString stringWithFormat:@"State in the end session response does not match the "
+                                      "request, expecting %@ but got %@. Response: %@",
                                       _request.state,
                                       response.state,
                                       response];

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -170,12 +170,22 @@ NS_ASSUME_NONNULL_BEGIN
     // verifies that the state in the response matches the state in the request, or both are nil
     if (!OIDIsEqualIncludingNil(_request.state, response.state)) {
       NSMutableDictionary *userInfo = [query.dictionaryValue mutableCopy];
-      userInfo[NSLocalizedDescriptionKey] =
-        [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
-                                   "response %@",
-                                   _request.state,
-                                   response.state,
-                                   response];
+      if (response.state == nil) {
+        userInfo[NSLocalizedDescriptionKey] =
+          [NSString stringWithFormat:@"The authorization response is missing the state parameter, "
+                                     "expecting %@. RFC 6749 section 4.1.2 requires the "
+                                     "authorization server to return the exact state value sent "
+                                     "in the request. Authorization response: %@",
+                                     _request.state,
+                                     response];
+      } else {
+        userInfo[NSLocalizedDescriptionKey] =
+          [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
+                                     "response %@",
+                                     _request.state,
+                                     response.state,
+                                     response];
+      }
       response = nil;
       responseError = [NSError errorWithDomain:OIDOAuthAuthorizationErrorDomain
                                           code:OIDErrorCodeOAuthAuthorizationClientError

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -173,9 +173,9 @@ NS_ASSUME_NONNULL_BEGIN
       if (response.state == nil) {
         userInfo[NSLocalizedDescriptionKey] =
           [NSString stringWithFormat:@"The authorization response is missing the state parameter, "
-                                      "expecting %@. RFC 6749 section 4.1.2 requires the "
-                                      "authorization server to echo the exact state value from "
-                                      "the request. Response: %@",
+                                      "expecting %@. RFC 6749 section 4.1.2 and OpenID Connect "
+                                      "Core section 3.1.2.5 require the authorization server to "
+                                      "echo the exact state value from the request. Response: %@",
                                       _request.state,
                                       response];
       } else {

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -320,8 +320,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (!response.state) {
       userInfo[NSLocalizedDescriptionKey] =
           [NSString stringWithFormat:@"The end session response is missing the state parameter, "
-                                      "expecting %@. This usually means end_session_endpoint is "
-                                      "not an OpenID Connect RP-Initiated Logout endpoint; some "
+                                      "expecting %@. This may mean end_session_endpoint is not "
+                                      "an OpenID Connect RP-Initiated Logout endpoint; some "
                                       "providers advertise a legacy or SAML single-logout "
                                       "endpoint under that key, and those do not echo state. "
                                       "Check end_session_endpoint in the provider's discovery "

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -307,12 +307,31 @@ NS_ASSUME_NONNULL_BEGIN
   // verifies that the state in the response matches the state in the request, or both are nil
   if (!OIDIsEqualIncludingNil(_request.state, response.state)) {
     NSMutableDictionary *userInfo = [query.dictionaryValue mutableCopy];
-    userInfo[NSLocalizedDescriptionKey] =
-    [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in authorization "
-     "response %@",
-     _request.state,
-     response.state,
-     response];
+    if (!response.state) {
+      userInfo[NSLocalizedDescriptionKey] =
+          [NSString stringWithFormat:@"The end session response is missing the state parameter, "
+                                      "expecting %@ but got nil. This commonly means the "
+                                      "configured end_session_endpoint is not an OpenID Connect "
+                                      "RP-Initiated Logout endpoint - some providers advertise a "
+                                      "legacy or SAML single-logout endpoint under that key, and "
+                                      "such endpoints do not echo the OAuth state parameter. "
+                                      "Verify the end_session_endpoint in the provider's "
+                                      "discovery document. If the provider genuinely cannot "
+                                      "return state, the caller may construct "
+                                      "OIDEndSessionRequest with an explicit nil state to omit "
+                                      "it, which disables state validation and the CSRF "
+                                      "protection it provides, in end session response %@",
+                                      _request.state,
+                                      response];
+    } else {
+      userInfo[NSLocalizedDescriptionKey] =
+          [NSString stringWithFormat:@"State mismatch, expecting %@ but got %@ in end session "
+                                      "response %@. The state in the response does not match "
+                                      "the state in the request.",
+                                      _request.state,
+                                      response.state,
+                                      response];
+    }
     response = nil;
     responseError = [NSError errorWithDomain:OIDOAuthAuthorizationErrorDomain
                                         code:OIDErrorCodeOAuthAuthorizationClientError

--- a/Sources/AppAuthCore/OIDAuthorizationService.m
+++ b/Sources/AppAuthCore/OIDAuthorizationService.m
@@ -327,10 +327,10 @@ NS_ASSUME_NONNULL_BEGIN
                                       "such endpoints do not echo the OAuth state parameter. "
                                       "Verify the end_session_endpoint in the provider's "
                                       "discovery document. If the provider genuinely cannot "
-                                      "return state, the caller may construct "
-                                      "OIDEndSessionRequest with an explicit nil state to omit "
-                                      "it, which disables state validation and the CSRF "
-                                      "protection it provides, in end session response %@",
+                                      "return state, the OIDEndSessionRequest may be "
+                                      "constructed without a state value, which disables "
+                                      "state validation and the CSRF protection it provides, "
+                                      "in end session response %@",
                                       _request.state,
                                       response];
     } else {


### PR DESCRIPTION
In issue #956, two different clients (likely) ran into an issue where they received a `nil` state response from the provider.

RFC 6749 section 4.1.2 and OIDC Core 3.1.2.5/6 require the server to echo the state value. Some providers don't handle multi-hop auth (passing the `state` param along) or are doing SAML / proprietary responses (no `state` param). These updates point folks in the right direction.